### PR TITLE
Feature/bures distance [unitaryHACK]

### DIFF
--- a/docs/states.rst
+++ b/docs/states.rst
@@ -23,6 +23,7 @@ Distance Metrics for Quantum States
     toqito.state_metrics.sub_fidelity
     toqito.state_metrics.trace_distance
     toqito.state_metrics.trace_norm
+    toqito.state_metrics.bures_distance
 
 Optimizations over Quantum States
 -----------------------------------------------

--- a/tests/test_state_metrics/test_bures_distance.py
+++ b/tests/test_state_metrics/test_bures_distance.py
@@ -40,6 +40,14 @@ def test_bures_distance_non_identical_states_2():
     sigma = 1 / 8 * e_0 * e_0.conj().T + 7 / 8 * e_1 * e_1.conj().T
     np.testing.assert_equal(np.isclose(bures_distance(rho, sigma), 0.6724, rtol=1e-03), True)
 
+def test_bures_distance_pure_states():
+    """Test the bures_distance between two pure states."""
+    e_0, e_1 = basis(2, 0), basis(2, 1)
+    e_plus = (e_0 + e_1)/np.sqrt(2)
+    rho =  e_plus * e_plus.conj().T
+    sigma = e_0 * e_0.conj().T
+    np.testing.assert_equal(np.isclose(bures_distance(rho, sigma), 0.765, rtol=1e-03), True)
+
 
 def test_bures_distance_non_square():
     """Tests for invalid dim."""

--- a/tests/test_state_metrics/test_bures_distance.py
+++ b/tests/test_state_metrics/test_bures_distance.py
@@ -16,15 +16,6 @@ def test_bures_distance_default():
     np.testing.assert_equal(np.isclose(res, 0), True)
 
 
-def test_bures_distance_cvx():
-    """Test bures_distance for cvx objects."""
-    rho = cvxpy.bmat([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])
-    sigma = rho
-
-    res = bures_distance(rho, sigma)
-    np.testing.assert_equal(np.isclose(res, 0), True)
-
-
 def test_bures_distance_non_identical_states_1():
     """Test the bures_distance between two non-identical states."""
     e_0, e_1 = basis(2, 0), basis(2, 1)

--- a/tests/test_state_metrics/test_bures_distance.py
+++ b/tests/test_state_metrics/test_bures_distance.py
@@ -1,0 +1,61 @@
+"""Tests for bures distance."""
+import cvxpy
+import numpy as np
+
+
+from toqito.state_metrics import bures_distance
+from toqito.states import basis
+
+
+def test_bures_distance_default():
+    """Test bures distance default arguments."""
+    rho = np.array([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])
+    sigma = rho
+
+    res = bures_distance(rho, sigma)
+    np.testing.assert_equal(np.isclose(res, 0), True)
+
+
+def test_bures_distance_cvx():
+    """Test bures distance for cvx objects."""
+    rho = cvxpy.bmat([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])
+    sigma = rho
+
+    res = bures_distance(rho, sigma)
+    np.testing.assert_equal(np.isclose(res, 0), True)
+
+
+def test_bures_distance_non_identical_states_1():
+    """Test the bures distance between two non-identical states."""
+    e_0, e_1 = basis(2, 0), basis(2, 1)
+    rho = 3 / 4 * e_0 * e_0.conj().T + 1 / 4 * e_1 * e_1.conj().T
+    sigma = 2 / 3 * e_0 * e_0.conj().T + 1 / 3 * e_1 * e_1.conj().T
+    np.testing.assert_equal(np.isclose(bures_distance(rho, sigma), 0.0918, rtol=1e-03), True)
+
+
+def test_bures_distance_non_identical_states_2():
+    """Test the bures distance between two non-identical states."""
+    e_0, e_1 = basis(2, 0), basis(2, 1)
+    rho = 3 / 4 * e_0 * e_0.conj().T + 1 / 4 * e_1 * e_1.conj().T
+    sigma = 1 / 8 * e_0 * e_0.conj().T + 7 / 8 * e_1 * e_1.conj().T
+    np.testing.assert_equal(np.isclose(bures_distance(rho, sigma), 0.6724, rtol=1e-03), True)
+
+
+def test_bures_distance_non_square():
+    """Tests for invalid dim."""
+    rho = np.array([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])
+    sigma = np.array([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])
+    with np.testing.assert_raises(ValueError):
+        bures_distance(rho, sigma)
+
+
+def test_bures_distance_invalid_dim():
+    """Tests for invalid dim."""
+    rho = np.array([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])
+    sigma = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    with np.testing.assert_raises(ValueError):
+        bures_distance(rho, sigma)
+
+
+if __name__ == "__main__":
+    np.testing.run_module_suite()

--- a/tests/test_state_metrics/test_bures_distance.py
+++ b/tests/test_state_metrics/test_bures_distance.py
@@ -1,4 +1,4 @@
-"""Tests for bures distance."""
+"""Tests for bures_distance."""
 import cvxpy
 import numpy as np
 
@@ -8,7 +8,7 @@ from toqito.states import basis
 
 
 def test_bures_distance_default():
-    """Test bures distance default arguments."""
+    """Test bures_distance default arguments."""
     rho = np.array([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])
     sigma = rho
 
@@ -17,7 +17,7 @@ def test_bures_distance_default():
 
 
 def test_bures_distance_cvx():
-    """Test bures distance for cvx objects."""
+    """Test bures_distance for cvx objects."""
     rho = cvxpy.bmat([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])
     sigma = rho
 
@@ -26,7 +26,7 @@ def test_bures_distance_cvx():
 
 
 def test_bures_distance_non_identical_states_1():
-    """Test the bures distance between two non-identical states."""
+    """Test the bures_distance between two non-identical states."""
     e_0, e_1 = basis(2, 0), basis(2, 1)
     rho = 3 / 4 * e_0 * e_0.conj().T + 1 / 4 * e_1 * e_1.conj().T
     sigma = 2 / 3 * e_0 * e_0.conj().T + 1 / 3 * e_1 * e_1.conj().T
@@ -34,7 +34,7 @@ def test_bures_distance_non_identical_states_1():
 
 
 def test_bures_distance_non_identical_states_2():
-    """Test the bures distance between two non-identical states."""
+    """Test the bures_distance between two non-identical states."""
     e_0, e_1 = basis(2, 0), basis(2, 1)
     rho = 3 / 4 * e_0 * e_0.conj().T + 1 / 4 * e_1 * e_1.conj().T
     sigma = 1 / 8 * e_0 * e_0.conj().T + 7 / 8 * e_1 * e_1.conj().T

--- a/tests/test_state_metrics/test_bures_distance.py
+++ b/tests/test_state_metrics/test_bures_distance.py
@@ -1,5 +1,4 @@
 """Tests for bures_distance."""
-import cvxpy
 import numpy as np
 
 

--- a/toqito/state_metrics/__init__.py
+++ b/toqito/state_metrics/__init__.py
@@ -5,3 +5,4 @@ from toqito.state_metrics.helstrom_holevo import helstrom_holevo
 from toqito.state_metrics.fidelity import fidelity
 from toqito.state_metrics.sub_fidelity import sub_fidelity
 from toqito.state_metrics.trace_distance import trace_distance
+from toqito.state_metrics.bures_distance import bures_distance

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -1,0 +1,70 @@
+import numpy as np
+
+from toqito.state_metrics import fidelity
+
+def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
+    r"""
+    Calculate the bures distance between the two density matrices : rho_1 and rho_2, defined
+    by:
+
+     D = sqrt(2 * (1 - fidelity(rho_1, rho_2) ) )
+
+    where:`fidelity` denotes the fidelity between `rho_1` and `rho_2` . The return is a value between :math:`0` and
+    :math:`sqrt(2)`, with :math:`0` corresponding to matrices : code:`rho_1 = rho_2` and :math:`sqrt(2)` corresponding to the case : code:`rho_1` and :code:`rho_2` with
+    orthogonal support,.
+
+    Examples
+    ==========
+
+    Consider the following Bell state
+
+    .. math::
+        u = \frac{1}{\sqrt{2}} \left( |00 \rangle + |11 \rangle \right) \in \mathcal{X}.
+
+    The corresponding density matrix of :math:`u` may be calculated by:
+
+    .. math::
+        \rho = u u^* = \frac{1}{2} \begin{pmatrix}
+                         1 & 0 & 0 & 1 \\
+                         0 & 0 & 0 & 0 \\
+                         0 & 0 & 0 & 0 \\
+                         1 & 0 & 0 & 1
+                       \end{pmatrix} \in \text{D}(\mathcal{X}).
+
+    In the event where we calculate the fidelity between states that are identical, we should obtain
+    the value of :math:`0`. This can be observed in :code:`toqito` as follows.
+
+    >>> from toqito.state_metrics import bures_distance
+    >>> import numpy as np
+    >>> rho = 1 / 2 * np.array(
+    >>>     [[1, 0, 0, 1],
+    >>>      [0, 0, 0, 0],
+    >>>      [0, 0, 0, 0],
+    >>>      [1, 0, 0, 1]]
+    >>> )
+    >>> sigma = rho
+    >>> bures_distance(rho, sigma)
+    0
+
+    References
+    ==========
+    .. [WikFid] Wikipedia: Bures metric
+        https://en.wikipedia.org/wiki/Bures_metric
+
+    :param rho_1: Density operator.
+    :param rho_2: Density operator.
+    :return: The Bures distance between :code:`rho_1` and :code:`sigma_2`.
+    """
+
+    # Perform some error checking.
+    if not np.all(rho_1.shape == (rho_2.shape)):
+        raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
+
+    # Round fidelity to only 10 decimals to avoid error when rho_1 = rho_2
+    round_fidelity =  round(fidelity(rho_1, rho_2),10)
+
+    if round_fidelity > 1 :
+        raise ValueError("Numeric Error: fidelity(rho_1, rho_2) greater than 1")
+
+    distance =  np.sqrt(2.0 * (1.0 - round_fidelity))
+    return distance

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -4,7 +4,7 @@ import numpy as np
 from toqito.state_metrics import fidelity
 
 def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
-	r""" 
+	r"""
 	Compute the bures distance of two density matrices [WikFid]_.
 
 	Calculate the bures distance between the two density matrices:

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -7,15 +7,16 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
     r"""
     Compute the bures distance of two density matrices [WikFid]_.
 
-    Calculate the bures distance between the two density matrices: rho_1 and 
-    rho_2, defined by:
+    Calculate the bures distance between the two density matrices:`rho_1` and 
+    `rho_2`, defined by:
     .. math::
         \sqrt{2 (1 - F(\rho_1, \rho_2)},
 
-    where:`fidelity` denotes the fidelity between `rho_1` and `rho_2` . The return is a value between 
-    :math:`0` and :math:`\sqrt(2)`, with :math:`0` corresponding to matrices: code:`rho_1 = rho_2`
-    and :math:`\sqrt(2)` corresponding to the  case : code:`rho_1`and :code:`rho_2`
-    with orthogonal support.
+    where:`fidelity` denotes the fidelity between `rho_1` and `rho_2`. 
+    The return is a value between :math:`0` and :math:`\sqrt(2)`, with 
+    :math:`0` corresponding to matrices: code:`rho_1 = rho_2`and 
+    :math:`\sqrt(2)` corresponding to the case: code:`rho_1`and 
+    :code:`rho_2` with orthogonal support.
 
     Examples
     ==========

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -4,7 +4,7 @@ import numpy as np
 from toqito.state_metrics import fidelity
 
 def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
-	r"""
+	r""" 
 	Compute the bures distance of two density matrices [WikFid]_.
 
 	Calculate the bures distance between the two density matrices:
@@ -12,7 +12,7 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
 	.. math::
 		\sqrt{2 (1 - F(\rho_1, \rho_2)},
 
-	where:`fidelity` denotes the fidelity between `rho_1` and `rho_2`. 
+	where:`fidelity` denotes the fidelity between `rho_1` and `rho_2`
 	The return is a value between :math:`0` and :math:`\sqrt(2)`,with
 	:math:`0` corresponding to matrices: code:`rho_1 = rho_2`and
 	:math:`\sqrt(2)` corresponding to the case: code:`rho_1`and

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -4,64 +4,64 @@ import numpy as np
 from toqito.state_metrics import fidelity
 
 def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
-	r"""
-	Compute the bures distance of two density matrices [WikFid]_.
+    r"""
+    Compute the bures distance of two density matrices [WikFid]_.
 
-	Calculate the bures distance between the two density matrices:
-	`rho_1` and `rho_2`, defined by:
-	.. math::
-		\sqrt{2 (1 - F(\rho_1, \rho_2)},
+    Calculate the bures distance between the two density matrices:
+    `rho_1` and `rho_2`, defined by:
+    .. math::
+        \sqrt{2 (1 - F(\rho_1, \rho_2)},
 
-	where:`fidelity` denotes the fidelity between `rho_1` and `rho_2`
-	The return is a value between :math:`0` and :math:`\sqrt(2)`,with
-	:math:`0` corresponding to matrices: code:`rho_1 = rho_2`and
-	:math:`\sqrt(2)` corresponding to the case: code:`rho_1`and
-	:code:`rho_2` with orthogonal support.
+    where:`fidelity` denotes the fidelity between `rho_1` and `rho_2`
+    The return is a value between :math:`0` and :math:`\sqrt(2)`,with
+    :math:`0` corresponding to matrices: code:`rho_1 = rho_2`and
+    :math:`\sqrt(2)` corresponding to the case: code:`rho_1`and
+    :code:`rho_2` with orthogonal support.
 
-	Examples
-	==========
+    Examples
+    ==========
 
-	Consider the following Bell state
+    Consider the following Bell state
 
-	.. math::
-		u = \frac{1}{\sqrt{2}} \left( |00 \rangle + |11 \rangle \right) \in \mathcal{X}.
+    .. math::
+        u = \frac{1}{\sqrt{2}} \left( |00 \rangle + |11 \rangle \right) \in \mathcal{X}.
 
-	The corresponding density matrix of :math:`u` may be calculated by:
+    The corresponding density matrix of :math:`u` may be calculated by:
 
-	.. math::
-		\rho = u u^* = \frac{1}{2} \begin{pmatrix}
-						 1 & 0 & 0 & 1 \\
-						 0 & 0 & 0 & 0 \\
-						 0 & 0 & 0 & 0 \\
-						 1 & 0 & 0 & 1
-					   \end{pmatrix} \in \text{D}(\mathcal{X}).
+    .. math::
+        \rho = u u^* = \frac{1}{2} \begin{pmatrix}
+                         1 & 0 & 0 & 1 \\
+                         0 & 0 & 0 & 0 \\
+                         0 & 0 & 0 & 0 \\
+                         1 & 0 & 0 & 1
+                       \end{pmatrix} \in \text{D}(\mathcal{X}).
 
-	In the event where we calculate the fidelity between states that are identical, we should obtain
-	the value of :math:`0`. This can be observed in :code:`toqito` as follows.
+    In the event where we calculate the fidelity between states that are identical, we should obtain
+    the value of :math:`0`. This can be observed in :code:`toqito` as follows.
 
-	>>> from toqito.state_metrics import bures_distance
-	>>> import numpy as np
-	>>> rho = 1 / 2 * np.array(
-	>>>     [[1, 0, 0, 1],
-	>>>      [0, 0, 0, 0],
-	>>>      [0, 0, 0, 0],
-	>>>      [1, 0, 0, 1]]
-	>>> )
-	>>> sigma = rho
-	>>> bures_distance(rho, sigma)
-	0
+    >>> from toqito.state_metrics import bures_distance
+    >>> import numpy as np
+    >>> rho = 1 / 2 * np.array(
+    >>>     [[1, 0, 0, 1],
+    >>>      [0, 0, 0, 0],
+    >>>      [0, 0, 0, 0],
+    >>>      [1, 0, 0, 1]]
+    >>> )
+    >>> sigma = rho
+    >>> bures_distance(rho, sigma)
+    0
 
-	References
-	==========
-	.. [WikFid] Wikipedia: Bures metric
-		https://en.wikipedia.org/wiki/Bures_metric
+    References
+    ==========
+    .. [WikFid] Wikipedia: Bures metric
+        https://en.wikipedia.org/wiki/Bures_metric
 
-	:param rho_1: Density operator.
-	:param rho_2: Density operator.
-	:return: The Bures distance between :code:`rho_1` and :code:`sigma_2`.
-	"""
-	# Perform some error checking.
-	if not np.all(rho_1.shape == (rho_2.shape)):
-		raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
-	# Round fidelity to only 10 decimals to avoid error when rho_1 = rho_2
-	return np.sqrt(2.0 * (1.0 - round(fidelity(rho_1, rho_2), 10) ))
+    :param rho_1: Density operator.
+    :param rho_2: Density operator.
+    :return: The Bures distance between :code:`rho_1` and :code:`sigma_2`.
+    """
+    # Perform some error checking.
+    if not np.all(rho_1.shape == (rho_2.shape)):
+        raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
+    # Round fidelity to only 10 decimals to avoid error when rho_1 = rho_2
+    return np.sqrt(2.0 * (1.0 - round(fidelity(rho_1, rho_2), 10) ))

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -4,14 +4,17 @@ from toqito.state_metrics import fidelity
 
 def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
     r"""
-    Calculate the bures distance between the two density matrices : rho_1 and rho_2, defined
-    by:
+    Compute the bures distance of two density matrices [WikFid]_.
+    
+    Calculate the bures distance between the two density matrices: 
+    rho_1 and rho_2, defined by:
+    
+    .. math::
+    \sqrt{2 (1 - F(\rho_1, \rho_2)}
 
-     D = sqrt(2 * (1 - fidelity(rho_1, rho_2) ) )
-
-    where:`fidelity` denotes the fidelity between `rho_1` and `rho_2` . The return is a value between :math:`0` and
-    :math:`sqrt(2)`, with :math:`0` corresponding to matrices : code:`rho_1 = rho_2` and :math:`sqrt(2)` corresponding to the case : code:`rho_1` and :code:`rho_2` with
-    orthogonal support,.
+    where:`fidelity` denotes the fidelity between `rho_1` and `rho_2` . The return is a value
+    between :math:`0` and :math:`\sqrt(2)`, with :math:`0` corresponding to matrices: code:`rho_1 = rho_2` 
+    and :math:`\sqrt(2)` corresponding to the  case : code:`rho_1` and :code:`rho_2` with orthogonal support.
 
     Examples
     ==========
@@ -61,10 +64,4 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
         raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
 
     # Round fidelity to only 10 decimals to avoid error when rho_1 = rho_2
-    round_fidelity =  round(fidelity(rho_1, rho_2),10)
-
-    if round_fidelity > 1 :
-        raise ValueError("Numeric Error: fidelity(rho_1, rho_2) greater than 1")
-
-    distance =  np.sqrt(2.0 * (1.0 - round_fidelity))
-    return distance
+    return np.sqrt(2.0 * (1.0 - round(fidelity(rho_1, rho_2), 10) ))

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -36,8 +36,8 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> 
                          1 & 0 & 0 & 1
                        \end{pmatrix} \in \text{D}(\mathcal{X}).
 
-    In the event where we calculate the Bures distance between states that are identical, we should obtain
-    the value of :math:`0`. This can be observed in :code:`toqito` as follows.
+    In the event where we calculate the Bures distance between states that are identical, we
+    should obtain the value of :math:`0`.This can be observed in :code:`toqito` as follows.
 
     >>> from toqito.state_metrics import bures_distance
     >>> import numpy as np

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -4,64 +4,64 @@ import numpy as np
 from toqito.state_metrics import fidelity
 
 def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
-    r"""
-    Compute the bures distance of two density matrices [WikFid]_.
+	r"""
+	Compute the bures distance of two density matrices [WikFid]_.
 
-    Calculate the bures distance between the two density matrices:`rho_1` and 
-    `rho_2`, defined by:
-    .. math::
-        \sqrt{2 (1 - F(\rho_1, \rho_2)},
+	Calculate the bures distance between the two density matrices:
+	`rho_1` and `rho_2`, defined by:
+	.. math::
+		\sqrt{2 (1 - F(\rho_1, \rho_2)},
 
-    where:`fidelity` denotes the fidelity between `rho_1` and `rho_2`. 
-    The return is a value between :math:`0` and :math:`\sqrt(2)`, with 
-    :math:`0` corresponding to matrices: code:`rho_1 = rho_2`and 
-    :math:`\sqrt(2)` corresponding to the case: code:`rho_1`and 
-    :code:`rho_2` with orthogonal support.
+	where:`fidelity` denotes the fidelity between `rho_1` and `rho_2`. 
+	The return is a value between :math:`0` and :math:`\sqrt(2)`,with
+	:math:`0` corresponding to matrices: code:`rho_1 = rho_2`and
+	:math:`\sqrt(2)` corresponding to the case: code:`rho_1`and
+	:code:`rho_2` with orthogonal support.
 
-    Examples
-    ==========
+	Examples
+	==========
 
-    Consider the following Bell state
+	Consider the following Bell state
 
-    .. math::
-        u = \frac{1}{\sqrt{2}} \left( |00 \rangle + |11 \rangle \right) \in \mathcal{X}.
+	.. math::
+		u = \frac{1}{\sqrt{2}} \left( |00 \rangle + |11 \rangle \right) \in \mathcal{X}.
 
-    The corresponding density matrix of :math:`u` may be calculated by:
+	The corresponding density matrix of :math:`u` may be calculated by:
 
-    .. math::
-        \rho = u u^* = \frac{1}{2} \begin{pmatrix}
-                         1 & 0 & 0 & 1 \\
-                         0 & 0 & 0 & 0 \\
-                         0 & 0 & 0 & 0 \\
-                         1 & 0 & 0 & 1
-                       \end{pmatrix} \in \text{D}(\mathcal{X}).
+	.. math::
+		\rho = u u^* = \frac{1}{2} \begin{pmatrix}
+						 1 & 0 & 0 & 1 \\
+						 0 & 0 & 0 & 0 \\
+						 0 & 0 & 0 & 0 \\
+						 1 & 0 & 0 & 1
+					   \end{pmatrix} \in \text{D}(\mathcal{X}).
 
-    In the event where we calculate the fidelity between states that are identical, we should obtain
-    the value of :math:`0`. This can be observed in :code:`toqito` as follows.
+	In the event where we calculate the fidelity between states that are identical, we should obtain
+	the value of :math:`0`. This can be observed in :code:`toqito` as follows.
 
-    >>> from toqito.state_metrics import bures_distance
-    >>> import numpy as np
-    >>> rho = 1 / 2 * np.array(
-    >>>     [[1, 0, 0, 1],
-    >>>      [0, 0, 0, 0],
-    >>>      [0, 0, 0, 0],
-    >>>      [1, 0, 0, 1]]
-    >>> )
-    >>> sigma = rho
-    >>> bures_distance(rho, sigma)
-    0
+	>>> from toqito.state_metrics import bures_distance
+	>>> import numpy as np
+	>>> rho = 1 / 2 * np.array(
+	>>>     [[1, 0, 0, 1],
+	>>>      [0, 0, 0, 0],
+	>>>      [0, 0, 0, 0],
+	>>>      [1, 0, 0, 1]]
+	>>> )
+	>>> sigma = rho
+	>>> bures_distance(rho, sigma)
+	0
 
-    References
-    ==========
-    .. [WikFid] Wikipedia: Bures metric
-        https://en.wikipedia.org/wiki/Bures_metric
+	References
+	==========
+	.. [WikFid] Wikipedia: Bures metric
+		https://en.wikipedia.org/wiki/Bures_metric
 
-    :param rho_1: Density operator.
-    :param rho_2: Density operator.
-    :return: The Bures distance between :code:`rho_1` and :code:`sigma_2`.
-    """
-    # Perform some error checking.
-    if not np.all(rho_1.shape == (rho_2.shape)):
-        raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
-    # Round fidelity to only 10 decimals to avoid error when rho_1 = rho_2
-    return np.sqrt(2.0 * (1.0 - round(fidelity(rho_1, rho_2), 10) ))
+	:param rho_1: Density operator.
+	:param rho_2: Density operator.
+	:return: The Bures distance between :code:`rho_1` and :code:`sigma_2`.
+	"""
+	# Perform some error checking.
+	if not np.all(rho_1.shape == (rho_2.shape)):
+		raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
+	# Round fidelity to only 10 decimals to avoid error when rho_1 = rho_2
+	return np.sqrt(2.0 * (1.0 - round(fidelity(rho_1, rho_2), 10) ))

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -1,3 +1,4 @@
+"""Bures distance metric."""
 import numpy as np
 
 from toqito.state_metrics import fidelity
@@ -13,8 +14,9 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
     \sqrt{2 (1 - F(\rho_1, \rho_2)}
 
     where:`fidelity` denotes the fidelity between `rho_1` and `rho_2` . The return is a value
-    between :math:`0` and :math:`\sqrt(2)`, with :math:`0` corresponding to matrices: code:`rho_1 = rho_2` 
-    and :math:`\sqrt(2)` corresponding to the  case : code:`rho_1` and :code:`rho_2` with orthogonal support.
+    between :math:`0` and :math:`\sqrt(2)`, with :math:`0` corresponding to matrices: 
+    code:`rho_1 = rho_2` and :math:`\sqrt(2)` corresponding to the  case : code:`rho_1`
+    and :code:`rho_2` with orthogonal support.
 
     Examples
     ==========
@@ -58,7 +60,6 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
     :param rho_2: Density operator.
     :return: The Bures distance between :code:`rho_1` and :code:`sigma_2`.
     """
-
     # Perform some error checking.
     if not np.all(rho_1.shape == (rho_2.shape)):
         raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -6,15 +6,16 @@ from toqito.state_metrics import fidelity
 def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
     r"""
     Compute the bures distance of two density matrices [WikFid]_.
-    Calculate the bures distance between the two density matrices: 
-    rho_1 and rho_2, defined by:
+
+    Calculate the bures distance between the two density matrices: rho_1 and 
+    rho_2, defined by:
     .. math::
         \sqrt{2 (1 - F(\rho_1, \rho_2)},
 
-    where:`fidelity` denotes the fidelity between `rho_1` and `rho_2` . The return is a value
-    between :math:`0` and :math:`\sqrt(2)`, with :math:`0` corresponding to matrices: 
-    code:`rho_1 = rho_2` and :math:`\sqrt(2)` corresponding to the  case : code:`rho_1`
-    and :code:`rho_2` with orthogonal support.
+    where:`fidelity` denotes the fidelity between `rho_1` and `rho_2` . The return is a value between 
+    :math:`0` and :math:`\sqrt(2)`, with :math:`0` corresponding to matrices: code:`rho_1 = rho_2`
+    and :math:`\sqrt(2)` corresponding to the  case : code:`rho_1`and :code:`rho_2`
+    with orthogonal support.
 
     Examples
     ==========

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -3,19 +3,19 @@ import numpy as np
 
 from toqito.state_metrics import fidelity
 
-def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
+def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> float:
     r"""
-    Compute the bures distance of two density matrices [WikFid]_.
+    Compute the Bures distance of two density matrices [WikBures]_.
 
-    Calculate the bures distance between the two density matrices:
-    `rho_1` and `rho_2`, defined by:
+    Calculate the Bures distance between the two density matrices:
+    ":code:`rho_1` and ":code:`rho_2`, defined by:
     .. math::
         \sqrt{2 (1 - F(\rho_1, \rho_2)},
 
-    where:`fidelity` denotes the fidelity between `rho_1` and `rho_2`
+    where :math:`F(\cdot)` denotes the fidelity between :math:`\rho_1` and :math:`\rho_2`.
     The return is a value between :math:`0` and :math:`\sqrt(2)`,with
-    :math:`0` corresponding to matrices: code:`rho_1 = rho_2`and
-    :math:`\sqrt(2)` corresponding to the case: code:`rho_1`and
+    :math:`0` corresponding to matrices: :code:`rho_1 = rho_2` and
+    :math:`\sqrt(2)` corresponding to the case: :code:`rho_1`and
     :code:`rho_2` with orthogonal support.
 
     Examples
@@ -36,7 +36,7 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
                          1 & 0 & 0 & 1
                        \end{pmatrix} \in \text{D}(\mathcal{X}).
 
-    In the event where we calculate the fidelity between states that are identical, we should obtain
+    In the event where we calculate the Bures distance between states that are identical, we should obtain
     the value of :math:`0`. This can be observed in :code:`toqito` as follows.
 
     >>> from toqito.state_metrics import bures_distance
@@ -53,15 +53,16 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
 
     References
     ==========
-    .. [WikFid] Wikipedia: Bures metric
+    .. [WikBures] Wikipedia: Bures metric
         https://en.wikipedia.org/wiki/Bures_metric
 
     :param rho_1: Density operator.
     :param rho_2: Density operator.
-    :return: The Bures distance between :code:`rho_1` and :code:`sigma_2`.
+    :param decimals: Number of decimal places to round to (default 10).
+    :return: The Bures distance between :code:`rho_1` and :code:`rho_2`.
     """
     # Perform some error checking.
-    if not np.all(rho_1.shape == (rho_2.shape)):
+    if not np.all(rho_1.shape == rho_2.shape):
         raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
     # Round fidelity to only 10 decimals to avoid error when rho_1 = rho_2
-    return np.sqrt(2.0 * (1.0 - round(fidelity(rho_1, rho_2), 10) ))
+    return np.sqrt(2.0 * (1.0 - np.round(fidelity(rho_1, rho_2), decimals) ))

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -3,19 +3,20 @@ import numpy as np
 
 from toqito.state_metrics import fidelity
 
+
 def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> float:
     r"""
     Compute the Bures distance of two density matrices [WikBures]_.
 
-    Calculate the Bures distance between the two density matrices:
-    ":code:`rho_1` and ":code:`rho_2`, defined by:
+    Calculate the Bures distance between the two density matrices: :code:`rho_1` and
+    :code:`rho_2`, defined by:
     .. math::
-        \sqrt{2 (1 - F(\rho_1, \rho_2)},
+        \sqrt{2 (1 - F(\rho_1, \rho_2))},
 
     where :math:`F(\cdot)` denotes the fidelity between :math:`\rho_1` and :math:`\rho_2`.
-    The return is a value between :math:`0` and :math:`\sqrt(2)`,with
+    The return is a value between :math:`0` and :math:`\sqrt{2}`,with
     :math:`0` corresponding to matrices: :code:`rho_1 = rho_2` and
-    :math:`\sqrt(2)` corresponding to the case: :code:`rho_1`and
+    :math:`\sqrt{2}` corresponding to the case: :code:`rho_1`and
     :code:`rho_2` with orthogonal support.
 
     Examples
@@ -37,7 +38,7 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> 
                        \end{pmatrix} \in \text{D}(\mathcal{X}).
 
     In the event where we calculate the Bures distance between states that are identical, we
-    should obtain the value of :math:`0`.This can be observed in :code:`toqito` as follows.
+    should obtain the value of :math:`0`. This can be observed in :code:`toqito` as follows.
 
     >>> from toqito.state_metrics import bures_distance
     >>> import numpy as np
@@ -65,4 +66,4 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> 
     if not np.all(rho_1.shape == rho_2.shape):
         raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
     # Round fidelity to only 10 decimals to avoid error when rho_1 = rho_2
-    return np.sqrt(2.0 * (1.0 - np.round(fidelity(rho_1, rho_2), decimals) ))
+    return np.sqrt(2.0 * (1.0 - np.round(fidelity(rho_1, rho_2), decimals)))

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -6,12 +6,10 @@ from toqito.state_metrics import fidelity
 def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
     r"""
     Compute the bures distance of two density matrices [WikFid]_.
-    
     Calculate the bures distance between the two density matrices: 
     rho_1 and rho_2, defined by:
-    
     .. math::
-    \sqrt{2 (1 - F(\rho_1, \rho_2)}
+        \sqrt{2 (1 - F(\rho_1, \rho_2)},
 
     where:`fidelity` denotes the fidelity between `rho_1` and `rho_2` . The return is a value
     between :math:`0` and :math:`\sqrt(2)`, with :math:`0` corresponding to matrices: 
@@ -63,6 +61,5 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray ) -> float:
     # Perform some error checking.
     if not np.all(rho_1.shape == (rho_2.shape)):
         raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
-
     # Round fidelity to only 10 decimals to avoid error when rho_1 = rho_2
     return np.sqrt(2.0 * (1.0 - round(fidelity(rho_1, rho_2), 10) ))


### PR DESCRIPTION
## Description
This function takes as input two density matrices and performs the following calculation:

```
from toqito.state_metrics import fidelity

np.sqrt(2.0 * (1.0 - fidelity(rho_1, rho_2)))
```
where `rho_1` and `rho_2 ` are density operators and where the `fidelity` function comes from `toqito.state_metrics.fidelity`.

## Todos
  -  [x] Compute the bures distance
  -  [x]  When `rho_1 = rho_2`,  `fidelity(rho_1, rho_2) = 1.0000000000000002`. This will create an error in the `sqrt`. I added the `round` function to the 10 decimal to avoid it.
  - [x] I added the tests for the function in  `tests/test_state_metrics/test_bures_distance.py`
  - [x] I added `from toqito.state_metrics.bures_distance import bures_distance` to  `toqito/state_metrics/__init__.py`

## Questions
-  [ ] Perhaps add something in the `fidelity` function for the case  `rho_1 = rho_2` and avoid the numeric error `1.0000000000000002`. That `2` may cause problems somewhere else.

## Status
-  [x] Ready to go