### PR TITLE
NPA hierarchy [unitaryHACK]

### DIFF
--- a/tests/test_helper/test_npa_constraints.py
+++ b/tests/test_helper/test_npa_constraints.py
@@ -1,0 +1,58 @@
+"""Test npa_constraints."""
+from collections import defaultdict
+import numpy as np
+import cvxpy
+
+from toqito.helper import npa_constraints
+
+
+# see Table 1. from NPA paper [arXiv:0803.4290].
+def test_cglmp_inequality():
+    """Test Collins-Gisin-Linden-Massar-Popescu inequality."""
+    dim = 3
+    (a_in, b_in) = (2, 2)
+    (a_out, b_out) = (dim, dim)
+
+    mat = defaultdict(cvxpy.Variable)
+    for x_in in range(a_in):
+        for y_in in range(b_in):
+            mat[x_in, y_in] = cvxpy.Variable((a_out, b_out),
+                                    name='M(a, b | {}, {})'.format(x_in, y_in))
+
+    i_b = 0
+    for k in range(dim // 2):
+        tmp = 0
+        for a_val in range(a_out):
+            for b_val in range(b_out):
+                if a_val == np.mod(b_val + k, dim):
+                    tmp += mat[0, 0][a_val, b_val]
+                    tmp += mat[1, 1][a_val, b_val]
+
+                if b_val == np.mod(a_val + k + 1, dim):
+                    tmp += mat[1, 0][a_val, b_val]
+
+                if b_val == np.mod(a_val + k, dim):
+                    tmp += mat[0, 1][a_val, b_val]
+
+                if a_val == np.mod(b_val - k - 1, dim):
+                    tmp -= mat[0, 0][a_val, b_val]
+                    tmp -= mat[1, 1][a_val, b_val]
+
+                if b_val == np.mod(a_val - k, dim):
+                    tmp -= mat[1, 0][a_val, b_val]
+
+                if b_val == np.mod(a_val - k - 1, dim):
+                    tmp -= mat[0, 1][a_val, b_val]
+
+        i_b += (1 - 2 * k / (dim - 1)) * tmp
+
+    k = 2
+    npa = npa_constraints(mat, k)
+    objective = cvxpy.Maximize(i_b)
+    problem = cvxpy.Problem(objective, npa)
+    val = problem.solve()
+    np.testing.assert_equal(np.allclose(val, 2.914, atol=1e-3), True)
+
+
+if __name__ == "__main__":
+    np.testing.run_module_suite()

--- a/tests/test_helper/test_npa_constraints.py
+++ b/tests/test_helper/test_npa_constraints.py
@@ -1,12 +1,14 @@
 """Test npa_constraints."""
 from collections import defaultdict
+from typing import Dict, Tuple
 import numpy as np
 import cvxpy
+import pytest
 
 from toqito.helper import npa_constraints
 
 
-def cglmp_inequality(dim):
+def cglmp_inequality(dim: int) -> Tuple[Dict[Tuple[int, int], cvxpy.Variable], cvxpy.Expression]:
     """Collins-Gisin-Linden-Massar-Popescu inequality."""
     (a_in, b_in) = (2, 2)
     (a_out, b_out) = (dim, dim)
@@ -15,9 +17,9 @@ def cglmp_inequality(dim):
     for x_in in range(a_in):
         for y_in in range(b_in):
             mat[x_in, y_in] = cvxpy.Variable((a_out, b_out),
-                                    name='M(a, b | {}, {})'.format(x_in, y_in))
+                                    name="M(a, b | {}, {})".format(x_in, y_in))
 
-    i_b = 0
+    i_b = cvxpy.Constant(0)
     for k in range(dim // 2):
         tmp = 0
         for a_val in range(a_out):
@@ -48,11 +50,12 @@ def cglmp_inequality(dim):
 
 
 # see Table 1. from NPA paper [arXiv:0803.4290].
-def test_cglmp_inequality():
+@pytest.mark.parametrize("k", [2, "1+ab+aab+baa"])
+def test_cglmp_inequality(k):
     """Test Collins-Gisin-Linden-Massar-Popescu inequality."""
     dim = 3
     mat, i_b = cglmp_inequality(dim)
-    npa = npa_constraints(mat, k=2)
+    npa = npa_constraints(mat, k)
     objective = cvxpy.Maximize(i_b)
     problem = cvxpy.Problem(objective, npa)
     val = problem.solve()
@@ -60,18 +63,19 @@ def test_cglmp_inequality():
 
 
 # see Table 1. from NPA paper [arXiv:0803.4290].
-def test_cglmp_dimension():
-    """Test Collins-Gisin-Linden-Massar-Popescu inequality."""
+@pytest.mark.parametrize("k, expected_size", [("1+a", 9), ("1+ab", 25)])
+def test_cglmp_dimension(k, expected_size):
+    """Test matrix size in Collins-Gisin-Linden-Massar-Popescu inequality."""
     dim = 3
     mat, i_b = cglmp_inequality(dim)
-    npa = npa_constraints(mat, k='1+ab')
+    npa = npa_constraints(mat, k)
     objective = cvxpy.Maximize(i_b)
     problem = cvxpy.Problem(objective, npa)
     r_size = 0
-    for vars in problem.variables():
-        if vars.name() == 'R':
-            r_size = vars.shape[0]
-    np.testing.assert_equal(np.allclose(r_size, 25), True)
+    for variable in problem.variables():
+        if variable.name() == "R":
+            r_size = variable.shape[0]
+    np.testing.assert_equal(np.allclose(r_size, expected_size), True)
 
 
 if __name__ == "__main__":

--- a/tests/test_helper/test_npa_constraints.py
+++ b/tests/test_helper/test_npa_constraints.py
@@ -6,10 +6,8 @@ import cvxpy
 from toqito.helper import npa_constraints
 
 
-# see Table 1. from NPA paper [arXiv:0803.4290].
-def test_cglmp_inequality():
-    """Test Collins-Gisin-Linden-Massar-Popescu inequality."""
-    dim = 3
+def cglmp_inequality(dim):
+    """Collins-Gisin-Linden-Massar-Popescu inequality."""
     (a_in, b_in) = (2, 2)
     (a_out, b_out) = (dim, dim)
 
@@ -46,12 +44,34 @@ def test_cglmp_inequality():
 
         i_b += (1 - 2 * k / (dim - 1)) * tmp
 
-    k = 2
-    npa = npa_constraints(mat, k)
+    return mat, i_b
+
+
+# see Table 1. from NPA paper [arXiv:0803.4290].
+def test_cglmp_inequality():
+    """Test Collins-Gisin-Linden-Massar-Popescu inequality."""
+    dim = 3
+    mat, i_b = cglmp_inequality(dim)
+    npa = npa_constraints(mat, k=2)
     objective = cvxpy.Maximize(i_b)
     problem = cvxpy.Problem(objective, npa)
     val = problem.solve()
     np.testing.assert_equal(np.allclose(val, 2.914, atol=1e-3), True)
+
+
+# see Table 1. from NPA paper [arXiv:0803.4290].
+def test_cglmp_dimension():
+    """Test Collins-Gisin-Linden-Massar-Popescu inequality."""
+    dim = 3
+    mat, i_b = cglmp_inequality(dim)
+    npa = npa_constraints(mat, k='1+ab')
+    objective = cvxpy.Maximize(i_b)
+    problem = cvxpy.Problem(objective, npa)
+    r_size = 0
+    for vars in problem.variables():
+        if vars.name() == 'R':
+            r_size = vars.shape[0]
+    np.testing.assert_equal(np.allclose(r_size, 25), True)
 
 
 if __name__ == "__main__":

--- a/tests/test_nonlocal_games/test_nonlocal_game.py
+++ b/tests/test_nonlocal_games/test_nonlocal_game.py
@@ -140,6 +140,24 @@ class TestNonlocalGame(unittest.TestCase):
         expected_res = 1
         self.assertEqual(np.isclose(res, expected_res, atol=0.5), True)
 
+    def test_chsh_game_commuting_measurement_value(self):
+        """Commuting measurement value for the CHSH game."""
+        prob_mat, pred_mat = self.chsh_nonlocal_game()
+
+        chsh = NonlocalGame(prob_mat, pred_mat)
+        res = chsh.commuting_measurement_value_upper_bound(k=1)
+        expected_res = 0.8535
+        self.assertEqual(np.isclose(res, expected_res, atol=0.5), True)
+
+    def test_ffl_game_commuting_measurement_value(self):
+        """Commuting measurement value for the FFL game."""
+        prob_mat, pred_mat = self.ffl_nonlocal_game()
+
+        ffl = NonlocalGame(prob_mat, pred_mat)
+        res = ffl.commuting_measurement_value_upper_bound(k=1)
+        expected_res = 0.666
+        self.assertEqual(np.isclose(res, expected_res, atol=0.5), True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/toqito/helper/__init__.py
+++ b/toqito/helper/__init__.py
@@ -3,3 +3,4 @@ from toqito.helper.expr_as_np_array import expr_as_np_array
 from toqito.helper.np_array_as_expr import np_array_as_expr
 from toqito.helper.update_odometer import update_odometer
 from toqito.helper.cvx_kron import cvx_kron
+from toqito.helper.npa_hierarchy import npa_constraints

--- a/toqito/helper/npa_hierarchy.py
+++ b/toqito/helper/npa_hierarchy.py
@@ -13,7 +13,7 @@ Symbol = namedtuple("Symbol",
 
 # This function simplifies the input word by applying
 # the commutation and projector rules.
-def _reduce(word: List[Symbol]) -> List[Symbol]:
+def _reduce(word: Tuple[Symbol]) -> Tuple[Symbol]:
     # commute: bring Alice in front.
     w_a, w_b = (), ()
     for symbol in word:
@@ -96,11 +96,11 @@ def _gen_words(
     return words
 
 
-def _is_zero(word: List[Symbol]) -> bool:
+def _is_zero(word: Tuple[Symbol]) -> bool:
     return len(word) == 0
 
 
-def _is_meas(word: List[Symbol]) -> bool:
+def _is_meas(word: Tuple[Symbol]) -> bool:
     if len(word) == 2:
         s_a, s_b = word
         return s_a.player == "Alice" \
@@ -109,7 +109,7 @@ def _is_meas(word: List[Symbol]) -> bool:
     return False
 
 
-def _is_meas_on_one_player(word: List[Symbol]) -> bool:
+def _is_meas_on_one_player(word: Tuple[Symbol]) -> bool:
     if len(word) == 1 and word[0].player in ["Alice", "Bob"]:
         return True
 

--- a/toqito/helper/npa_hierarchy.py
+++ b/toqito/helper/npa_hierarchy.py
@@ -1,0 +1,223 @@
+"""NPA constraints."""
+from itertools import product
+from collections import namedtuple
+from typing import Union, List, Dict, Tuple
+
+import cvxpy
+
+
+Symbol = namedtuple('Symbol',
+                    ['player', 'question', 'answer'],
+                    defaults=['', None, None])
+
+
+# This function simplifies the input word by appling
+# the commutation and projector rules.
+def _reduce(word):
+    # commute: bring Alice in front.
+    w_a, w_b = (), ()
+    for symbol in word:
+        if symbol.player == 'Alice':
+            w_a += (symbol,)
+        if symbol.player == 'Bob':
+            w_b += (symbol,)
+
+    word = w_a + w_b
+    for i in range(len(word) - 1):
+        symbol_x, symbol_y = word[i], word[i + 1]
+
+        # projector: merge them.
+        if symbol_x == symbol_y:
+            return _reduce(word[:i] + word[i + 1:])
+
+        # orthogonal: evaluates to zero.
+        if symbol_x.player == symbol_y.player \
+          and symbol_x.question == symbol_y.question \
+          and symbol_x.answer != symbol_y.answer:
+            return ()
+
+    return word
+
+
+
+def _parse(k):
+    k = k.split('+')
+    base_k = int(k[0])
+
+    conf = set()
+    for val in k[1:]:
+        # otherwise we already take this configuration
+        # in base_k - level of hierarchy.
+        if len(val) > base_k:
+            cnt_a, cnt_b = 0, 0
+            for bit in val:
+                if bit == 'a':
+                    cnt_a += 1
+                if bit == 'b':
+                    cnt_b += 1
+
+            conf.add((cnt_a, cnt_b))
+
+    return base_k, conf
+
+
+# This function generates all non - equivalent words of length up to k.
+def _gen_words(k, a_out, a_in, b_out, b_in):
+    # remove one outcome to avoid redundancy
+    # since all projectors sum to identity.
+    b_symbols = [Symbol('Bob', y, b)   for y in range(b_in) for b in range(b_out - 1)]
+    a_symbols = [Symbol('Alice', x, a) for x in range(a_in) for a in range(a_out - 1)]
+
+    words = [(Symbol(''),)]
+
+    conf = []
+    if isinstance(k, str):
+        k, conf = _parse(k)
+
+    #pylint: disable=too-many-nested-blocks
+    for i in range(1, k + 1):
+        for j in range(i + 1):
+            # words of type: a^j b^(i - j)
+            for word_a in product(a_symbols, repeat=j):
+                if len(_reduce(word_a)) == j:
+                    for word_b in product(b_symbols, repeat=i - j):
+                        if len(_reduce(word_b)) == i - j:
+                            words += [word_a + word_b]
+
+    # now generate the intermediate levels of hierarchy
+    for cnt_a, cnt_b in conf:
+        for word_a in product(a_symbols, repeat=cnt_a):
+            if len(_reduce(word_a)) == cnt_a:
+                for word_b in product(b_symbols, repeat=cnt_b):
+                    if len(_reduce(word_b)) == cnt_b:
+                        words += [word_a + word_b]
+
+    return words
+
+
+def _is_zero(word):
+    return len(word) == 0
+
+
+def _is_meas(word):
+    if len(word) == 2:
+        s_a, s_b = word
+        return s_a.player == 'Alice' \
+            and s_b.player == 'Bob'
+
+    return False
+
+
+def _is_meas_on_one_player(word):
+    if len(word) == 1 \
+      and word[0].player in ['Alice', 'Bob']:
+        return True
+
+    return False
+
+
+def _get_shape(prob):
+    a_in, a_out = (0, 0)
+    b_in, b_out = (0, 0)
+    for (x_in, y_in), _var in prob.items():
+        a_in = max(a_in, x_in + 1)
+        b_in = max(b_in, y_in + 1)
+        a_out, b_out = _var.shape
+
+    return a_out, a_in, b_out, b_in
+
+
+def npa_constraints(
+    prob: Dict[Tuple[int, int], cvxpy.Variable],
+    k: Union[int, str] = 1
+) -> List[cvxpy.constraints.constraint.Constraint]:
+    """
+    Generate the constraints specified by the NPA hierarchy up to a finite level.
+
+    You can determine the level of the hierarchy by a positive integer or a string
+    of a form like '1+ab+aab', which indicates that an intermediate level of the hierarchy
+    should be used, where this example uses all products of 1 measurement, all products of
+    one Alice and one Bob measurement, and all products of two Alice and one Bob measurement.
+
+    The probabilities must be given as a dictionary. The keys are tuples of Alice and Bob questions
+    and the values are cvxpy Variables representing the joint probability for different outcomes.
+
+    :param prob: A dictionary with keys the different questions for Alice and Bob
+                and values the probability matrices for different outcomes.
+    :param k: The level of the NPA hierarchy to use (default=1).
+    :return: A list of cvxpy constraints.
+    """
+    a_out, a_in, b_out, b_in = _get_shape(prob)
+
+    words = _gen_words(k, a_out, a_in, b_out, b_in)
+    dim = len(words)
+
+    r_var = cvxpy.Variable((dim, dim), PSD=True,
+                           name='R')
+    constraints = [r_var[0, 0] == 1]
+
+    seen = {}
+    for i in range(dim):
+        for j in range(i, dim):
+            w_i, w_j = words[i], words[j]
+            w_i = tuple(reversed(w_i))
+            word = _reduce(w_i + w_j)
+
+            # if i = 0 we would consider (ε, ε) as an empty word.
+            if i != 0 and _is_zero(word):
+                constraints += [
+                    r_var[i, j] == 0]
+
+            elif _is_meas(word):
+                s_a, s_b = word
+                constraints += [
+                    r_var[i, j] == prob[s_a.question, s_b.question][s_a.answer, s_b.answer]]
+
+            elif _is_meas_on_one_player(word):
+                symbol = word[0]
+                if symbol.player == 'Alice':
+                    _sum = 0
+                    for b_ans in range(b_out):
+                        _sum += prob[symbol.question, 0][symbol.answer, b_ans]
+
+                    constraints += [r_var[i, j] == _sum]
+
+                if symbol.player == 'Bob':
+                    _sum = 0
+                    for a_ans in range(a_out):
+                        _sum += prob[0, symbol.question][a_ans, symbol.answer]
+
+                    constraints += [r_var[i, j] == _sum]
+
+            elif word in seen:
+                old_i, old_j = seen[word]
+                constraints += [r_var[i, j] == r_var[old_i, old_j]]
+
+            else:
+                seen[word] = (i, j)
+
+
+    # now we impose constraints to the probability vector
+    for x_alice_in in range(a_in):
+        for y_bob_in in range(b_in):
+            constraints += [prob[x_alice_in, y_bob_in] >= 0,
+                            cvxpy.sum(prob[x_alice_in, y_bob_in]) == 1]
+
+    # Bob marginal consistency
+    for y_bob_in in range(b_in):
+        for b_ans in range(b_out):
+            _sum = cvxpy.sum(prob[0, y_bob_in][:, b_ans])
+            for x_alice_in in range(1, a_in):
+                cur_sum = cvxpy.sum(prob[x_alice_in, y_bob_in][:, b_ans])
+                constraints += [_sum == cur_sum]
+
+    # Alice marginal consistency
+    for x_alice_in in range(a_in):
+        for a_ans in range(a_out):
+            _sum = cvxpy.sum(prob[x_alice_in, 0][a_ans, :])
+            for y_bob_in in range(1, b_in):
+                cur_sum = cvxpy.sum(prob[x_alice_in, y_bob_in][a_ans, :])
+                constraints += [_sum == cur_sum]
+
+
+    return constraints

--- a/toqito/nonlocal_games/nonlocal_game.py
+++ b/toqito/nonlocal_games/nonlocal_game.py
@@ -548,7 +548,7 @@ class NonlocalGame:
         for x_in in range(alice_in):
             for y_in in range(bob_in):
                 mat[x_in, y_in] = cvxpy.Variable((alice_out, bob_out),
-                                            name='M(a, b | {}, {})'.format(x_in, y_in))
+                                                name="M(a, b | {}, {})".format(x_in, y_in))
 
         p_win = cvxpy.Constant(0)
         for a_out in range(alice_out):

--- a/toqito/nonlocal_games/nonlocal_game.py
+++ b/toqito/nonlocal_games/nonlocal_game.py
@@ -1,11 +1,11 @@
 """Two-player nonlocal game."""
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Union
 from collections import defaultdict
 import cvxpy
 import numpy as np
 from toqito.random import random_povm
 from toqito.matrix_ops import tensor
-from toqito.helper import update_odometer
+from toqito.helper import update_odometer, npa_constraints
 
 
 class NonlocalGame:
@@ -517,3 +517,51 @@ class NonlocalGame:
         ns_val = problem.solve()
 
         return ns_val
+
+    def commuting_measurement_value_upper_bound(self, k: Union[int, str] = 1) -> float:
+        """
+        Compute an upper bound on the commuting measurement value of the nonlocal game.
+
+        This function calculates an upper bound on the commuting measurement value by
+        using k - levels of the NPA hierarchy [NPA]_. The NPA hierarchy is a uniform family
+        of semidefinite programs that converges to the commuting measurement value of
+        any nonlocal game.
+
+        You can determine the level of the hierarchy by a positive integer or a string
+        of a form like '1+ab+aab', which indicates that an intermediate level of the hierarchy
+        should be used, where this example uses all products of 1 measurement, all products of
+        one Alice and one Bob measurement, and all products of two Alice and one Bob measurement.
+
+        References
+        ==========
+        .. [NPA] Miguel Navascues, Stefano Pironio, Antonio Acin.
+            "A convergent hierarchy of semidefinite programs characterizing
+             the set of quantum correlations."
+            https://arxiv.org/abs/0803.4290
+
+        :param k: The level of the NPA hierarchy to use (default=1).
+        :return: The upper bound on the commuting strategy value of a nonlocal game.
+        """
+        alice_out, bob_out, alice_in, bob_in = self.pred_mat.shape
+
+        mat = defaultdict(cvxpy.Variable)
+        for x_in in range(alice_in):
+            for y_in in range(bob_in):
+                mat[x_in, y_in] = cvxpy.Variable((alice_out, bob_out),
+                                            name='M(a, b | {}, {})'.format(x_in, y_in))
+
+        p_win = cvxpy.Constant(0)
+        for a_out in range(alice_out):
+            for b_out in range(bob_out):
+                for x_in in range(alice_in):
+                    for y_in in range(bob_in):
+                        p_win += self.prob_mat[x_in, y_in] * \
+                            self.pred_mat[a_out, b_out, x_in, y_in] * \
+                            mat[x_in, y_in][a_out, b_out]
+
+        npa = npa_constraints(mat, k)
+        objective = cvxpy.Maximize(p_win)
+        problem = cvxpy.Problem(objective, npa)
+        cs_val = problem.solve()
+
+        return cs_val


### PR DESCRIPTION
## Description
Resolves #5.
Implements a function to calculate an upper bound on the commuting measurement value of a nonlocal game.

## Questions
-  [x] Is `toqito/helper` the best place for `npa_hierarchy.py` or we should expose the functionality of `npa_constraints` to the user?

## Status
-  [x] Ready to go