### PR TITLE
Implement construction of nonlocal game from binary constraint system game [unitaryHACK]

### DIFF
--- a/tests/test_nonlocal_games/test_nonlocal_game.py
+++ b/tests/test_nonlocal_games/test_nonlocal_game.py
@@ -55,6 +55,42 @@ class TestNonlocalGame(unittest.TestCase):
 
         return [c_1, c_2]
 
+    def test_chsh_bcs_game_to_nonlocal_game(self):
+        """Conversion of BCS game to nonlocal game"""
+        bcs_game = self.chsh_bcs_game()
+        chsh = NonlocalGame.from_bcs_game(bcs_game)
+
+        # Compute expected prob_mat
+        prob_mat = np.array([[1 / 4, 1 / 4], [1 / 4, 1 / 4]])
+        np.testing.assert_array_equal(chsh.prob_mat, prob_mat)
+
+        # Compute expected pred_mat
+        pred_mat = np.zeros((4, 2, 2, 2))
+        # Compute first constraint: v1 ^ v2 = 0
+        constraint1 = np.array([
+            [1, 0],
+            [0, 0],
+            [0, 0],
+            [0, 1]])
+        pred_mat[:, :, 0, 0] = constraint1
+        pred_mat[:, :, 0, 1] = constraint1
+        # Compute second constraint: v1 ^ v2 = 1
+        pred_mat[:, :, 1, 0] = np.array([
+            [0, 0],
+            [1, 0],
+            [0, 1],
+            [0, 0]])
+        pred_mat[:, :, 1, 1] = np.array([
+            [0, 0],
+            [0, 1],
+            [1, 0],
+            [0, 0]])
+        np.testing.assert_array_equal(chsh.pred_mat, pred_mat)
+
+    def test_bcs_game_without_constraint(self):
+        """Empty list of constraints raises exception"""
+        self.assertRaises(ValueError, NonlocalGame.from_bcs_game, [])
+
     def test_chsh_lower_bound(self):
         """Calculate the lower bound on the quantum value for the CHSH game."""
         prob_mat, pred_mat = self.chsh_nonlocal_game()
@@ -92,6 +128,36 @@ class TestNonlocalGame(unittest.TestCase):
         prob_mat, pred_mat = self.chsh_nonlocal_game()
 
         chsh = NonlocalGame(prob_mat, pred_mat, 2)
+        res = chsh.classical_value()
+        expected_res = 10 / 16
+        self.assertEqual(np.isclose(res, expected_res), True)
+
+    def test_bcs_chsh_lower_bound(self):
+        """Calculate the lower bound on the quantum value for the converted BCS CHSH game."""
+        bcs_game = self.chsh_bcs_game()
+        chsh = NonlocalGame.from_bcs_game(bcs_game)
+        res = chsh.quantum_value_lower_bound()
+        self.assertLessEqual(np.isclose(res, np.cos(np.pi / 8) ** 2, rtol=1e-02), True)
+
+    def test_bcs_chsh_game_classical_value(self):
+        """Classical value for the converted BCS CHSH game."""
+        bcs_game = self.chsh_bcs_game()
+        chsh = NonlocalGame.from_bcs_game(bcs_game)
+        res = chsh.classical_value()
+        expected_res = 3 / 4
+        self.assertEqual(np.isclose(res, expected_res), True)
+
+    def test_bcs_chsh_game_classical_value_rep_2(self):
+        r"""
+        Classical value for the CHSH game for 2 reps.
+
+        Note that for classical strategies, it is known that parallel repetition
+        does *not* hold for the CHSH game, that is:
+
+        w_c(CHSH \land CHSH) = 10/16 > 9/16 = w_c(CHSH) w_c(CHSH).
+        """
+        bcs_game = self.chsh_bcs_game()
+        chsh = NonlocalGame.from_bcs_game(bcs_game, 2)
         res = chsh.classical_value()
         expected_res = 10 / 16
         self.assertEqual(np.isclose(res, expected_res), True)
@@ -176,47 +242,6 @@ class TestNonlocalGame(unittest.TestCase):
         res = ffl.commuting_measurement_value_upper_bound(k=1)
         expected_res = 0.666
         self.assertEqual(np.isclose(res, expected_res, atol=0.5), True)
-
-    def test_chsh_bcs_game_to_nonlocal_game(self):
-        """Conversion of BCS game to nonlocal game"""
-        bcs_game = self.chsh_bcs_game()
-        chsh = NonlocalGame.from_bcs_game(bcs_game)
-
-        # Compute expected prob_mat
-        prob_mat = np.array([[1 / 4, 1 / 4], [1 / 4, 1 / 4]])
-        np.testing.assert_array_equal(chsh.prob_mat, prob_mat)
-
-        # Compute expected pred_mat
-        pred_mat = np.zeros((4, 2, 2, 2))
-        # Compute first constraint: v1 ^ v2 = 0
-        constraint1 = np.array([
-            [1, 0],
-            [0, 0],
-            [0, 0],
-            [0, 1]])
-        pred_mat[:, :, 0, 0] = constraint1
-        pred_mat[:, :, 0, 1] = constraint1
-        # Compute second constraint: v1 ^ v2 = 1
-        pred_mat[:, :, 1, 0] = np.array([
-            [0, 0],
-            [1, 0],
-            [0, 1],
-            [0, 0]])
-        pred_mat[:, :, 1, 1] = np.array([
-            [0, 0],
-            [0, 1],
-            [1, 0],
-            [0, 0]])
-        np.testing.assert_array_equal(chsh.pred_mat, pred_mat)
-
-        # Check classical value of converted nonlocal game
-        res = chsh.classical_value()
-        expected_res = 3 / 4
-        np.testing.assert_almost_equal(res, expected_res)
-
-    def test_bcs_game_without_constraint(self):
-        """Empty list of constraints raises exception"""
-        self.assertRaises(ValueError, NonlocalGame.from_bcs_game, [])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_nonlocal_games/test_nonlocal_game.py
+++ b/tests/test_nonlocal_games/test_nonlocal_game.py
@@ -43,16 +43,17 @@ class TestNonlocalGame(unittest.TestCase):
     @staticmethod
     def chsh_bcs_game():
         """Define the CHSH BCS game"""
-        constraints = np.zeros((2, 2, 2))
+        c_1 = np.zeros((2, 2))
+        c_2 = np.zeros((2, 2))
 
         for v_1 in range(2):
             for v_2 in range(2):
                 if v_1 ^ v_2 == 0:
-                    constraints[0, v_1, v_2] = 1
+                    c_1[v_1, v_2] = 1
                 else:
-                    constraints[1, v_1, v_2] = 1
+                    c_2[v_1, v_2] = 1
 
-        return constraints
+        return [c_1, c_2]
 
     def test_chsh_lower_bound(self):
         """Calculate the lower bound on the quantum value for the CHSH game."""
@@ -212,6 +213,10 @@ class TestNonlocalGame(unittest.TestCase):
         res = chsh.classical_value()
         expected_res = 3 / 4
         np.testing.assert_almost_equal(res, expected_res)
+
+    def test_bcs_game_without_constraint(self):
+        """Empty list of constraints raises exception"""
+        self.assertRaises(ValueError, NonlocalGame.from_bcs_game, [])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_nonlocal_games/test_nonlocal_game.py
+++ b/tests/test_nonlocal_games/test_nonlocal_game.py
@@ -45,12 +45,12 @@ class TestNonlocalGame(unittest.TestCase):
         """Define the CHSH BCS game"""
         constraints = np.zeros((2, 2, 2))
 
-        for v1 in range(2):
-            for v2 in range(2):
-                if v1 ^ v2 == 0:
-                    constraints[0, v1, v2] = 1
+        for v_1 in range(2):
+            for v_2 in range(2):
+                if v_1 ^ v_2 == 0:
+                    constraints[0, v_1, v_2] = 1
                 else:
-                    constraints[1, v1, v2] = 1
+                    constraints[1, v_1, v_2] = 1
 
         return constraints
 

--- a/toqito/nonlocal_games/nonlocal_game.py
+++ b/toqito/nonlocal_games/nonlocal_game.py
@@ -1,5 +1,5 @@
 """Two-player nonlocal game."""
-from typing import Dict, Tuple, Union
+from typing import Dict, List, Tuple, Union
 from collections import defaultdict
 import cvxpy
 import numpy as np
@@ -68,6 +68,66 @@ class NonlocalGame:
                 i_ind = update_odometer(i_ind, num_alice_in * np.ones(reps))
             self.pred_mat = pred_mat2
             self.reps = reps
+
+    @classmethod
+    def from_bcs_game(cls, constraints: List[np.ndarray], reps: int = 1) -> 'NonlocalGame':
+        """
+        Construct nonlocal game object from a binary constraint system game.
+
+        :param constraints: A list of m matrices corresponding to the `m`
+                            constraints in the BCS game. Each constraint matrix is
+                            an `n`-dimensional matrix of shape `2 x 2 x ... x 2`.
+                            The `(i, j, k, ...)`-th entry is 1 if and only if the
+                            contraint is satisfied given the values v_1 = i, v_2 = j,
+                            v_3 = k, ..., and otherwise 0.
+        :param reps: Number of parallel repetitions to perform. Default is 1.
+
+        :return: An instance of a nonlocal game object.
+        """
+        num_constraints = len(constraints)
+        if num_constraints == 0:
+            raise ValueError('At least 1 constraint is required')
+        num_variables = constraints[0].ndim
+
+        # Retrieve dependent variables for each constraint
+        dependent_variables = np.zeros((num_constraints, num_variables))
+
+        # `v_i` is _not_ a dependent variable of `c_j` if all entries in
+        # the `i`-th dimension of `constraints[j]` are equal, i.e.:
+        #   c_j[:, ..., :, 0, : ..., :] == c_j[:, ..., :, 1, : ..., :]
+        for j in range(num_constraints):
+            for i in range(num_variables):
+                dependent_variables[j, i] = np.diff(constraints[j], axis=i).any()
+
+        # Calculate probability matrix P(x, y) where:
+        #   x: uniformly randomly-selected constraint `c_x`
+        #   y: uniformly randomly-selected variable `v_y` in `c_x`
+        prob_mat = np.zeros((num_constraints, num_variables))
+        for x in range(num_constraints):
+            px = 1. / num_constraints
+            num_dependent_vars = dependent_variables[x].sum()
+            py = dependent_variables[x] / num_dependent_vars
+            prob_mat[x] = px * py
+
+        # Compute prediction matrix of outcomes given questions and answer pairs:
+        #   a: Alice's truth assignment to all variables in `c_x`
+        #   b: Bob's truth assignment for `v_y` in `c_x`
+        pred_mat = np.zeros((2 ** num_variables, 2, num_constraints, num_variables))
+        for x in range(num_constraints):
+            for a in range(pred_mat.shape[0]):
+                # Convert to binary representation
+                bin_a = [int(x) for x in np.binary_repr(a)]
+                truth_assignment = np.zeros(num_variables, dtype=np.int8)
+                truth_assignment[-len(bin_a):] = bin_a
+                truth_assignment = tuple(truth_assignment)
+
+                for y in range(num_variables):
+                    # The verifier can only accept the answer if Bob's truth assignment
+                    # is consistent with Alice's
+                    b = truth_assignment[y]
+                    pred_mat[a, b, x, y] = constraints[x][truth_assignment]
+
+        return cls(prob_mat, pred_mat, reps)
 
     def classical_value(self) -> float:
         """

--- a/toqito/nonlocal_games/nonlocal_game.py
+++ b/toqito/nonlocal_games/nonlocal_game.py
@@ -103,29 +103,31 @@ class NonlocalGame:
         #   x: uniformly randomly-selected constraint `c_x`
         #   y: uniformly randomly-selected variable `v_y` in `c_x`
         prob_mat = np.zeros((num_constraints, num_variables))
-        for x in range(num_constraints):
-            px = 1. / num_constraints
-            num_dependent_vars = dependent_variables[x].sum()
-            py = dependent_variables[x] / num_dependent_vars
-            prob_mat[x] = px * py
+        for j in range(num_constraints):
+            p_x = 1. / num_constraints
+            num_dependent_vars = dependent_variables[j].sum()
+            p_y = dependent_variables[j] / num_dependent_vars
+            prob_mat[j] = p_x * p_y
 
         # Compute prediction matrix of outcomes given questions and answer pairs:
         #   a: Alice's truth assignment to all variables in `c_x`
         #   b: Bob's truth assignment for `v_y` in `c_x`
         pred_mat = np.zeros((2 ** num_variables, 2, num_constraints, num_variables))
-        for x in range(num_constraints):
-            for a in range(pred_mat.shape[0]):
+        for x_alice in range(num_constraints):
+            for a_alice in range(pred_mat.shape[0]):
                 # Convert to binary representation
-                bin_a = [int(x) for x in np.binary_repr(a)]
+                bin_a = [int(x) for x in np.binary_repr(a_alice)]
                 truth_assignment = np.zeros(num_variables, dtype=np.int8)
                 truth_assignment[-len(bin_a):] = bin_a
                 truth_assignment = tuple(truth_assignment)
 
-                for y in range(num_variables):
+                for y_bob in range(num_variables):
                     # The verifier can only accept the answer if Bob's truth assignment
                     # is consistent with Alice's
-                    b = truth_assignment[y]
-                    pred_mat[a, b, x, y] = constraints[x][truth_assignment]
+                    b_bob = truth_assignment[y_bob]
+
+                    pred_mat[a_alice, b_bob, x_alice, y_bob] = \
+                        constraints[x_alice][truth_assignment]
 
         return cls(prob_mat, pred_mat, reps)
 

--- a/toqito/nonlocal_games/nonlocal_game.py
+++ b/toqito/nonlocal_games/nonlocal_game.py
@@ -113,21 +113,21 @@ class NonlocalGame:
         #   a: Alice's truth assignment to all variables in `c_x`
         #   b: Bob's truth assignment for `v_y` in `c_x`
         pred_mat = np.zeros((2 ** num_variables, 2, num_constraints, num_variables))
-        for x_alice in range(num_constraints):
-            for a_alice in range(pred_mat.shape[0]):
+        for x_ques in range(num_constraints):
+            for a_ans in range(pred_mat.shape[0]):
                 # Convert to binary representation
-                bin_a = [int(x) for x in np.binary_repr(a_alice)]
+                bin_a = [int(x) for x in np.binary_repr(a_ans)]
                 truth_assignment = np.zeros(num_variables, dtype=np.int8)
                 truth_assignment[-len(bin_a):] = bin_a
                 truth_assignment = tuple(truth_assignment)
 
-                for y_bob in range(num_variables):
+                for y_ques in range(num_variables):
                     # The verifier can only accept the answer if Bob's truth assignment
                     # is consistent with Alice's
-                    b_bob = truth_assignment[y_bob]
+                    b_ans = truth_assignment[y_ques]
 
-                    pred_mat[a_alice, b_bob, x_alice, y_bob] = \
-                        constraints[x_alice][truth_assignment]
+                    pred_mat[a_ans, b_ans, x_ques, y_ques] = \
+                        constraints[x_ques][truth_assignment]
 
         return cls(prob_mat, pred_mat, reps)
 


### PR DESCRIPTION
## Description
Binary constraint system games are a subset of non-local games that are useful tools for studying non-local games.

This PR implements a constructor for `NonlocalGame` that takes in a list of `m` constraints representing the BCS game and returns a `NonlocalGame`. Each constraint is an `n`-dimensional matrix of shape `2 x 2 x ... x 2`. The `(i, j, k, ...)`-th entry is 1 if and only if the constraint is satisfied given the values v_1 = i, v_2 = j, v_3 = k, ..., and otherwise 0.

Resolves #44.

## Todos
  -  [x] Fix issue with solver for `quantum_value_lower_bound`
  -  [x] Implement more tests

## Questions
Refer to #44.

## Status
-  [x] Ready to go