### PR TITLE
Fix implementation of `random_povm`

### DIFF
--- a/tests/test_random/test_random_povm.py
+++ b/tests/test_random/test_random_povm.py
@@ -1,16 +1,34 @@
 """Test random_povm."""
+import unittest
 import numpy as np
 
 from toqito.random import random_povm
 
 
-def test_random_povm_unitary_not_real():
-    """Generate random POVMs and check that they sum to the identity."""
-    dim, num_inputs, num_outputs = 2, 2, 2
-    povms = random_povm(dim, num_inputs, num_outputs)
-    np.testing.assert_equal(
-        np.allclose(povms[:, :, 0, 0] + povms[:, :, 0, 1], np.identity(dim)), True
-    )
+class TestRandomPOVM(unittest.TestCase):
+    """Unit test for NonlocalGame."""
+
+    def test_random_povm_unitary_not_real(self):
+        """Generate random POVMs and check that they sum to the identity."""
+        dim, num_inputs, num_outputs = 2, 2, 2
+        povms = random_povm(dim, num_inputs, num_outputs)
+
+        self.assertEqual(povms.shape, (dim, dim, num_inputs, num_outputs))
+
+        np.testing.assert_allclose(
+            povms[:, :, 0, 0] + povms[:, :, 0, 1], np.identity(dim), atol=1e-7
+        )
+
+    def test_random_povm_uneven_dimensions(self):
+        """Generate random POVMs of uneven dimensions"""
+        dim, num_inputs, num_outputs = 2, 3, 4
+        povms = random_povm(dim, num_inputs, num_outputs)
+
+        self.assertEqual(povms.shape, (dim, dim, num_inputs, num_outputs))
+
+        for i in range(num_inputs):
+            povm_sum = np.sum(povms[:, :, i, :], axis=-1)
+            np.testing.assert_allclose(povm_sum, np.identity(dim), atol=1e-7)
 
 
 if __name__ == "__main__":

--- a/toqito/random/random_povm.py
+++ b/toqito/random/random_povm.py
@@ -9,9 +9,10 @@ def random_povm(dim: int, num_inputs: int, num_outputs: int) -> np.ndarray:
     Examples
     ==========
 
-    We can generate a set of POVMs consisting of a specific dimension along with a given number of
-    measurement inputs and measurement outputs. As an example, we can construct a random set of
-    POVMs of dimension :math:`2` with :math:`2` inputs and :math:`2` outputs.
+    We can generate a set of `dim`-by-`dim` POVMs consisting of a specific dimension along with
+    a given number of measurement inputs and measurement outputs. As an example, we can
+    construct a random set of :math:`2`-by-:math:`2` POVMs of dimension with :math:`2` inputs
+    and :math:`2` outputs.
 
     >>> from toqito.random import random_povm
     >>> import numpy as np
@@ -40,13 +41,13 @@ def random_povm(dim: int, num_inputs: int, num_outputs: int) -> np.ndarray:
     .. [WIKPOVM] Wikipedia: POVM
         https://en.wikipedia.org/wiki/POVM
 
-    :param dim: The dimension of the measurements.
+    :param dim: The dimensions of the measurements.
     :param num_inputs: The number of inputs for the measurement.
     :param num_outputs: The number of outputs for the measurement.
-    :return: A set of POVMs of dimension :code:`dim`.
+    :return: A set of `dim`-by-`dim` POVMs of shape `(dim, dim, num_inputs, num_outputs)`.
     """
     povms = []
-    gram_vectors = np.random.normal(size=(dim, dim, num_inputs, num_outputs))
+    gram_vectors = np.random.normal(size=(num_inputs, num_outputs, dim, dim))
     for input_block in gram_vectors:
         normalizer = sum(
             [np.array(output_block).T.conj() @ output_block for output_block in input_block]
@@ -63,7 +64,7 @@ def random_povm(dim: int, num_inputs: int, num_outputs: int) -> np.ndarray:
             output_povms.append(internal.T.conj() @ internal)
         povms.append(output_povms)
 
-    # This allows us to index the POVMs as [d, d, num_inputs, num_outputs].
+    # This allows us to index the POVMs as [dim, dim, num_inputs, num_outputs].
     povms = np.swapaxes(np.array(povms), 0, 2)
     povms = np.swapaxes(povms, 1, 3)
 


### PR DESCRIPTION
## Description
I noticed a bug in the code of `random_povm` in which running `random_povm(dim, num_inputs, num_outputs)`, where `dim != num_inputs` and `dim != num_outputs` throws an error. It turns out that this is a one-line fix.

I also touched up the docs to state more clearly what the output should look like.

## Status
-  [x] Ready to go