### PR TITLE
Fix implementation of computing the quantum value lower bound of a non-local game

### DIFF
--- a/tests/test_nonlocal_games/test_nonlocal_game.py
+++ b/tests/test_nonlocal_games/test_nonlocal_game.py
@@ -52,6 +52,10 @@ class TestNonlocalGame(unittest.TestCase):
         # the true quantum value.
         self.assertLessEqual(np.isclose(res, np.cos(np.pi / 8) ** 2, rtol=1e-02), True)
 
+        # Even with 2 qubits each, the lower bound remains the same
+        res = chsh.quantum_value_lower_bound(4)
+        self.assertLessEqual(np.isclose(res, np.cos(np.pi / 8) ** 2, rtol=1e-02), True)
+
     def test_chsh_game_classical_value(self):
         """Classical value for the CHSH game."""
         prob_mat, pred_mat = self.chsh_nonlocal_game()

--- a/tests/test_random/test_random_povm.py
+++ b/tests/test_random/test_random_povm.py
@@ -1,16 +1,34 @@
 """Test random_povm."""
+import unittest
 import numpy as np
 
 from toqito.random import random_povm
 
 
-def test_random_povm_unitary_not_real():
-    """Generate random POVMs and check that they sum to the identity."""
-    dim, num_inputs, num_outputs = 2, 2, 2
-    povms = random_povm(dim, num_inputs, num_outputs)
-    np.testing.assert_equal(
-        np.allclose(povms[:, :, 0, 0] + povms[:, :, 0, 1], np.identity(dim)), True
-    )
+class TestRandomPOVM(unittest.TestCase):
+    """Unit test for NonlocalGame."""
+
+    def test_random_povm_unitary_not_real(self):
+        """Generate random POVMs and check that they sum to the identity."""
+        dim, num_inputs, num_outputs = 2, 2, 2
+        povms = random_povm(dim, num_inputs, num_outputs)
+
+        self.assertEqual(povms.shape, (dim, dim, num_inputs, num_outputs))
+
+        np.testing.assert_allclose(
+            povms[:, :, 0, 0] + povms[:, :, 0, 1], np.identity(dim), atol=1e-7
+        )
+
+    def test_random_povm_uneven_dimensions(self):
+        """Generate random POVMs of uneven dimensions"""
+        dim, num_inputs, num_outputs = 2, 3, 4
+        povms = random_povm(dim, num_inputs, num_outputs)
+
+        self.assertEqual(povms.shape, (dim, dim, num_inputs, num_outputs))
+
+        for i in range(num_inputs):
+            povm_sum = np.sum(povms[:, :, i, :], axis=-1)
+            np.testing.assert_allclose(povm_sum, np.identity(dim), atol=1e-7)
 
 
 if __name__ == "__main__":

--- a/toqito/random/random_povm.py
+++ b/toqito/random/random_povm.py
@@ -9,9 +9,10 @@ def random_povm(dim: int, num_inputs: int, num_outputs: int) -> np.ndarray:
     Examples
     ==========
 
-    We can generate a set of POVMs consisting of a specific dimension along with a given number of
-    measurement inputs and measurement outputs. As an example, we can construct a random set of
-    POVMs of dimension :math:`2` with :math:`2` inputs and :math:`2` outputs.
+    We can generate a set of `dim`-by-`dim` POVMs consisting of a specific dimension along with
+    a given number of measurement inputs and measurement outputs. As an example, we can
+    construct a random set of :math:`2`-by-:math:`2` POVMs of dimension with :math:`2` inputs
+    and :math:`2` outputs.
 
     >>> from toqito.random import random_povm
     >>> import numpy as np
@@ -40,13 +41,13 @@ def random_povm(dim: int, num_inputs: int, num_outputs: int) -> np.ndarray:
     .. [WIKPOVM] Wikipedia: POVM
         https://en.wikipedia.org/wiki/POVM
 
-    :param dim: The dimension of the measurements.
+    :param dim: The dimensions of the measurements.
     :param num_inputs: The number of inputs for the measurement.
     :param num_outputs: The number of outputs for the measurement.
-    :return: A set of POVMs of dimension :code:`dim`.
+    :return: A set of `dim`-by-`dim` POVMs of shape `(dim, dim, num_inputs, num_outputs)`.
     """
     povms = []
-    gram_vectors = np.random.normal(size=(dim, dim, num_inputs, num_outputs))
+    gram_vectors = np.random.normal(size=(num_inputs, num_outputs, dim, dim))
     for input_block in gram_vectors:
         normalizer = sum(
             [np.array(output_block).T.conj() @ output_block for output_block in input_block]
@@ -63,7 +64,7 @@ def random_povm(dim: int, num_inputs: int, num_outputs: int) -> np.ndarray:
             output_povms.append(internal.T.conj() @ internal)
         povms.append(output_povms)
 
-    # This allows us to index the POVMs as [d, d, num_inputs, num_outputs].
+    # This allows us to index the POVMs as [dim, dim, num_inputs, num_outputs].
     povms = np.swapaxes(np.array(povms), 0, 2)
     povms = np.swapaxes(povms, 1, 3)
 


### PR DESCRIPTION
## Description
When testing my implementation of #62 by trying to calculate the quantum value lower bound of the CHSH game, I got the following error:
```python
ValueError: Invalid dimensions (4, 2). Must be a square matrix.

toqito\nonlocal_games\nonlocal_game.py:361: in quantum_value_lower_bound
    alice_povms, lower_bound = self.__optimize_alice(bob_povms)
toqito\nonlocal_games\nonlocal_game.py:392: in __optimize_alice
    alice_povms[x_ques, a_ans] = cvxpy.Variable(
..\venv\lib\site-packages\cvxpy\expressions\variable.py:81: in __init__
    super(Variable, self).__init__(shape, **kwargs)
```

This is because the current SDP algorithm requires a square matrix  if `PSD` is true, but in the case of the BCS representation of the CHSH game, `num_output_alice = 4` and `num_inputs_alice = 2`.  More info can be found [here](https://github.com/vprusso/toqito/issues/44#issuecomment-843391727).

This feature fixes this by following what was done in [QETLAB](https://github.com/nathanieljohnston/QETLAB/blob/702e6230a62c2241452775ceb88e63630bfd679e/NonlocalGameLB.m) more closely and optimizing over the shared `d`-dimensional quantum state `tau`. We also allow the user to specify what `d` is in the arguments to `NonlocalGame.quantum_value_lower_bound`.

## Status
-  [ ] Ready to go (depends on the fix in #64 to be merged in first)