### PR TITLE
Feature/is_quantum_channel [unitaryHACK]

### DIFF
--- a/docs/channels.rst
+++ b/docs/channels.rst
@@ -66,3 +66,4 @@ Properties of Quantum Channels
     toqito.channel_props.is_trace_preserving
     toqito.channel_props.is_unital
     toqito.channel_props.choi_rank
+    toqito.channel_props.is_quantum_channel

--- a/tests/test_channel_props/test_is_quantum_channel.py
+++ b/tests/test_channel_props/test_is_quantum_channel.py
@@ -20,4 +20,3 @@ def test_is_completely_positive_choi_true():
 
 if __name__ == "__main__":
     np.testing.run_module_suite()
-

--- a/tests/test_channel_props/test_is_quantum_channel.py
+++ b/tests/test_channel_props/test_is_quantum_channel.py
@@ -1,0 +1,23 @@
+"""Tests for is_quantum_channel."""
+import numpy as np
+
+from toqito.channel_props import is_quantum_channel
+from toqito.channels import depolarizing
+
+
+def test_is_completely_positive_kraus_false():
+    """Verify non-completely positive channel as Kraus ops as False."""
+    unitary_mat = np.array([[1, 1], [-1, 1]]) / np.sqrt(2)
+    kraus_ops = [[np.identity(2), np.identity(2)], [unitary_mat, -unitary_mat]]
+
+    np.testing.assert_equal(is_quantum_channel(kraus_ops), False)
+
+
+def test_is_completely_positive_choi_true():
+    """Verify Choi matrix of the depolarizing map as a quantum channel."""
+    np.testing.assert_equal(is_quantum_channel(depolarizing(2)), True)
+
+
+if __name__ == "__main__":
+    np.testing.run_module_suite()
+

--- a/toqito/channel_props/__init__.py
+++ b/toqito/channel_props/__init__.py
@@ -5,3 +5,4 @@ from toqito.channel_props.is_positive import is_positive
 from toqito.channel_props.is_unital import is_unital
 from toqito.channel_props.choi_rank import choi_rank
 from toqito.channel_props.is_trace_preserving import is_trace_preserving
+from toqito.channel_props.is_quantum_channel import is_quantum_channel

--- a/toqito/channel_props/is_quantum_channel.py
+++ b/toqito/channel_props/is_quantum_channel.py
@@ -61,11 +61,11 @@ def is_quantum_channel(
             0 & 0 & 0 & 1
         \end{pmatrix}.
 
-    We may verify that this channel is a quantum channel
+    We may verify that this channel is a quantum channel,
 
     >>> from toqito.channels import depolarizing
     >>> from toqito.channel_props import is_quantum_channel
-    >>> is_completely_positive(depolarizing(2))
+    >>> is_quantum_channel(depolarizing(2))
     True
 
     References
@@ -77,7 +77,7 @@ def is_quantum_channel(
     :param phi: The channel provided as either a Choi matrix or a list of Kraus operators.
     :param rtol: The relative tolerance parameter (default 1e-05).
     :param atol: The absolute tolerance parameter (default 1e-08).
-    :return: True if the channel is a quantum channel, and False otherwise.
+    :return: :code:`True` if the channel is a quantum channel, and :code:`False` otherwise.
     """
     # If the variable `phi` is provided as a list, we assume this is a list
     # of Kraus operators.
@@ -85,5 +85,5 @@ def is_quantum_channel(
         phi = kraus_to_choi(phi)
 
     # A valid quantum channel is a superoperator that is both completely
-    # positive and trace-preserving
+    # positive and trace-preserving.
     return is_completely_positive(phi, rtol, atol) and is_trace_preserving(phi, rtol, atol)

--- a/toqito/channel_props/is_quantum_channel.py
+++ b/toqito/channel_props/is_quantum_channel.py
@@ -1,4 +1,4 @@
-"""Is quantum channel"""
+"""Is quantum channel."""
 from typing import List, Union
 
 import numpy as np
@@ -15,6 +15,7 @@ def is_quantum_channel(
 ) -> bool:
     r"""
     Determine whether the given input is a quantum channel [WatQC18]_.
+    
     A map :math:`\Phi \in \text{T} \left(\mathcal{X}, \mathcal{Y} \right)` is a *quantum
     channel* for some choice of complex Euclidean spaces :math:`\mathcal{X}`
     and :math:`\mathcal{Y}`, if it holds that:

--- a/toqito/channel_props/is_quantum_channel.py
+++ b/toqito/channel_props/is_quantum_channel.py
@@ -1,0 +1,88 @@
+"""Is quantum channel"""
+from typing import List, Union
+
+import numpy as np
+
+from toqito.channel_ops import kraus_to_choi
+from toqito.channel_props import is_completely_positive
+from toqito.channel_props import is_trace_preserving
+
+
+def is_quantum_channel(
+    phi: Union[np.ndarray, List[List[np.ndarray]]],
+    rtol: float = 1e-05,
+    atol: float = 1e-08,
+) -> bool:
+    r"""
+    Determine whether the given input is a quantum channel [WatQC18]_.
+    A map :math:`\Phi \in \text{T} \left(\mathcal{X}, \mathcal{Y} \right)` is a *quantum
+    channel* for some choice of complex Euclidean spaces :math:`\mathcal{X}`
+    and :math:`\mathcal{Y}`, if it holds that:
+
+    1. :math:`\Phi` is completely positive.
+    2. :math:`\Phi` is trace preserving.
+
+    Examples
+    ==========
+    We can specify the input as a list of Kraus operators. Consider the map :math:`\Phi` defined as
+
+    .. math::
+        \Phi(X) = X - U X U^*
+
+    where
+
+    .. math::
+        U = \frac{1}{\sqrt{2}}
+        \begin{pmatrix}
+            1 & 1 \\
+            -1 & 1
+        \end{pmatrix}.
+
+    This map is not a quantum channel, as we can verify as follows.
+
+    >>> from toqito.channel_props import is_quantum_channel
+    >>> import numpy as np
+    >>> unitary_mat = np.array([[1, 1], [-1, 1]]) / np.sqrt(2)
+    >>> kraus_ops = [[np.identity(2), np.identity(2)], [unitary_mat, -unitary_mat]]
+    >>> is_quantum_channel(kraus_ops)
+    False
+
+    We can also specify the input as a Choi matrix. For instance, consider the Choi matrix
+    corresponding to the :math:`2`-dimensional completely depolarizing channel
+
+    .. math::
+        \Omega =
+        \frac{1}{2}
+        \begin{pmatrix}
+            1 & 0 & 0 & 0 \\
+            0 & 1 & 0 & 0 \\
+            0 & 0 & 1 & 0 \\
+            0 & 0 & 0 & 1
+        \end{pmatrix}.
+
+    We may verify that this channel is a quantum channel
+
+    >>> from toqito.channels import depolarizing
+    >>> from toqito.channel_props import is_quantum_channel
+    >>> is_completely_positive(depolarizing(2))
+    True
+
+    References
+    ==========
+    .. [WatQC18] Watrous, John.
+        "The Theory of Quantum Information."
+        Section: "2.2.1  Definitions and basic notions concerning channels".
+        Cambridge University Press, 2018.
+    :param phi: The channel provided as either a Choi matrix or a list of Kraus operators.
+    :param rtol: The relative tolerance parameter (default 1e-05).
+    :param atol: The absolute tolerance parameter (default 1e-08).
+    :return: True if the channel is a quantum channel, and False otherwise.
+    """
+    # If the variable `phi` is provided as a list, we assume this is a list
+    # of Kraus operators.
+    if isinstance(phi, list):
+        phi = kraus_to_choi(phi)
+
+    # A valid quantum channel is a superoperator that is both completely
+    # positive and trace-preserving
+    return is_completely_positive(phi, rtol, atol) and is_trace_preserving(phi, rtol, atol)

--- a/toqito/channel_props/is_quantum_channel.py
+++ b/toqito/channel_props/is_quantum_channel.py
@@ -15,7 +15,7 @@ def is_quantum_channel(
 ) -> bool:
     r"""
     Determine whether the given input is a quantum channel [WatQC18]_.
-    
+
     A map :math:`\Phi \in \text{T} \left(\mathcal{X}, \mathcal{Y} \right)` is a *quantum
     channel* for some choice of complex Euclidean spaces :math:`\mathcal{X}`
     and :math:`\mathcal{Y}`, if it holds that:


### PR DESCRIPTION
## Description
A function that determines if a given superoperator is a quantum channel. A valid quantum channel is a superoperator that is both trace-preserving and completely positive.

## Todos
  -  [x] Added the tests for the function in `tests/test_channel_props/test_is_quantum_channel.py`
  -  [x] Added `from toqito.channel_props.is_quantum_channel import is_quantum_channel` to ` toqito/channel_props/__init__.py`
  -  [x] Added the function to the docs

## Questions

## Status
-  [x] Ready to go