### PR TITLE
Adding matsumoto_fidelity feature

### DIFF
--- a/docs/states.rst
+++ b/docs/states.rst
@@ -1,3 +1,4 @@
+
 States
 =====================
 
@@ -24,6 +25,7 @@ Distance Metrics for Quantum States
     toqito.state_metrics.trace_distance
     toqito.state_metrics.trace_norm
     toqito.state_metrics.bures_distance
+    toqito.state_metrics.matsumoto_fidelity
 
 Optimizations over Quantum States
 -----------------------------------------------

--- a/tests/test_state_metrics/test_matsumoto_fidelity.py
+++ b/tests/test_state_metrics/test_matsumoto_fidelity.py
@@ -1,4 +1,4 @@
-"""Tests for fidelity."""
+"""Tests for matsumoto_fidelity."""
 import cvxpy
 import numpy as np
 

--- a/tests/test_state_metrics/test_matsumoto_fidelity.py
+++ b/tests/test_state_metrics/test_matsumoto_fidelity.py
@@ -1,0 +1,61 @@
+"""Tests for fidelity."""
+import cvxpy
+import numpy as np
+
+
+from toqito.state_metrics import matsumoto_fidelity
+from toqito.states import basis
+
+
+def test_matsumoto_fidelity_default():
+    """Test Matsumoto fidelity default arguments."""
+    rho = np.array([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])
+    sigma = rho
+
+    res = matsumoto_fidelity(rho, sigma)
+    np.testing.assert_equal(np.isclose(res, 1), True)
+
+
+def test_matsumoto_fidelity_cvx():
+    """Test Matsumoto fidelity for cvx objects."""
+    rho = cvxpy.bmat([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])
+    sigma = rho
+
+    res = matsumoto_fidelity(rho, sigma)
+    np.testing.assert_equal(np.isclose(res, 1), True)
+
+
+def test_matsumoto_fidelity_non_identical_states_1():
+    """Test the Matsumoto fidelity between two non-identical states."""
+    e_0, e_1 = basis(2, 0), basis(2, 1)
+    rho = 3 / 4 * e_0 * e_0.conj().T + 1 / 4 * e_1 * e_1.conj().T
+    sigma = 2 / 3 * e_0 * e_0.conj().T + 1 / 3 * e_1 * e_1.conj().T
+    np.testing.assert_equal(np.isclose(matsumoto_fidelity(rho, sigma), 0.996, rtol=1e-03), True)
+
+
+def test_matsumoto_fidelity_non_identical_states_2():
+    """Test the Matsumoto fidelity between two non-identical states."""
+    e_0, e_1 = basis(2, 0), basis(2, 1)
+    rho = 3 / 4 * e_0 * e_0.conj().T + 1 / 4 * e_1 * e_1.conj().T
+    sigma = 1 / 8 * e_0 * e_0.conj().T + 7 / 8 * e_1 * e_1.conj().T
+    np.testing.assert_equal(np.isclose(matsumoto_fidelity(rho, sigma), 0.774, rtol=1e-03), True)
+
+
+def test_matsumoto_fidelity_non_square():
+    """Tests for invalid dim."""
+    rho = np.array([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])
+    sigma = np.array([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])
+    with np.testing.assert_raises(ValueError):
+        matsumoto_fidelity(rho, sigma)
+
+
+def test_matsumoto_fidelity_invalid_dim():
+    """Tests for invalid dim."""
+    rho = np.array([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])
+    sigma = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    with np.testing.assert_raises(ValueError):
+        matsumoto_fidelity(rho, sigma)
+
+
+if __name__ == "__main__":
+    np.testing.run_module_suite()

--- a/toqito/state_metrics/__init__.py
+++ b/toqito/state_metrics/__init__.py
@@ -6,3 +6,4 @@ from toqito.state_metrics.fidelity import fidelity
 from toqito.state_metrics.sub_fidelity import sub_fidelity
 from toqito.state_metrics.trace_distance import trace_distance
 from toqito.state_metrics.bures_distance import bures_distance
+from toqito.state_metrics.matsumoto_fidelity import matsumoto_fidelity

--- a/toqito/state_metrics/matsumoto_fidelity.py
+++ b/toqito/state_metrics/matsumoto_fidelity.py
@@ -18,7 +18,7 @@ def matsumoto_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
     if isinstance(rho, cvxpy.atoms.affine.vstack.Vstack) or isinstance(
         sigma, cvxpy.atoms.affine.vstack.Vstack
     ):
-        w_var = cvxpy.Variable(rho.shape, complex=True, Hermitian=True)
+        w_var = cvxpy.Variable(rho.shape, hermitian=True)
         objective = cvxpy.Maximize(cvxpy.real(cvxpy.trace(w_var)))
         constraints = [cvxpy.bmat([[rho, w_var], [w_var, sigma]]) >> 0]
         problem = cvxpy.Problem(objective, constraints)

--- a/toqito/state_metrics/matsumoto_fidelity.py
+++ b/toqito/state_metrics/matsumoto_fidelity.py
@@ -1,0 +1,45 @@
+"""Matsumoto fidelity metric."""
+import cvxpy
+import scipy
+import numpy as np
+
+from toqito.matrix_props import is_density
+
+
+def matsumoto_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
+    r"""TODO: docstring"""
+
+    if not np.all(rho.shape == sigma.shape):
+        raise ValueError("InvalidDim: `rho` and `sigma` must be matrices of the same size.")
+
+    # If `rho` or `sigma` is a cvxpy variable then compute fidelity via
+    # semidefinite programming, so that this function can be used in the
+    # objective function or constraints of other cvxpy optimization problems.
+    if isinstance(rho, cvxpy.atoms.affine.vstack.Vstack) or isinstance(
+        sigma, cvxpy.atoms.affine.vstack.Vstack
+    ):
+        w_var = cvxpy.Variable(rho.shape, complex=True, Hermitian=True)
+        objective = cvxpy.Maximize(cvxpy.real(cvxpy.trace(w_var)))
+        constraints = [cvxpy.bmat([[rho, w_var], [w_var, sigma]]) >> 0]
+        problem = cvxpy.Problem(objective, constraints)
+
+        return problem.solve()
+
+    if not is_density(rho) or not is_density(sigma):
+        raise ValueError("Fidelity is only defined for density operators.")
+
+    # If `rho` or `sigma` are *not* cvxpy variables, compute Matsumoto fidelity directly.
+    # For numerical stability, invert the matrix with larger determinant
+    if np.abs(scipy.linalg.det(sigma)) > np.abs(scipy.linalg.det(rho)):
+        rho, sigma = sigma, rho
+
+    # If rho is singular, add epsilon
+    try:
+        sq_rho = scipy.linalg.sqrtm(rho)
+        sqinv_rho = scipy.linalg.inv(sq_rho)
+    except np.linalg.LinAlgError:
+        sq_rho = scipy.linalg.sqrtm(rho+1e-8) # if rho is not invertible, add epsilon=1e-8 to it
+        sqinv_rho = scipy.linalg.inv(sq_rho)
+
+    sq_mfid = sq_rho @ scipy.linalg.sqrtm(sqinv_rho @ sigma @ sqinv_rho) @ sq_rho
+    return np.real(np.trace(sq_mfid))

--- a/toqito/state_metrics/matsumoto_fidelity.py
+++ b/toqito/state_metrics/matsumoto_fidelity.py
@@ -7,12 +7,75 @@ from toqito.matrix_props import is_density
 
 
 def matsumoto_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
-    r"""TODO: docstring"""
+    r"""
+    Compute the Matsumoto fidelity of two density matrices [Mat10]_.
+
+    Calculate the Matsumoto fidelity between the two density matrices :code:`rho` and :code:`sigma`, defined
+    by:
+
+    .. math::
+        \mathrm{tr}(\rho\#\sigma),
+
+    where :math:`\#` denotes the matrix geometric mean, which for invertible states is
+
+    .. math::
+        \rho\#\sigma = \rho^{1/2}\sqrt{\rho^{-1/2}\sigma\rho^{-1/2}}\rho^{1/2}.
+
+    For singular states it is defined by the limit
+
+    .. math::
+        \rho\#\sigma = \lim_{\eps\to0}(\rho+\eps\mathbb{I})\#(+\eps\mathbb{I}).
+
+    The return is a value between :math:`0` and :math:`1`, with :math:`0` corresponding to matrices :code:`rho` and :code:`sigma` with
+    orthogonal support, and :math:`1` corresponding to the case :code:`rho = sigma`. The Matsumoto fidelity is a lower bound for the fidelity.
+
+    Examples
+    ==========
+
+    Consider the following Bell state
+
+    .. math::
+        u = \frac{1}{\sqrt{2}} \left( |00 \rangle + |11 \rangle \right) \in \mathcal{X}.
+
+    The corresponding density matrix of :math:`u` may be calculated by:
+
+    .. math::
+        \rho = u u^* = \frac{1}{2} \begin{pmatrix}
+                         1 & 0 & 0 & 1 \\
+                         0 & 0 & 0 & 0 \\
+                         0 & 0 & 0 & 0 \\
+                         1 & 0 & 0 & 1
+                       \end{pmatrix} \in \text{D}(\mathcal{X}).
+
+    In the event where we calculate the Matsumoto fidelity between states that are identical, we should obtain
+    the value of :math:`1`. This can be observed in :code:`toqito` as follows.
+
+    >>> from toqito.state_metrics import matsumoto_fidelity
+    >>> import numpy as np
+    >>> rho = 1 / 2 * np.array(
+    >>>     [[1, 0, 0, 1],
+    >>>      [0, 0, 0, 0],
+    >>>      [0, 0, 0, 0],
+    >>>      [1, 0, 0, 1]]
+    >>> )
+    >>> sigma = rho
+    >>> matsumoto_fidelity(rho, sigma)
+    0.9999998585981018
+
+    References
+    ==========
+    .. [Mat10] Keiji Matsumoto. "Reverse test and quantum analogue of classical fidelity and generalized fidelity"
+        https://arxiv.org/abs/1006.0302
+    
+    :param rho: Density operator.
+    :param sigma: Density operator.
+    :return: The Matsumoto fidelity between :code:`rho` and :code:`sigma`.
+    """
 
     if not np.all(rho.shape == sigma.shape):
         raise ValueError("InvalidDim: `rho` and `sigma` must be matrices of the same size.")
 
-    # If `rho` or `sigma` is a cvxpy variable then compute fidelity via
+    # If `rho` or `sigma` is a cvxpy variable then compute Matsumoto fidelity via
     # semidefinite programming, so that this function can be used in the
     # objective function or constraints of other cvxpy optimization problems.
     if isinstance(rho, cvxpy.atoms.affine.vstack.Vstack) or isinstance(
@@ -26,7 +89,7 @@ def matsumoto_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
         return problem.solve()
 
     if not is_density(rho) or not is_density(sigma):
-        raise ValueError("Fidelity is only defined for density operators.")
+        raise ValueError("Matsumoto fidelity is only defined for density operators.")
 
     # If `rho` or `sigma` are *not* cvxpy variables, compute Matsumoto fidelity directly.
     # For numerical stability, invert the matrix with larger determinant

--- a/toqito/state_metrics/matsumoto_fidelity.py
+++ b/toqito/state_metrics/matsumoto_fidelity.py
@@ -10,8 +10,8 @@ def matsumoto_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
     r"""
     Compute the Matsumoto fidelity of two density matrices [Mat10]_.
 
-    Calculate the Matsumoto fidelity between the two density matrices :code:`rho` and :code:`sigma`, defined
-    by:
+    Calculate the Matsumoto fidelity between the two density matrices :code:`rho`
+    and :code:`sigma`, defined by:
 
     .. math::
         \mathrm{tr}(\rho\#\sigma),
@@ -26,8 +26,9 @@ def matsumoto_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
     .. math::
         \rho\#\sigma = \lim_{\eps\to0}(\rho+\eps\mathbb{I})\#(+\eps\mathbb{I}).
 
-    The return is a value between :math:`0` and :math:`1`, with :math:`0` corresponding to matrices :code:`rho` and :code:`sigma` with
-    orthogonal support, and :math:`1` corresponding to the case :code:`rho = sigma`. The Matsumoto fidelity is a lower bound for the fidelity.
+    The return is a value between :math:`0` and :math:`1`, with :math:`0` corresponding to matrices
+    :code:`rho` and :code:`sigma` with orthogonal support, and :math:`1` corresponding to the case
+    :code:`rho = sigma`. The Matsumoto fidelity is a lower bound for the fidelity.
 
     Examples
     ==========
@@ -47,8 +48,8 @@ def matsumoto_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
                          1 & 0 & 0 & 1
                        \end{pmatrix} \in \text{D}(\mathcal{X}).
 
-    In the event where we calculate the Matsumoto fidelity between states that are identical, we should obtain
-    the value of :math:`1`. This can be observed in :code:`toqito` as follows.
+    In the event where we calculate the Matsumoto fidelity between states that are identical,
+    we should obtain the value of :math:`1`. This can be observed in :code:`toqito` as follows.
 
     >>> from toqito.state_metrics import matsumoto_fidelity
     >>> import numpy as np
@@ -64,7 +65,8 @@ def matsumoto_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
 
     References
     ==========
-    .. [Mat10] Keiji Matsumoto. "Reverse test and quantum analogue of classical fidelity and generalized fidelity"
+    .. [Mat10] Keiji Matsumoto.
+    "Reverse test and quantum analogue of classical fidelity and generalized fidelity"
         https://arxiv.org/abs/1006.0302
     
     :param rho: Density operator.

--- a/toqito/state_metrics/matsumoto_fidelity.py
+++ b/toqito/state_metrics/matsumoto_fidelity.py
@@ -73,7 +73,6 @@ def matsumoto_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
     :param sigma: Density operator.
     :return: The Matsumoto fidelity between :code:`rho` and :code:`sigma`.
     """
-
     if not np.all(rho.shape == sigma.shape):
         raise ValueError("InvalidDim: `rho` and `sigma` must be matrices of the same size.")
 

--- a/toqito/state_metrics/matsumoto_fidelity.py
+++ b/toqito/state_metrics/matsumoto_fidelity.py
@@ -68,7 +68,7 @@ def matsumoto_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
     .. [Mat10] Keiji Matsumoto.
     "Reverse test and quantum analogue of classical fidelity and generalized fidelity"
         https://arxiv.org/abs/1006.0302
-    
+
     :param rho: Density operator.
     :param sigma: Density operator.
     :return: The Matsumoto fidelity between :code:`rho` and :code:`sigma`.

--- a/toqito/state_metrics/matsumoto_fidelity.py
+++ b/toqito/state_metrics/matsumoto_fidelity.py
@@ -66,7 +66,7 @@ def matsumoto_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
     References
     ==========
     .. [Mat10] Keiji Matsumoto.
-    "Reverse test and quantum analogue of classical fidelity and generalized fidelity"
+        "Reverse test and quantum analogue of classical fidelity and generalized fidelity"
         https://arxiv.org/abs/1006.0302
 
     :param rho: Density operator.


### PR DESCRIPTION
## Description
This implements `matsumoto_fidelity` as described in #28, including documentation and tests.

The implementation is similar to that of `fidelity`, the main difference being that the direct calculation requires at least one of the density matrices to be invertible.
To work around this I adapted the QETLAB implementation: try to invert the matrix with largest determinant; if an error is raised, add a small number `eps` to it. Initially I tried to use machine epsilon, but it created stability problems with the square root. After some trial and error, I found `1e-8` to be a reasonable value (this is also what QETLAB uses).
This works because for singular matrices the limit of zero `eps` is the correct definition of the Matsumoto fidelity (eq. 1.6 in https://arxiv.org/abs/2006.06918). The QETLAB documentation states that the result is accurate to `1e-4`, which is consistent with what I see.

A possible improvement could be to check whether the matrices are singular (perhaps with `toqito.matrix_props.is_positive_definite`) and use the `cvxpy` solution if they are. This could be given as an option, to avoid introducing a `cvxpy` dependence.

Regarding the tests, I reproduced those of `fidelity`. One thing to note is that they are all for either equal states, or classical mixtures. In particular, `matsumoto_fidelity` and `fidelity` have the same behaviour for all the tests.

## Questions
-  [ ] Should we use `cvxpy` if both matrices are singular?
-  [x] Should we add more tests?