### PR TITLE
Feature/is_unitary

### DIFF
--- a/docs/channels.rst
+++ b/docs/channels.rst
@@ -67,3 +67,4 @@ Properties of Quantum Channels
     toqito.channel_props.is_unital
     toqito.channel_props.choi_rank
     toqito.channel_props.is_quantum_channel
+    toqito.channel_props.is_unitary

--- a/tests/test_channel_props/test_is_unitary.py
+++ b/tests/test_channel_props/test_is_unitary.py
@@ -19,4 +19,3 @@ def test_is_completely_positive_choi_true():
 
 if __name__ == "__main__":
     np.testing.run_module_suite()
-

--- a/tests/test_channel_props/test_is_unitary.py
+++ b/tests/test_channel_props/test_is_unitary.py
@@ -19,4 +19,4 @@ def test_is_completely_positive_choi_true():
 
 if __name__ == "__main__":
     np.testing.run_module_suite()
-    
+

--- a/tests/test_channel_props/test_is_unitary.py
+++ b/tests/test_channel_props/test_is_unitary.py
@@ -1,0 +1,22 @@
+"""Tests for is_unitary."""
+import numpy as np
+
+from toqito.channel_props import is_unitary
+from toqito.channels import depolarizing
+
+
+def test_is_completely_positive_kraus_false():
+    """Verify that the identity channel is a unitary channel."""
+    kraus_ops = [[np.identity(2), np.identity(2)]]
+
+    np.testing.assert_equal(is_unitary(kraus_ops), True)
+
+
+def test_is_completely_positive_choi_true():
+    """Verify that the Choi matrix of the depolarizing map is not a unitary channel."""
+    np.testing.assert_equal(is_unitary(depolarizing(2)), False)
+
+
+if __name__ == "__main__":
+    np.testing.run_module_suite()
+    

--- a/toqito/channel_props/__init__.py
+++ b/toqito/channel_props/__init__.py
@@ -6,3 +6,4 @@ from toqito.channel_props.is_unital import is_unital
 from toqito.channel_props.choi_rank import choi_rank
 from toqito.channel_props.is_trace_preserving import is_trace_preserving
 from toqito.channel_props.is_quantum_channel import is_quantum_channel
+from toqito.channel_props.is_unitary import is_unitary

--- a/toqito/channel_props/is_unitary.py
+++ b/toqito/channel_props/is_unitary.py
@@ -1,0 +1,76 @@
+"""Is channel unitary."""
+from typing import List, Union
+
+import numpy as np
+
+from toqito.channel_ops import choi_to_kraus
+
+def is_unitary(
+    phi: Union[np.ndarray, List[List[np.ndarray]]]
+) -> bool:
+    r"""
+    Given a quantum channel, determine if it is unitary [WatUC18]_.
+
+    Let :math:`\mathcal{X}` be a complex Euclidean space an let :math:`U \in U(\mathcal{X})` be a
+    unitary operator. Then a unitary channel, is defined as:
+
+    .. math::
+        \Phi(X) = U X U^*
+
+    Examples
+    ==========
+    The identity channel is one example of a unitray channel:
+
+    .. math::
+        U =
+        \begin{pmatrix}
+            1 & 0 \\
+            0 & 1
+        \end{pmatrix}.
+
+    We can verify this as follows:
+
+    >>> from toqito.channel_props import is_unitary
+    >>> import numpy as np
+    >>> kraus_ops = [[np.identity(2), np.identity(2)]]
+    >>> is_unitary(kraus_ops)
+    True
+
+    We can also specify the input as a Choi matrix. For instance, consider the Choi matrix
+    corresponding to the :math:`2`-dimensional completely depolarizing channel.
+
+    .. math::
+        \Omega =
+        \frac{1}{2}
+        \begin{pmatrix}
+            1 & 0 & 0 & 0 \\
+            0 & 1 & 0 & 0 \\
+            0 & 0 & 1 & 0 \\
+            0 & 0 & 0 & 1
+        \end{pmatrix}.
+
+    We may verify that this channel is not a unitary channel.
+
+    >>> from toqito.channels import depolarizing
+    >>> from toqito.channel_props import is_unitary
+    >>> is_unitary(depolarizing(2))
+    False
+
+    References
+    ==========
+    .. [WatUC18] Watrous, John.
+        "The Theory of Quantum Information."
+        Section: "2.2.1  Definitions and basic notions concerning channels".
+        Cambridge University Press, 2018.
+
+    :param phi: The channel provided as either a Choi matrix or a list of Kraus operators.
+    :return: :code:`True` if the channel is a unitary channel, and :code:`False` otherwise.
+    """
+    # If the variable `phi` is provided as a ndarray, we assume this is a
+    # choi operator.
+    if isinstance(phi, np.ndarray):
+        phi = choi_to_kraus(phi)
+
+    # If the length of the list of krauss operarator is equal to one, the channel is unitary.
+    return len(phi)==1
+

--- a/toqito/channel_props/is_unitary.py
+++ b/toqito/channel_props/is_unitary.py
@@ -9,13 +9,13 @@ def is_unitary(
     phi: Union[np.ndarray, List[List[np.ndarray]]]
 ) -> bool:
     r"""
-    Given a quantum channel, determine if it is unitary [WatUC18]_.
+    Given a quantum channel, determine if it is unitary [WatIU18]_.
 
     Let :math:`\mathcal{X}` be a complex Euclidean space an let :math:`U \in U(\mathcal{X})` be a
     unitary operator. Then a unitary channel is defined as:
 
     .. math::
-        \Phi(X) = U X U^*
+        \Phi(X) = U X U^*.
 
     Examples
     ==========
@@ -58,7 +58,7 @@ def is_unitary(
 
     References
     ==========
-    .. [WatUC18] Watrous, John.
+    .. [WatIU18] Watrous, John.
         "The Theory of Quantum Information."
         Section: "2.2.1  Definitions and basic notions concerning channels".
         Cambridge University Press, 2018.
@@ -67,9 +67,9 @@ def is_unitary(
     :return: :code:`True` if the channel is a unitary channel, and :code:`False` otherwise.
     """
     # If the variable `phi` is provided as a ndarray, we assume this is a
-    # choi operator.
+    # Choi matrix.
     if isinstance(phi, np.ndarray):
         phi = choi_to_kraus(phi)
 
     # If the length of the list of krauss operarator is equal to one, the channel is unitary.
-    return len(phi)==1
+    return len(phi) == 1

--- a/toqito/channel_props/is_unitary.py
+++ b/toqito/channel_props/is_unitary.py
@@ -73,4 +73,3 @@ def is_unitary(
 
     # If the length of the list of krauss operarator is equal to one, the channel is unitary.
     return len(phi)==1
-

--- a/toqito/channel_props/is_unitary.py
+++ b/toqito/channel_props/is_unitary.py
@@ -12,14 +12,14 @@ def is_unitary(
     Given a quantum channel, determine if it is unitary [WatUC18]_.
 
     Let :math:`\mathcal{X}` be a complex Euclidean space an let :math:`U \in U(\mathcal{X})` be a
-    unitary operator. Then a unitary channel, is defined as:
+    unitary operator. Then a unitary channel is defined as:
 
     .. math::
         \Phi(X) = U X U^*
 
     Examples
     ==========
-    The identity channel is one example of a unitray channel:
+    The identity channel is one example of a unitary channel:
 
     .. math::
         U =


### PR DESCRIPTION
## Description
A function that determines if a quantum channel is unitary

## Todos
  -  [x] Added the tests for the function in `tests/test_channel_props/test_is_unitary.py`
  -  [x] Added `from toqito.channel_props.is_unitary import is_unitary` to `toqito/channel_props/__init__.py`
  -  [x] Added the function to the docs

## Questions

## Status
-  [x] Ready to go