### PR TITLE
Adding `dual_channel` feature

### DIFF
--- a/docs/channels.rst
+++ b/docs/channels.rst
@@ -51,6 +51,7 @@ Operations on Quantum Channels
     toqito.channel_ops.choi_to_kraus
     toqito.channel_ops.kraus_to_choi
     toqito.channel_ops.partial_channel
+    toqito.channel_ops.dual_channel
 
 Properties of Quantum Channels
 ------------------------------

--- a/tests/test_channel_ops/test_dual_channel.py
+++ b/tests/test_channel_ops/test_dual_channel.py
@@ -95,7 +95,7 @@ def test_dual_channel_unspecified_dims():
 def test_dual_channel_invalid_input():
     """Invalid input"""
     with np.testing.assert_raises(ValueError):
-        dual_channel(0)
+        dual_channel([0])
 
 
 if __name__ == "__main__":

--- a/tests/test_channel_ops/test_dual_channel.py
+++ b/tests/test_channel_ops/test_dual_channel.py
@@ -1,0 +1,86 @@
+"""Tests for dual_channel"""
+import numpy as np
+
+from toqito.channel_ops import dual_channel
+from toqito.channels import choi
+
+
+def test_dual_channel_kraus():
+    """Test dual_channel on a channel represented as Kraus operators."""
+    kraus_1 = np.array([[1, 0, 1j, 0]])
+    kraus_2 = np.array([[0, 1, 0, 1j]])
+
+    expected_res = [
+    [np.array([[1, 0, -1j, 0]]).T, np.array([[1, 0, -1j, 0]]).T],
+    [np.array([[0, 1, 0, -1j]]).T, np.array([[0, 1, 0, -1j]]).T]
+    ]
+
+    res = dual_channel([[kraus_1, kraus_1], [kraus_2, kraus_2]])
+
+    bool_mat = np.isclose(res, expected_res)
+    np.testing.assert_equal(np.all(bool_mat), True)
+
+
+def test_dual_channel_choi_square():
+    """Test dual_channel on a 9x9 Choi matrix, inferring dims=[3,3]."""
+    res = dual_channel(choi(1, 1, 0))
+
+    bool_mat = np.isclose(res, choi(1, 0, 1))
+    np.testing.assert_equal(np.all(bool_mat), True)
+
+def test_dual_channel_choi_dims():
+    """Test dual_channel on a Choi matrix with differnt inpunt and output dimensions."""
+    j = np.array(
+        [
+            [1, -1j, 0, 0, 0, 1],
+            [1j, -1, 0, 0, 0, -1j],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [1, 1j, 0, 0, 0, 1]
+        ]
+    )
+
+    expected_res = np.array(
+        [
+            [1, 0, 0, 1j, 0, 1],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [-1j, 0, 0, -1, 0, 1j],
+            [0, 0, 0, 0, 0, 0],
+            [1, 0, 0, -1j, 0, 1]
+        ]
+    )
+
+    res = dual_channel(j, [3,2])
+
+    bool_mat = np.isclose(res, expected_res)
+    np.testing.assert_equal(np.all(bool_mat), True)
+
+def test_dual_channel_nonsquare_matrix():
+    """If the channel is represented as a Choi matrix, it must be square."""
+    with np.testing.assert_raises(ValueError):
+        j = np.array([[1, 2, 3, 4], [4, 3, 2, 1]])
+        dual_channel(j)
+
+def test_dual_channel_not_matrix():
+    """If the channel is represented as an array, it must be two-dimensional (a matrix)."""
+    with np.testing.assert_raises(ValueError):
+        j = np.array([1, 2, 3, 4])
+        dual_channel(j)
+
+def test_dual_channel_unspecified_dims():
+    """If the size of the Choi matrix is not a perfect square,
+    the dimensions of the input and output spaces must be specified."""
+    with np.testing.assert_raises(ValueError):
+        j = np.arange(36).reshape(6,6)
+        dual_channel(j)
+
+def test_dual_channel_invalid_input():
+    """Invalid input"""
+    with np.testing.assert_raises(ValueError):
+        dual_channel(0)
+
+
+if __name__ == "__main__":
+    np.testing.run_module_suite()

--- a/tests/test_channel_ops/test_dual_channel.py
+++ b/tests/test_channel_ops/test_dual_channel.py
@@ -4,9 +4,25 @@ import numpy as np
 from toqito.channel_ops import dual_channel
 from toqito.channels import choi
 
+def test_dual_channel_kraus1():
+    """Test dual_channel on a channel represented as Kraus operators (1d list, CP map)."""
+    kraus_1 = np.array([[1, 0, 1j, 0]])
+    kraus_2 = np.array([[0, 1, 0, 1j]])
 
-def test_dual_channel_kraus():
-    """Test dual_channel on a channel represented as Kraus operators."""
+    expected_res = [
+    np.array([[1, 0, -1j, 0]]).T,
+    np.array([[0, 1, 0, -1j]]).T
+    ]
+
+    res = dual_channel([kraus_1, kraus_2])
+
+    bool_mat = np.isclose(res, expected_res)
+    np.testing.assert_equal(np.all(bool_mat), True)
+
+
+
+def test_dual_channel_kraus2():
+    """Test dual_channel on a channel represented as Kraus operators (2d list)."""
     kraus_1 = np.array([[1, 0, 1j, 0]])
     kraus_2 = np.array([[0, 1, 0, 1j]])
 
@@ -52,7 +68,7 @@ def test_dual_channel_choi_dims():
         ]
     )
 
-    res = dual_channel(j, [3,2])
+    res = dual_channel(j, [3, 2])
 
     bool_mat = np.isclose(res, expected_res)
     np.testing.assert_equal(np.all(bool_mat), True)
@@ -73,7 +89,7 @@ def test_dual_channel_unspecified_dims():
     """If the size of the Choi matrix is not a perfect square,
     the dimensions of the input and output spaces must be specified."""
     with np.testing.assert_raises(ValueError):
-        j = np.arange(36).reshape(6,6)
+        j = np.arange(36).reshape(6, 6)
         dual_channel(j)
 
 def test_dual_channel_invalid_input():

--- a/tests/test_channel_ops/test_dual_channel.py
+++ b/tests/test_channel_ops/test_dual_channel.py
@@ -29,7 +29,7 @@ def test_dual_channel_choi_square():
     np.testing.assert_equal(np.all(bool_mat), True)
 
 def test_dual_channel_choi_dims():
-    """Test dual_channel on a Choi matrix with differnt inpunt and output dimensions."""
+    """Test dual_channel on a Choi matrix with different input and output dimensions."""
     j = np.array(
         [
             [1, -1j, 0, 0, 0, 1],

--- a/toqito/channel_ops/__init__.py
+++ b/toqito/channel_ops/__init__.py
@@ -3,3 +3,4 @@ from toqito.channel_ops.apply_channel import apply_channel
 from toqito.channel_ops.partial_channel import partial_channel
 from toqito.channel_ops.choi_to_kraus import choi_to_kraus
 from toqito.channel_ops.kraus_to_choi import kraus_to_choi
+from toqito.channel_ops.dual_channel import dual_channel

--- a/toqito/channel_ops/dual_channel.py
+++ b/toqito/channel_ops/dual_channel.py
@@ -1,0 +1,21 @@
+"""Compute the dual of a map"""
+from typing import List, Union
+import numpy as np
+
+def dual_channel(phi: Union[np.ndarray, List[List[np.ndarray]]]) -> Union[np.ndarray, List[List[np.ndarray]]]:
+	r"""
+	TODO: docstring
+	"""
+	# If phi is a list, assume it contains couples of Kraus operators, and take the Hermitian conjugate
+	if isinstance(phi, list):
+		return [[a.conj().T for a in x] for x in phi]
+
+
+    # If phi is a ndarray, assume it is a Choi matrix
+	if isnstance(phi, np.ndarray):
+        # swap
+		pass
+    raise ValueError(
+        "Invalid: The variable `phi_op` must either be a list of "
+        "Kraus operators or as a Choi matrix."
+    )

--- a/toqito/channel_ops/dual_channel.py
+++ b/toqito/channel_ops/dual_channel.py
@@ -2,19 +2,34 @@
 from typing import List, Union
 import numpy as np
 
-def dual_channel(phi: Union[np.ndarray, List[List[np.ndarray]]]) -> Union[np.ndarray, List[List[np.ndarray]]]:
-	r"""
-	TODO: docstring
-	"""
-	# If phi is a list, assume it contains couples of Kraus operators, and take the Hermitian conjugate
-	if isinstance(phi, list):
-		return [[a.conj().T for a in x] for x in phi]
+from toqito.matrix_props import is_square
+from toqito.perms import swap
 
+def dual_channel(
+    phi_op: Union[np.ndarray, List[List[np.ndarray]]],
+    dims: List[int] = None
+) -> Union[np.ndarray, List[List[np.ndarray]]]:
+    r"""
+    TODO: docstring
+    """
+    # If phi_op is a list, assume it contains couples of Kraus operators
+    # and take the Hermitian conjugate
+    if isinstance(phi_op, list):
+        return [[a.conj().T for a in x] for x in phi_op]
 
-    # If phi is a ndarray, assume it is a Choi matrix
-	if isnstance(phi, np.ndarray):
-        # swap
-		pass
+    # If phi_op is a ndarray, assume it is a Choi matrix
+    if isnstance(phi_op, np.ndarray):
+        if not(is_square(phi_op)):
+            raise ValueError("Invalid: `phi_op` is not a valid Choi matrix (not square).")
+        if dims is None:
+            sqr = np.sqrt(phi_op.shape[0])
+            if sqr.is_integer():
+                dims = [int(round(sqr))] * 2
+            else:
+                raise ValueError(
+                    "The dimensions `dims` of the input and output spaces should be specified."
+                    )
+        return swap(phi_op.conj(), dim=dims)
     raise ValueError(
         "Invalid: The variable `phi_op` must either be a list of "
         "Kraus operators or as a Choi matrix."

--- a/toqito/channel_ops/dual_channel.py
+++ b/toqito/channel_ops/dual_channel.py
@@ -6,11 +6,30 @@ from toqito.matrix_props import is_square
 from toqito.perms import swap
 
 def dual_channel(
-    phi_op: Union[np.ndarray, List[List[np.ndarray]]],
+    phi_op: Union[np.ndarray, List[np.ndarray], List[List[np.ndarray]]],
     dims: List[int] = None
 ) -> Union[np.ndarray, List[List[np.ndarray]]]:
     r"""
     Compute the dual of a map (quantum channel) [WatDChan18]_ .
+
+    The map can be represented as a Choi matrix, with optional specification of input
+    and output dimensions. In this case the Choi matrix of the dual channel is
+    returned, obtained by swapping input and output (see :func:`toqito.perms.swap`),
+    and complex conjugating all elements.
+
+    The map can also be represented as a list of Kraus operators.
+    A list of lists, each containing two elements, corresponds to the families
+    of operators :math:`\{(A_a, B_a)\}` representing the map
+
+    .. math::
+        \Phi(X) = \sum_a A_a X B^*_a.
+
+    The dual map is obtained by taking the Hermitian adjoint of each operator.
+    If :code:`phi_op` is given as a one-dimensional list, :math:`\{(A_a,B_a)\}`,
+    it is interpreted as the completely positive map
+
+    .. math::
+        \Phi(X) = \sum_a A_a X A^*_a.
 
     References
     ==========
@@ -20,8 +39,7 @@ def dual_channel(
         Cambridge University Press, 2018.
 
     :param phi_op: A superoperator. :code:`phi_op` should be provided either as a Choi matrix,
-                   or as a list of numpy arrays with 2 columns whose entries are its
-                   Kraus operators.
+                   or as a (1d or 2d) list of numpy arrays whose entries are its Kraus operators.
     :param dims: Dimension of the input and output systems, for Choi matrix representation.
                  If :code:`None`, try to infer them from :code:`phi_op.shape`.
     :return: The map dual to :chode:`phi_op`, in the same representation.

--- a/toqito/channel_ops/dual_channel.py
+++ b/toqito/channel_ops/dual_channel.py
@@ -18,7 +18,7 @@ def dual_channel(
         return [[a.conj().T for a in x] for x in phi_op]
 
     # If phi_op is a ndarray, assume it is a Choi matrix
-    if isnstance(phi_op, np.ndarray):
+    if isinstance(phi_op, np.ndarray):
         if not(is_square(phi_op)):
             raise ValueError("Invalid: `phi_op` is not a valid Choi matrix (not square).")
         if dims is None:

--- a/toqito/channel_ops/dual_channel.py
+++ b/toqito/channel_ops/dual_channel.py
@@ -19,17 +19,18 @@ def dual_channel(
 
     # If phi_op is a ndarray, assume it is a Choi matrix
     if isinstance(phi_op, np.ndarray):
-        if not(is_square(phi_op)):
-            raise ValueError("Invalid: `phi_op` is not a valid Choi matrix (not square).")
-        if dims is None:
-            sqr = np.sqrt(phi_op.shape[0])
-            if sqr.is_integer():
-                dims = [int(round(sqr))] * 2
-            else:
-                raise ValueError(
-                    "The dimensions `dims` of the input and output spaces should be specified."
-                    )
-        return swap(phi_op.conj(), dim=dims)
+        if len(phi_op.shape) == 2:
+            if not(is_square(phi_op)):
+                raise ValueError("Invalid: `phi_op` is not a valid Choi matrix (not square).")
+            if dims is None:
+                sqr = np.sqrt(phi_op.shape[0])
+                if sqr.is_integer():
+                    dims = [int(round(sqr))] * 2
+                else:
+                    raise ValueError(
+                        "The dimensions `dims` of the input and output should be specified."
+                        )
+            return swap(phi_op.conj(), dim=dims)
     raise ValueError(
         "Invalid: The variable `phi_op` must either be a list of "
         "Kraus operators or as a Choi matrix."

--- a/toqito/channel_ops/dual_channel.py
+++ b/toqito/channel_ops/dual_channel.py
@@ -25,7 +25,7 @@ def dual_channel(
         \Phi(X) = \sum_a A_a X B^*_a.
 
     The dual map is obtained by taking the Hermitian adjoint of each operator.
-    If :code:`phi_op` is given as a one-dimensional list, :math:`\{(A_a,B_a)\}`,
+    If :code:`phi_op` is given as a one-dimensional list, :math:`\{A_a\}`,
     it is interpreted as the completely positive map
 
     .. math::
@@ -38,11 +38,11 @@ def dual_channel(
         Section: Representations and characterizations of channels.
         Cambridge University Press, 2018.
 
-    :param phi_op: A superoperator. :code:`phi_op` should be provided either as a Choi matrix,
+    :param phi_op: A superoperator. It should be provided either as a Choi matrix,
                    or as a (1d or 2d) list of numpy arrays whose entries are its Kraus operators.
     :param dims: Dimension of the input and output systems, for Choi matrix representation.
                  If :code:`None`, try to infer them from :code:`phi_op.shape`.
-    :return: The map dual to :chode:`phi_op`, in the same representation.
+    :return: The map dual to :code:`phi_op`, in the same representation.
     """
     # If phi_op is a list, assume it contains couples of Kraus operators
     # and take the Hermitian conjugate

--- a/toqito/channel_ops/dual_channel.py
+++ b/toqito/channel_ops/dual_channel.py
@@ -29,12 +29,15 @@ def dual_channel(
     # If phi_op is a list, assume it contains couples of Kraus operators
     # and take the Hermitian conjugate
     if isinstance(phi_op, list):
-        return [[a.conj().T for a in x] for x in phi_op]
+        if isinstance(phi_op[0], list):
+            return [[a.conj().T for a in x] for x in phi_op]
+        if isinstance(phi_op[0], np.ndarray):
+            return [a.conj().T for a in phi_op]
 
     # If phi_op is a ndarray, assume it is a Choi matrix
     if isinstance(phi_op, np.ndarray):
         if len(phi_op.shape) == 2:
-            if not(is_square(phi_op)):
+            if not is_square(phi_op):
                 raise ValueError("Invalid: `phi_op` is not a valid Choi matrix (not square).")
             if dims is None:
                 sqr = np.sqrt(phi_op.shape[0])

--- a/toqito/channel_ops/dual_channel.py
+++ b/toqito/channel_ops/dual_channel.py
@@ -10,7 +10,21 @@ def dual_channel(
     dims: List[int] = None
 ) -> Union[np.ndarray, List[List[np.ndarray]]]:
     r"""
-    TODO: docstring
+    Compute the dual of a map (quantum channel) [WatDChan18]_ .
+
+    References
+    ==========
+    .. [WatDChan18] Watrous, John.
+        The theory of quantum information.
+        Section: Representations and characterizations of channels.
+        Cambridge University Press, 2018.
+
+    :param phi_op: A superoperator. :code:`phi_op` should be provided either as a Choi matrix,
+                   or as a list of numpy arrays with 2 columns whose entries are its
+                   Kraus operators.
+    :param dims: Dimension of the input and output systems, for Choi matrix representation.
+                 If :code:`None`, try to infer them from :code:`phi_op.shape`.
+    :return: The map dual to :chode:`phi_op`, in the same representation.
     """
     # If phi_op is a list, assume it contains couples of Kraus operators
     # and take the Hermitian conjugate


### PR DESCRIPTION
## Description
This implements `dual_channel` as described in #29 , including documentation and tests.

It accept both one-dimensional and two-dimensional lists for the Kraus representation (as in #79), and outputs the same format.

## Status
-  [x] Ready to go