### PR TITLE
Fixed issue in concurrence function

### DIFF
--- a/toqito/state_props/concurrence.py
+++ b/toqito/state_props/concurrence.py
@@ -13,8 +13,11 @@ def concurrence(rho: np.ndarray) -> float:
     .. math::
         \max(0, \lambda_1 - \lambda_2 - \lambda_3 - \lambda_4),
 
-    where :math:`\lambda_1, \ldots, \lambda_4` are the eigenvalues in decreasing order of the
-    matrix.
+    where :math:`\lambda_1, \ldots, \lambda_4` are the square roots of the eigenvalues in decreasing order of the
+    matrix
+
+    .. math::
+        \rho\tilde{\rho} = \rho \sigma_y \otimes \sigma_y \rho^* \sigma_y \otimes \sigma_y.
 
     Concurrence can serve as a measure of entanglement.
 
@@ -63,7 +66,7 @@ def concurrence(rho: np.ndarray) -> float:
     References
     ==========
     .. [WikCon] Wikipedia page for concurrence (quantum computing)
-       https://en.wikipedia.org/wiki/Concurrence_(quantum_computing)
+        https://en.wikipedia.org/wiki/Concurrence_(quantum_computing)
 
     :param rho: The bipartite system specified as a matrix.
     :return: The concurrence of the bipartite state :math:`\rho`.
@@ -74,8 +77,8 @@ def concurrence(rho: np.ndarray) -> float:
     sigma_y = pauli("Y", False)
     sigma_y_y = np.kron(sigma_y, sigma_y)
 
-    rho_hat = sigma_y_y @ rho.conj().T @ sigma_y_y
+    rho_tilde = sigma_y_y @ rho.conj() @ sigma_y_y
 
-    eig_vals = np.linalg.eigvals(rho @ rho_hat)
+    eig_vals = np.linalg.eigvals(rho @ rho_tilde)
     eig_vals = np.sort(np.abs(np.sqrt(eig_vals)))[::-1]
     return max(0, eig_vals[0] - eig_vals[1] - eig_vals[2] - eig_vals[3])


### PR DESCRIPTION
Made fix to concurrence function

## Description
The concurrence function was calculation rho_hat (now rho_tilde) with a conjugate transpose as opposed to solely a complex conjugate on rho. This was ammended and documentation clarified.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  -  [ ] Fixed concurrence function
  -  [ ] Clarified documentation

## Questions
-  [ ] Tried to fix wiki hyperlink as wasn't working (should be fixed)

## Status
-  [ ] Ready to go