### PR TITLE
Fixing complex warning for enlg and nlg.

### DIFF
--- a/toqito/nonlocal_games/extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/extended_nonlocal_game.py
@@ -69,13 +69,16 @@ class ExtendedNonlocalGame:
                     num_bob_out**reps,
                     num_alice_in**reps,
                     num_bob_in**reps,
-                )
+                ),
+                dtype=complex,
             )
             i_ind = np.zeros(reps, dtype=int)
             j_ind = np.zeros(reps, dtype=int)
             for i in range(num_alice_in**reps):
                 for j in range(num_bob_in**reps):
-                    to_tensor = np.empty([reps, dim_x, dim_y, num_alice_out, num_bob_out])
+                    to_tensor = np.empty(
+                        [reps, dim_x, dim_y, num_alice_out, num_bob_out], dtype=complex
+                    )
                     for k in range(reps - 1, -1, -1):
                         to_tensor[k] = pred_mat[:, :, :, :, i_ind[k], j_ind[k]]
                     pred_mat2[:, :, :, :, i, j] = tensor(to_tensor)

--- a/toqito/nonlocal_games/nonlocal_game.py
+++ b/toqito/nonlocal_games/nonlocal_game.py
@@ -54,13 +54,14 @@ class NonlocalGame:
                     num_bob_out**reps,
                     num_alice_in**reps,
                     num_bob_in**reps,
-                )
+                ),
+                dtype=complex
             )
             i_ind = np.zeros(reps, dtype=int)
             j_ind = np.zeros(reps, dtype=int)
             for i in range(num_alice_in**reps):
                 for j in range(num_bob_in**reps):
-                    to_tensor = np.empty([reps, num_alice_out, num_bob_out])
+                    to_tensor = np.empty([reps, num_alice_out, num_bob_out], dtype=complex)
                     for k in range(reps - 1, -1, -1):
                         to_tensor[k] = pred_mat[:, :, i_ind[k], j_ind[k]]
                     pred_mat2[:, :, i, j] = tensor(to_tensor)


### PR DESCRIPTION
Parallel repetition code for both extended nonlocal games and nonlocal games previously threw `Complex`-type warnings. This has since been addressed and fixed. 