### PR TITLE
Minor fixes and improvements.

### DIFF
--- a/tests/test_matrix_props/test_is_block_positive.py
+++ b/tests/test_matrix_props/test_is_block_positive.py
@@ -19,8 +19,8 @@ def test_swap_operator_is_block_positive(dim):
 def test_choi_is_block_positive():
     """Test Choi map is 1-block positive but not 2-block positive."""
     mat = choi()
-    np.testing.assert_equal(is_block_positive(mat), True)
-    np.testing.assert_equal(is_block_positive(mat, k=2), False)
+    np.testing.assert_equal(is_block_positive(mat, rtol=0.001), True)
+    np.testing.assert_equal(is_block_positive(mat, k=2, rtol=0.001), False)
 
 
 def test_is_block_positive():

--- a/tests/test_matrix_props/test_sk_norm.py
+++ b/tests/test_matrix_props/test_sk_norm.py
@@ -28,8 +28,8 @@ def test_s1_norm_example():
     expected = 1 / 8 * (3 + 2 * np.sqrt(2))
 
     lower_bound, upper_bound = sk_operator_norm(mat)
-    np.testing.assert_equal(np.allclose(lower_bound, expected), True)
-    np.testing.assert_equal(np.allclose(upper_bound, expected), True)
+    np.testing.assert_equal(np.allclose(lower_bound, expected, atol=0.001), True)
+    np.testing.assert_equal(np.allclose(upper_bound, expected, atol=0.001), True)
 
 
 def test_sk_norm_rank_1():

--- a/tests/test_nonlocal_games/test_extended_nonlocal_game.py
+++ b/tests/test_nonlocal_games/test_extended_nonlocal_game.py
@@ -185,4 +185,4 @@ class TestExtendedNonlocalGame(unittest.TestCase):
         res = chsh.commuting_measurement_value_upper_bound(k=2)
         expected_res = 3 / 4
 
-        self.assertEqual(np.isclose(res, expected_res), True)
+        self.assertEqual(np.isclose(res, expected_res, atol=0.001), True)

--- a/toqito/nonlocal_games/extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/extended_nonlocal_game.py
@@ -462,7 +462,7 @@ class ExtendedNonlocalGame:
             for y_in in range(bob_in):
                 mat[x_in, y_in] = cvxpy.Variable(
                     (alice_out * referee_dim, bob_out * referee_dim),
-                    name=f"K(a, b | {x_in}, {y_in})",
+                    name=f"K(a, b | {x_in}, {y_in})", hermitian=True,
                 )
 
         p_win = cvxpy.Constant(0)
@@ -479,7 +479,7 @@ class ExtendedNonlocalGame:
                         )
 
         npa = npa_constraints(mat, k, referee_dim)
-        objective = cvxpy.Maximize(p_win)
+        objective = cvxpy.Maximize(cvxpy.real(p_win))
         problem = cvxpy.Problem(objective, npa)
         cs_val = problem.solve()
 

--- a/toqito/states/max_entangled.py
+++ b/toqito/states/max_entangled.py
@@ -8,7 +8,7 @@ from toqito.matrices import iden
 
 def max_entangled(
     dim: int, is_sparse: bool = False, is_normalized: bool = True
-) -> [np.ndarray, sparse.dia.dia_matrix]:
+) -> [np.ndarray, sparse.dia_matrix]:
     r"""
     Produce a maximally entangled bipartite pure state [WikEnt]_.
 

--- a/toqito/states/max_mixed.py
+++ b/toqito/states/max_mixed.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy import sparse
 
 
-def max_mixed(dim: int, is_sparse: bool = False) -> [np.ndarray, sparse.dia.dia_matrix]:
+def max_mixed(dim: int, is_sparse: bool = False) -> [np.ndarray, sparse.dia_matrix]:
     r"""
     Produce the maximally mixed state [AAR6]_.
 


### PR DESCRIPTION
- Adding `hermitian=True` to `commuting_measurement_value_upper_bound`. 
- Adding `cvxpy.real()` in `cvxpy.Maximize` in `commuting_measurement_value_upper_bound`.
- Adding `rtol` and `atol` threshold to tests
- Removing deprecated `sparse.dia.dia_matrix` to `sparse.dia_matrix`