### PR TITLE
XOR/standard nonlocal game converter

### DIFF
--- a/tests/test_nonlocal_games/test_xor_game.py
+++ b/tests/test_nonlocal_games/test_xor_game.py
@@ -170,16 +170,14 @@ class TestXORGame(unittest.TestCase):
             game.quantum_value()
 
     def test_to_nonlocal_game(self):
-        prob = np.array([[0.25,0.25],[0.25,0.25]])
+        prob = 1/4 * np.ones((2,2))
         pred = np.array([[0,0],[0,1]])
 
-        specific_game = XORGame(pred, prob, 1)
-
-        generic_pred = specific_game.to_nonlocal_game()
-        generic_game = NonlocalGame(prob, generic_pred, 1)
+        xor_chsh = XORGame(pred, prob, reps=1)
+        nlg_chsh = xor_chsh.to_nonlocal_game()
 
 
-        np.testing.assert_equal(specific_game.classical_value(), generic_game.classical_value())
+        np.testing.assert_equal(xor_chsh.classical_value(), nlg_chsh.classical_value())
 
 
 if __name__ == "__main__":

--- a/tests/test_nonlocal_games/test_xor_game.py
+++ b/tests/test_nonlocal_games/test_xor_game.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 
 from toqito.nonlocal_games.xor_game import XORGame
+from toqito.nonlocal_games.nonlocal_game import NonlocalGame
 
 
 class TestXORGame(unittest.TestCase):
@@ -167,6 +168,18 @@ class TestXORGame(unittest.TestCase):
 
             game = XORGame(prob_mat, pred_mat)
             game.quantum_value()
+
+    def test_to_nonlocal_game(self):
+        prob = np.array([[0.25,0.25],[0.25,0.25]])
+        pred = np.array([[0,0],[0,1]])
+
+        specific_game = XORGame(pred, prob, 1)
+
+        generic_pred = specific_game.to_nonlocal_game()
+        generic_game = NonlocalGame(prob, generic_pred, 1)
+
+
+        np.testing.assert_equal(specific_game.classical_value(), generic_game.classical_value())
 
 
 if __name__ == "__main__":

--- a/toqito/nonlocal_games/xor_game.py
+++ b/toqito/nonlocal_games/xor_game.py
@@ -2,6 +2,8 @@
 import cvxpy
 import numpy as np
 
+from toqito.nonlocal_games.nonlocal_game import NonlocalGame
+
 
 class XORGame:
     r"""
@@ -292,18 +294,21 @@ class XORGame:
         )
     def to_nonlocal_game(self) -> np.ndarray:
         """
+                pred_mat = self.pred_mat
+                xor_pred_mat = np.ndarray((2, 2, q_0, q_1))
+        
         Given an XOR game, this function returns a predicate matrix representing the more generic :code:`nonlocal_game` equivalent.
 
         :return: A four-dimensional predicate matrix compatible with the :code:`NonlocalGame` class.
         """
         q_0, q_1 = self.prob_mat.shape
-        pred_mat = self.pred_mat
-        result = np.ndarray((2,2,q_0,q_1))
+        xor_pred_mat = self.pred_mat
+        nlg_pred_mat = np.ndarray((2,2,q_0,q_1))
 
         for a in range(2):
             for b in range(2):
                 for x in range(q_0):
                     for y in range(q_1):
-                        result[a,b,x,y] = pred_mat[x,y] == a ^ b
+                        nlg_pred_mat[a,b,x,y] = xor_pred_mat[x,y] == a ^ b
 
-        return result
+        return NonlocalGame(self.prob_mat, nlg_pred_mat, reps=self.reps)

--- a/toqito/nonlocal_games/xor_game.py
+++ b/toqito/nonlocal_games/xor_game.py
@@ -294,7 +294,7 @@ class XORGame:
         """
         Given an XOR game, this function returns a predicate matrix representing the more generic :code:`nonlocal_game` equivalent.
 
-        :return: A four-dimensional predicate matrix compatible with the :code:`nonlocal_game` class.
+        :return: A four-dimensional predicate matrix compatible with the :code:`NonlocalGame` class.
         """
         q_0, q_1 = self.prob_mat.shape
         pred_mat = self.pred_mat

--- a/toqito/nonlocal_games/xor_game.py
+++ b/toqito/nonlocal_games/xor_game.py
@@ -291,6 +291,11 @@ class XORGame:
             "a nonlocal game."
         )
     def to_nonlocal_game(self) -> np.ndarray:
+        """
+        Given an XOR game, this function returns a predicate matrix representing the more generic :code:`nonlocal_game` equivalent.
+
+        :return: A four-dimensional predicate matrix compatible with the :code:`nonlocal_game` class.
+        """
         q_0, q_1 = self.prob_mat.shape
         pred_mat = self.pred_mat
         result = np.ndarray((2,2,q_0,q_1))

--- a/toqito/nonlocal_games/xor_game.py
+++ b/toqito/nonlocal_games/xor_game.py
@@ -290,3 +290,15 @@ class XORGame:
             "multiple repetitions for the classical value of "
             "a nonlocal game."
         )
+    def to_nonlocal_game(self) -> np.ndarray:
+        q_0, q_1 = self.prob_mat.shape
+        pred_mat = self.pred_mat
+        result = np.ndarray((2,2,q_0,q_1))
+
+        for a in range(2):
+            for b in range(2):
+                for x in range(q_0):
+                    for y in range(q_1):
+                        result[a,b,x,y] = pred_mat[x,y] == a ^ b
+
+        return result

--- a/toqito/nonlocal_games/xor_game.py
+++ b/toqito/nonlocal_games/xor_game.py
@@ -297,9 +297,9 @@ class XORGame:
                 pred_mat = self.pred_mat
                 xor_pred_mat = np.ndarray((2, 2, q_0, q_1))
         
-        Given an XOR game, this function returns a predicate matrix representing the more generic :code:`nonlocal_game` equivalent.
+        Given an XOR game, this function computes a predicate matrix representing the more generic :code:`NonlocalGame` equivalent.
 
-        :return: A four-dimensional predicate matrix compatible with the :code:`NonlocalGame` class.
+        :return: A :code:`NonlocalGame` object equivalent to the XOR game.
         """
         q_0, q_1 = self.prob_mat.shape
         xor_pred_mat = self.pred_mat


### PR DESCRIPTION
## Description
Created a brief function to convert the 2-dimensional predicate matrix of an XOR game into a 4-dimensional one compatible with the `NonlocalGame` object.

## Questions
-  [x] I am not entirely sure how to test this function properly. For now, I'm just creating a new `NonlocalGame` and check if the classical values are the same. Is there a better, more reliable testing method?

## Other
This is a preliminary step to solve issue #15, the approach being to take advantage of already existing features in the `NonlocalGame` class by enabling access to them from the `XORGame` class.

## Status
-  [x] Ready to go