### PR TITLE
Parallel repetition for XOR games

### DIFF
--- a/tests/test_nonlocal_games/test_xor_game.py
+++ b/tests/test_nonlocal_games/test_xor_game.py
@@ -126,12 +126,12 @@ class TestXORGame(unittest.TestCase):
 
 	def test_classical_parallel_rep(self):
 		"""Tests for classical value parallel reps."""
-		with self.assertRaises(ValueError):
-			prob_mat = np.array([[1 / 4, 1 / 4], [1 / 4, 1 / 4]])
-			pred_mat = np.array([[0, 0], [0, 1]])
+		prob_mat = np.array([[1 / 4, 1 / 4], [1 / 4, 1 / 4]])
+		pred_mat = np.array([[0, 0], [0, 1]])
 
-			game = XORGame(prob_mat, pred_mat, 2)
-			game.classical_value()
+		game = XORGame(prob_mat, pred_mat, 2)
+		res = game.classical_value()
+		self.assertEqual(res, 0.625)
 
 	def test_negative_prob_mat(self):
 		"""Tests for invalid negative probability matrix."""

--- a/toqito/nonlocal_games/xor_game.py
+++ b/toqito/nonlocal_games/xor_game.py
@@ -245,53 +245,10 @@ class XORGame:
 		"""
 		Compute the classical value of the XOR game.
 
-		:raises ValueError: Does not support parallel repetitions.
 		:return: A value between [0, 1] representing the classical value.
 		"""
-		if self.reps == 1:
-			q_0, q_1 = self.prob_mat.shape
 
-			# At worst, out winning probability is 0. Now, try to improve.
-			val = 0
-
-			# Find the maximum probability of winning (this is NP-hard, so don't
-			# expect an easy way to do it: just loop over all strategies.
-
-			# Loop over Alice's answers
-			for a_ans in range(2**q_0):
-				# Loop over Bob's answers:
-				for b_ans in range(2**q_1):
-					a_vec = (a_ans >> np.arange(q_0)) & 1
-					b_vec = (b_ans >> np.arange(q_1)) & 1
-
-					# Now compute the winning probability under this strategy:
-					# XOR together Alice's responses and Bob's responses, then
-					# check where the XORed value equals the value in the given
-					# matrix. Where the values match, multiply by the
-					# probability of getting that pair of questions (i.e.,
-					# multiply by the probability of getting that pair of
-					# questions (i.e., multiply entry-wise by P) and then sum
-					# over the rows and columns.
-					classical_strategy = np.mod(
-						np.multiply(a_vec.conj().T.reshape(-1, 1), np.ones((1, q_1)))
-						+ np.multiply(np.ones((q_0, 1)), b_vec),
-						2,
-					)
-					p_win = np.sum(
-						np.sum(np.multiply(classical_strategy == self.pred_mat, self.prob_mat))
-					)
-					# Is this strategy better than other ones tried so far?
-					val = max(val, p_win)
-
-					# Already optimal? Quit.
-					if val >= 1 - self.tol:
-						return val
-			return val
-		raise ValueError(
-			"Error: toqito currently does not support "
-			"multiple repetitions for the classical value of "
-			"a nonlocal game."
-		)
+		return self.to_nonlocal_game().classical_value()
 	
 	def nonsignaling_value(self) -> float:
 		"""


### PR DESCRIPTION
## Description
Adds parallel repetition for XOR games by bridging over to the generic NLG version of the function.

## Questions
-  Would it be better to only create a new NLG object if `reps>1` and use the already existing XOR function otherwise? It might yield some small performance benefits, but I'm not sure.

## Status
-  [ ] Ready to go

## Other comments
My apologies for the long silence – I was quite busy the last few weeks. I also built a separate `classical_value` function to avoid having to create a `NonlocalGame` object, but it is incredibly slow and doesn't seem to like it when `q_0, q_1 > 2`.

This solution seems a bit underwhelming, but it works, and seems to run fairly quickly as well.