### PR TITLE
Update contribution guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,6 +10,8 @@ describes how to merge code changes into this `toqito`.
 *    On your local machine,
      [clone](https://help.github.com/articles/cloning-a-repository/) your fork of
      the repository.
+*    To install an editable version on your local machine, run `pip install -e .` in
+     the top-level directory of the cloned repository.
 
 ## Making Changes
 
@@ -26,7 +28,10 @@ describes how to merge code changes into this `toqito`.
      automatically.  Each commit added to the PR will be validated for
      mergability, compilation and test suite compliance; the results of these tests
      will be visible on the PR page.
-*    If you're providing a new feature, you must add test cases and documentation.
+*    If you're providing a new feature, you must add test cases and documentation. We use `sphinx`
+     to build the documentation. To build the documentation locally via `make html` in the
+     `toqito/docs` directory, make sure `sphinx` and `sphinx-rtd-theme` are installed.
+     For more information, visit [sphinx documentation](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html) & [sphinx-rtd-theme documentation](https://sphinx-rtd-theme.readthedocs.io/en/stable/installing.html)
 *    When the code is ready to go, make sure you run the test suite using pytest.
 *    When you're ready to be considered for merging, check the "Ready to go"
      box on the PR page to let the `toqito` devs know that the changes are complete.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -4,9 +4,11 @@ Getting started
 Installing
 ^^^^^^^^^^
 
-1. Ensure you have Python 3.9 or greater installed on your machine.
+1. Ensure you have Python 3.9 or greater installed on your machine or in 
+a virtual environment (`pyenv <https://github.com/pyenv/pyenv>`_, `pyenv tutorial <https://realpython.com/intro-to-pyenv/>`_). 
 
 2. Consider using a `virtual environment <https://packaging.python.org/guides/installing-using-pip-and-virtualenv/>`_.
+You can also use :code:`pyenv` with :code:`virtualenv` `to manage different Python versions <https://github.com/pyenv/pyenv-virtualenv>`_. 
 
 3. The preferred way to install the :code:`toqito` package is via :code:`pip`.
 
@@ -40,9 +42,12 @@ Python module installed and built for your machine.
 Testing
 ^^^^^^^
 
-The :code:`pytest` module is used for testing. In order to run and :code:`pytest`, you will need to ensure it is
-installed on your machine. Consult the `pytest <https://docs.pytest.org/en/latest/>`_ website for more information. To
-run the suite of tests for :code:`toqito`, run the following command in the root directory of this project:
+The :code:`pytest` module is used for testing and :code:`pytest-cov` is used to generate
+coverage reports. In order to run and :code:`pytest`, you will need to ensure it is
+installed on your machine along with :code:`pytest-cov`. Consult the `pytest <https://docs.pytest.org/en/latest/>`_ 
+and `pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`_ websites for more
+information. To run the suite of tests for :code:`toqito`, run the following command
+in the root directory of this project:
 
 .. code-block:: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ mypy = "^0.750.0"
 coverage = "^4.5"
 coveralls = "^1.9"
 setuptools = ">65.5.1"
-sphinx = "3.1.2"
+sphinx = "6.2.1"
 sphinx_rtd_theme = "*"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,11 +60,11 @@ pytest-cov = "*"
 mypy = "^0.750.0"
 coverage = "^4.5"
 coveralls = "^1.9"
-setuptools = "<=57.5.0"
+setuptools = ">65.5.1"
 sphinx = "3.1.2"
 sphinx_rtd_theme = "*"
 
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["setuptools","poetry>=0.12"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Fixes #150

When `pip install -e.` is used, the dependencies listed in `pyproject.toml` are not installed. I had to manually install them because I couldn't figure out a way to do something like `pip install dev_dependencies`.  A line for this is currently missing. 

Something to keep track of is `black` and `flake8` will flag quite a few formatting issues when I run `black toqito/` and `flake8 toqito/`. 