### PR TITLE
Add `channel_dim`.

### DIFF
--- a/tests/test_helper/test_channel_dim.py
+++ b/tests/test_helper/test_channel_dim.py
@@ -1,0 +1,105 @@
+"""Test channel dimensions."""
+import numpy as np
+import pytest
+
+from toqito.helper import channel_dim
+from toqito.matrices import pauli
+from toqito.perms import swap_operator
+
+
+def test_channel_dim_kraus():
+    """
+    Test channel dim of the superoperator PHI defined by:
+
+    Phi(X) = [[1,5],[1,0],[0,2]] X [[0,1][2,3][4,5]].conj().T -
+    [[1,0],[0,0],[0,1]] X [[0,0][1,1],[0,0]].conj().T
+    """
+    kraus_1 = np.array([[1, 5], [1, 0], [0, 2]])
+    kraus_2 = np.array([[0, 1], [2, 3], [4, 5]])
+    kraus_3 = np.array([[-1, 0], [0, 0], [0, -1]])
+    kraus_4 = np.array([[0, 0], [1, 1], [0, 0]])
+
+    din, dout, de = channel_dim([[kraus_1, kraus_2], [kraus_3, kraus_4]])
+    np.testing.assert_equal((din, dout, de), (2, 3, 2))
+
+
+@pytest.mark.parametrize("nested", [1, 2, 3])
+def test_channel_dim_cpt_kraus(nested):
+    """Test channel dim of a single qubit depolarizing channel."""
+    kraus = [0.5 * pauli(ind) for ind in range(4)]
+    if nested == 2:
+        kraus = [kraus]
+    elif nested == 3:
+        kraus = [[mat] for mat in kraus]
+
+    din, dout, de = channel_dim(kraus, allow_rect=False)
+    np.testing.assert_equal((din, dout, de), (2, 2, 4))
+
+
+def test_channel_dim_non_square():
+    """Test channel dim of a channel with non square inputs."""
+    kraus_1 = np.arange(6).reshape((2, 3))
+    kraus_2 = np.arange(8).reshape((4, 2))
+    din, dout, de = channel_dim([[kraus_1, kraus_2]])
+    np.testing.assert_equal(din, np.array([3, 2]))
+    np.testing.assert_equal(dout, np.array([2, 4]))
+    np.testing.assert_equal(de, 1)
+
+
+def test_channel_dim_non_square_and_allow_rect_disabled():
+    """Test channel dim of a channel with non square inputs with allow_rect set to Falses."""
+    kraus_1 = np.arange(6).reshape((2, 3))
+    kraus_2 = np.arange(8).reshape((4, 2))
+    with np.testing.assert_raises(ValueError):
+        channel_dim([[kraus_1, kraus_2]], allow_rect=False)
+
+
+def test_channel_dim_with_wrong_dim_input():
+    """Test channel dim if user provided dim that doesn't match with the channel."""
+    kraus = [0.5 * pauli(ind) for ind in range(4)]
+    with np.testing.assert_raises(ValueError):
+        channel_dim(kraus, dim=3)
+
+
+def test_channel_dim_with_kraus_op_of_different_shapes():
+    """Test channel dim when Kraus operators have different shapes."""
+    kraus_1 = np.arange(6).reshape((2, 3))
+    kraus_2 = np.arange(8).reshape((4, 2))
+    with np.testing.assert_raises(ValueError):
+        channel_dim([[kraus_1, kraus_2], [kraus_2, kraus_1]])
+
+
+def test_channel_dim_choi():
+    """Test channel dim of the transpose map."""
+    din, dout, de = channel_dim(swap_operator(2))
+    np.testing.assert_equal((din, dout, de), (2, 2, 4))
+
+
+def test_channel_dim_choi_non_square():
+    """Test channel dim of the transpose map."""
+    din, dout, de = channel_dim(swap_operator([2, 3]), dim=np.array([[3, 2], [2, 3]]))
+    np.testing.assert_equal(din, np.array([3, 2]))
+    np.testing.assert_equal(dout, np.array([2, 3]))
+    np.testing.assert_equal(de, 6)
+
+
+def test_channel_dim_choi_non_square_and_allow_rect_disabled():
+    """Test channel dim of a channel with non square inputs with allow_rect set to Falses."""
+    with np.testing.assert_raises(ValueError):
+        channel_dim(swap_operator([2, 3]), dim=np.array([[3, 2], [2, 3]]), allow_rect=False)
+
+
+def test_channel_dim_choi_with_wrong_dim_input():
+    """Test channel dim of the transpose map but withn input dim mismatch."""
+    with np.testing.assert_raises(ValueError):
+        channel_dim(swap_operator(3), dim=[2, 3])
+
+
+def test_channel_dim_with_invalid_dim_input():
+    """Test channel dim with invalid dim."""
+    with np.testing.assert_raises(ValueError):
+        channel_dim(swap_operator(3), dim=np.eye(3))
+
+
+if __name__ == "__main__":
+    np.testing.run_module_suite()

--- a/tests/test_helper/test_channel_dim.py
+++ b/tests/test_helper/test_channel_dim.py
@@ -108,5 +108,11 @@ def test_channel_dim_with_vector_dim_input():
     np.testing.assert_equal((din, dout, de), (3, 2, 1))
 
 
+def test_channel_dim_with_compute_env_dim_disabled():
+    """Test channel dim without computing the enviroment dimension."""
+    din, dout, de = channel_dim(swap_operator(2), compute_env_dim=False)
+    np.testing.assert_equal((din, dout, de), (2, 2, None))
+
+
 if __name__ == "__main__":
     np.testing.run_module_suite()

--- a/tests/test_helper/test_channel_dim.py
+++ b/tests/test_helper/test_channel_dim.py
@@ -101,5 +101,12 @@ def test_channel_dim_with_invalid_dim_input():
         channel_dim(swap_operator(3), dim=np.eye(3))
 
 
+def test_channel_dim_with_vector_dim_input():
+    """Test channel dim with vector dim."""
+    v_mat = np.array([[1, 0, 0], [0, 1, 0]])
+    din, dout, de = channel_dim([v_mat], dim=[3, 2])
+    np.testing.assert_equal((din, dout, de), (3, 2, 1))
+
+
 if __name__ == "__main__":
     np.testing.run_module_suite()

--- a/toqito/helper/__init__.py
+++ b/toqito/helper/__init__.py
@@ -5,3 +5,4 @@ from toqito.helper.update_odometer import update_odometer
 from toqito.helper.cvx_kron import cvx_kron
 from toqito.helper.npa_hierarchy import npa_constraints
 from toqito.helper.kp_norm import kp_norm
+from toqito.helper.channel_dim import channel_dim

--- a/toqito/helper/channel_dim.py
+++ b/toqito/helper/channel_dim.py
@@ -8,6 +8,7 @@ def channel_dim(
     phi: np.ndarray | list[np.ndarray] | list[list[np.ndarray]],
     allow_rect: bool = True,
     dim: int | list[int] | np.ndarray = None,
+    compute_env_dim: bool = True,
 ) -> tuple[np.ndarray | int]:
     """
     Compute the input, output, and environment dimensions of a channel.
@@ -25,12 +26,14 @@ def channel_dim(
     spaces, an error will be produced. If PHI maps M_{r,c} to M_{x,y} then DIM should be the
     2-by-2 matrix [[r,x], [c,y]]. If PHI maps M_m to M_n, then DIM can simply be the vector
     [m,n]. If ALLOW_RECT is false then returned input and output dimensions will be scalars
-    instead of vectors.
+    instead of vectors. If COMPUTE_ENV_DIM is false and the PHI is a Choi matrix we avoid
+    computing the rank of the Choi matrix.
 
     :param phi: A superoperator. It should be provided either as a Choi matrix,
                 or as a (1d or 2d) list of numpy arrays whose entries are its Kraus operators.
     :param allow_rect: A flag indicating that the input and output spaces of PHI can be non-square (default True).
     :param dim: A scalar, vector or matrix containing the input and output dimensions of PHI.
+    :param compute_env_dim: A flag indicating whether we compute the enviroment dimension.
     :return: The input, output, and environment dimensions of a channel.
     """
     dim_in = np.zeros(2, dtype=int)
@@ -107,7 +110,9 @@ def channel_dim(
             raise ValueError("The input and output spaces of PHI must be square.")
 
         # environment dimension is the rank of the Choi matrix
-        dim_e = np.linalg.matrix_rank(phi)
+        dim_e = None
+        if compute_env_dim:
+            dim_e = np.linalg.matrix_rank(phi)
 
     # Finally, put `dim` back into `dim_in` and `dim_out`.
     if allow_rect:
@@ -133,6 +138,6 @@ def _expand_dim(dim):
     dim = dim.ravel()
     # user entered a 2-dimensional vector for DIM
     if dim.shape == (2,):
-        return np.vstack([dim, dim]).T
+        return np.vstack([dim, dim])
 
     raise ValueError("The dimensions must be provided in a matrix no larger than 2-by-2.")

--- a/toqito/helper/channel_dim.py
+++ b/toqito/helper/channel_dim.py
@@ -1,0 +1,138 @@
+"""Channel dimensions."""
+from __future__ import annotations
+import itertools
+import numpy as np
+
+
+def channel_dim(
+    phi: np.ndarray | list[np.ndarray] | list[list[np.ndarray]],
+    allow_rect: bool = True,
+    dim: int | list[int] | np.ndarray = None,
+) -> tuple[np.ndarray | int]:
+    """
+    Compute the input, output, and environment dimensions of a channel.
+
+    This function returns the dimensions of the input, output, and environment spaces of
+    input channel, in that order. Input and output dimensions are both 1-by-2 vectors
+    containing the row and column dimensions of their spaces. The enviroment dimension
+    is always a scalar, and it is equal to the number of Kraus operators of PHI (if PHI is
+    provided as a Choi matrix then enviroment dimension is the *minimal* number of Kraus
+    operators of any representation of PHI).
+
+    Input DIM should provided if and only if PHI is a Choi matrix with unequal input and
+    output dimensions (since it is impossible to determine the input and output dimensions
+    from the Choi matrix alone). If ALLOW_RECT is false and PHI acts on non-square matrix
+    spaces, an error will be produced. If PHI maps M_{r,c} to M_{x,y} then DIM should be the
+    2-by-2 matrix [[r,x], [c,y]]. If PHI maps M_m to M_n, then DIM can simply be the vector
+    [m,n]. If ALLOW_RECT is false then returned input and output dimensions will be scalars
+    instead of vectors.
+
+    :param phi: A superoperator. It should be provided either as a Choi matrix,
+                or as a (1d or 2d) list of numpy arrays whose entries are its Kraus operators.
+    :param allow_rect: A flag indicating that the input and output spaces of PHI can be non-square (default True).
+    :param dim: A scalar, vector or matrix containing the input and output dimensions of PHI.
+    :return: The input, output, and environment dimensions of a channel.
+    """
+    dim_in = np.zeros(2, dtype=int)
+    dim_out = np.zeros(2, dtype=int)
+
+    if isinstance(phi, list):
+        sz_phi_op = [len(phi), len(phi[0])]
+
+        # Map is completely positive if input is given as:
+        # 1. [K1, K2, .. Kr]
+        # 2. [[K1], [K2], .. [Kr]]
+        # 3. [[K1, K2, .. Kr]] and r > 2
+        is_cpt = False
+        if isinstance(phi[0], list) and (
+            sz_phi_op[1] == 1 or (sz_phi_op[0] == 1 and sz_phi_op[1] > 2)
+        ):
+            # get a flat list of Kraus operators.
+            phi = list(itertools.chain(*phi))
+            is_cpt = True
+
+        dim_e = len(phi)
+        if isinstance(phi[0], np.ndarray):
+            dim_out[0], dim_in[0] = phi[0].shape
+            # input and output are squares.
+            dim_in[1] = dim_in[0]
+            dim_out[1] = dim_out[0]
+            is_cpt = True
+        else:
+            dim_out[0], dim_in[0] = phi[0][0].shape
+            dim_out[1], dim_in[1] = phi[0][1].shape
+
+        if dim is None:
+            dim = np.vstack([dim_in, dim_out]).T
+        dim = _expand_dim(dim)
+
+        # Now do some error checking.
+        if (dim_in[0] != dim_in[1] or dim_out[0] != dim_out[1]) and not allow_rect:
+            raise ValueError("The input and output spaces of PHI must be square.")
+
+        if np.any(dim != np.vstack([dim_in, dim_out]).T):
+            raise ValueError(
+                "The dimensions of PHI do not match those provided in the DIM argument."
+            )
+
+        if (is_cpt and any(k_mat.shape != (dim[0, 1], dim[0, 0]) for k_mat in phi)) or (
+            not is_cpt
+            and any(
+                k_mat[0].shape != (dim[0, 1], dim[0, 0]) or k_mat[1].shape != (dim[1, 1], dim[1, 0])
+                for k_mat in phi
+            )
+        ):
+            raise ValueError("The Kraus operators of PHI do not all have the same size.")
+
+    # If Phi is a Choi matrix, the dimensions are a bit more of a pain: we have
+    # to guess a bit if the input and output dimensions are different.
+    else:
+        # Try to guess input and output dims.
+        rows, cols = phi.shape
+        dim_in = np.array([int(np.round(np.sqrt(rows))), int(np.round(np.sqrt(cols)))])
+        dim_out = dim_in
+
+        if dim is None:
+            dim = np.vstack([dim_in, dim_out]).T
+        dim = _expand_dim(dim)
+
+        if dim[0, 0] * dim[0, 1] != rows or dim[1, 0] * dim[1, 1] != cols:
+            raise ValueError(
+                "If the input and output dimensions are unequal and PHI is provided "
+                "as a Choi matrix, the optional argument DIM must be specified "
+                "(and its dimensions must agree with PHI)."
+            )
+
+        if (dim[0, 0] != dim[1, 0] or dim[0, 1] != dim[1, 1]) and not allow_rect:
+            raise ValueError("The input and output spaces of PHI must be square.")
+
+        # environment dimension is the rank of the Choi matrix
+        dim_e = np.linalg.matrix_rank(phi)
+
+    # Finally, put `dim` back into `dim_in` and `dim_out`.
+    if allow_rect:
+        dim_in = np.array([dim[0, 0], dim[1, 0]])
+        dim_out = np.array([dim[0, 1], dim[1, 1]])
+    else:
+        dim_in = dim[0, 0]
+        dim_out = dim[0, 1]
+
+    return (dim_in, dim_out, dim_e)
+
+
+def _expand_dim(dim):
+    # user just entered a single number for DIM
+    if isinstance(dim, int):
+        return np.array([[dim, dim], [dim, dim]])
+
+    dim = np.array(dim)
+    # user entered a full 2-by-2 matrix for DIM
+    if dim.shape == (2, 2):
+        return dim
+
+    dim = dim.ravel()
+    # user entered a 2-dimensional vector for DIM
+    if dim.shape == (2,):
+        return np.vstack([dim, dim]).T
+
+    raise ValueError("The dimensions must be provided in a matrix no larger than 2-by-2.")

--- a/toqito/helper/channel_dim.py
+++ b/toqito/helper/channel_dim.py
@@ -29,6 +29,8 @@ def channel_dim(
     instead of vectors. If COMPUTE_ENV_DIM is false and the PHI is a Choi matrix we avoid
     computing the rank of the Choi matrix.
 
+    This functions was adapted from QETLAB.
+
     :param phi: A superoperator. It should be provided either as a Choi matrix,
                 or as a (1d or 2d) list of numpy arrays whose entries are its Kraus operators.
     :param allow_rect: A flag indicating that the input and output spaces of PHI can be non-square (default True).


### PR DESCRIPTION
## Description
This commit adds a helper function to compute the input, output and environment dimensions of a channel. It will be used in subsequent PRs to fix places where we try to retrieve the dimensions of the channel.

Closes #32

## Status
-  [x] Ready to go