### PR TITLE
`choi_to_kraus` for non CP maps.

### DIFF
--- a/tests/test_channel_ops/test_choi_to_kraus.py
+++ b/tests/test_channel_ops/test_choi_to_kraus.py
@@ -2,6 +2,7 @@
 import numpy as np
 
 from toqito.channel_ops import choi_to_kraus
+from toqito.perms import swap_operator
 
 
 def test_choi_to_kraus():
@@ -9,10 +10,16 @@ def test_choi_to_kraus():
 
     choi_mat = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
     kraus_ops = [
-        np.array([[0, 1j / np.sqrt(2)], [-1j / np.sqrt(2), 0]]),
-        np.array([[0, 1 / np.sqrt(2)], [1 / np.sqrt(2), 0]]),
-        np.array([[1, 0], [0, 0]]),
-        np.array([[0, 0], [0, 1]]),
+        [
+            np.array([[0.0, 0.70710678], [-0.70710678, 0.0]]),
+            np.array([[0.0, -0.70710678], [0.70710678, 0.0]]),
+        ],
+        [
+            np.array([[0.0, 0.70710678], [0.70710678, 0.0]]),
+            np.array([[0.0, 0.70710678], [0.70710678, 0.0]]),
+        ],
+        [np.array([[1.0, 0.0], [0.0, 0.0]]), np.array([[1.0, 0.0], [0.0, 0.0]])],
+        [np.array([[0.0, 0.0], [0.0, 1.0]]), np.array([[0.0, 0.0], [0.0, 1.0]])],
     ]
     res_kraus_ops = choi_to_kraus(choi_mat)
 
@@ -26,6 +33,79 @@ def test_choi_to_kraus():
     np.testing.assert_equal(np.all(bool_mat), True)
 
     bool_mat = np.isclose(kraus_ops[3], res_kraus_ops[3])
+    np.testing.assert_equal(np.all(bool_mat), True)
+
+
+def test_choi_to_kraus_cpt():
+    """Choi matrix of an isometry map."""
+    choi_mat = np.array(
+        [
+            [1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    kraus_ops = [np.array([[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0]])]
+
+    res_kraus_ops = choi_to_kraus(choi_mat, dim=[3, 2])
+
+    bool_mat = np.isclose(kraus_ops, res_kraus_ops)
+    np.testing.assert_equal(np.all(bool_mat), True)
+
+
+def test_choi_to_kraus_non_square():
+    """Choi matrix of the swap operator for non square input/output."""
+
+    choi_mat = swap_operator([2, 3])
+    kraus_ops = [
+        [
+            np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
+            np.array([[1.0, 0.0], [0.0, 0.0], [0.0, 0.0]]),
+        ],
+        [
+            np.array([[0.0, -1.0, 0.0], [0.0, 0.0, 0.0]]),
+            np.array([[-0.0, -0.0], [-1.0, -0.0], [-0.0, -0.0]]),
+        ],
+        [
+            np.array([[0.0, 0.0, -1.0], [0.0, 0.0, 0.0]]),
+            np.array([[-0.0, -0.0], [-0.0, -0.0], [-1.0, -0.0]]),
+        ],
+        [
+            np.array([[0.0, 0.0, 0.0], [-1.0, 0.0, 0.0]]),
+            np.array([[-0.0, -1.0], [-0.0, -0.0], [-0.0, -0.0]]),
+        ],
+        [
+            np.array([[0.0, 0.0, 0.0], [0.0, -1.0, 0.0]]),
+            np.array([[-0.0, -0.0], [-0.0, -1.0], [-0.0, -0.0]]),
+        ],
+        [
+            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+            np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 1.0]]),
+        ],
+    ]
+    res_kraus_ops = choi_to_kraus(choi_mat, dim=[[3, 2], [2, 3]])
+    np.testing.assert_equal(
+        all(
+            np.allclose(k_op[0], res_k_op[0]) and np.allclose(k_op[1], res_k_op[1])
+            for k_op, res_k_op in zip(kraus_ops, res_kraus_ops)
+        ),
+        True,
+    )
+
+
+def test_choi_to_kraus_general_map():
+    """Choi matrix of a map that erases everything and keeps the M(1, 2) entry of the input matrix."""
+    choi_mat = np.array(
+        [[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
+    )
+    kraus_ops = [np.array([[1, 0], [0, 0]]), np.array([[0, 0], [0, 1]])]
+
+    res_kraus_ops = choi_to_kraus(choi_mat)
+
+    bool_mat = np.isclose(kraus_ops, res_kraus_ops)
     np.testing.assert_equal(np.all(bool_mat), True)
 
 

--- a/tests/test_matrix_ops/test_unvec.py
+++ b/tests/test_matrix_ops/test_unvec.py
@@ -22,7 +22,7 @@ def test_unvec_custom_dim():
 
     test_input_vec = np.array([1, 3, 2, 4])
 
-    res = unvec(test_input_vec, [1, 4])
+    res = unvec(test_input_vec, [4, 1])
 
     bool_mat = np.isclose(res, expected_res)
     np.testing.assert_equal(np.all(bool_mat), True)

--- a/toqito/channel_ops/choi_to_kraus.py
+++ b/toqito/channel_ops/choi_to_kraus.py
@@ -1,17 +1,29 @@
 """Compute a list of Kraus operators from the Choi matrix."""
+from __future__ import annotations
 import numpy as np
 
+from toqito.helper import channel_dim
 from toqito.matrix_ops import unvec
+from toqito.matrix_props import is_hermitian, is_positive_semidefinite
 
 
-def choi_to_kraus(choi_mat: np.ndarray, tol: float = 1e-9) -> list[list[np.ndarray]]:
+def choi_to_kraus(
+    choi_mat: np.ndarray, tol: float = 1e-9, dim: int | list[int] | np.ndarray = None
+) -> list[np.ndarray] | list[list[np.ndarray]]:
     r"""
     Compute a list of Kraus operators from the Choi matrix [Rigetti20]_.
 
     Note that unlike the Choi or natural representation of operators, the Kraus representation is
     *not* unique.
 
-    This function has been adapted from [Rigetti20]_.
+    If the input channel maps :math:`M_{r,c}` to :math:`M_{x,y}` then :code:`dim` should be the
+    list :code:`[[r,x], [c,y]]`. If it maps :math:`M_m` to :math:`M_n`, then :code:`dim` can simply
+    be the vector :code:`[m,n]`.
+
+    For completely positive maps the output is a single flat list of numpy arrays since the left and
+    right Kraus maps are the same.
+
+    This function has been adapted from [Rigetti20]_ and QETLAB package.
 
     Examples
     ========
@@ -31,25 +43,22 @@ def choi_to_kraus(choi_mat: np.ndarray, tol: float = 1e-9) -> list[list[np.ndarr
 
     .. math::
         \begin{equation}
-            \begin{aligned}
-                \frac{1}{\sqrt{2}}
-                \begin{pmatrix}
-                    0 & i \\ -i & 0
-                \end{pmatrix}, &\quad
-                \frac{1}{\sqrt{2}}
-                \begin{pmatrix}
-                    0 & 1 \\
-                    1 & 0
-                \end{pmatrix}, \\
-                \begin{pmatrix}
-                    1 & 0 \\
-                    0 & 0
-                \end{pmatrix}, &\quad
-                \begin{pmatrix}
-                    0 & 0 \\
-                    0 & 1
-                \end{pmatrix}.
-            \end{aligned}
+        \big[
+            \frac{1}{\sqrt{2}} \begin{pmatrix} 0 & 1 \\ -1 & 0 \end{pmatrix},
+            \frac{1}{\sqrt{2}} \begin{pmatrix} 0 & -1 \\ 1 & 0 \end{pmatrix} 
+        \big],
+        \big[
+            \frac{1}{\sqrt{2}} \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix},
+            \frac{1}{\sqrt{2}} \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix}
+        \big],
+        \big[
+            \begin{pmatrix} 1 & 0 \\ 0 & 0 \end{pmatrix},
+            \begin{pmatrix} 1 & 0 \\ 0 & 0 \end{pmatrix}
+        \big],
+        \big[
+            \begin{pmatrix} 0 & 0 \\ 0 & 1 \end{pmatrix},
+            \begin{pmatrix} 0 & 0 \\ 0 & 1 \end{pmatrix}
+        \big]
         \end{equation}
 
     This can be verified in :code:`toqito` as follows.
@@ -59,11 +68,18 @@ def choi_to_kraus(choi_mat: np.ndarray, tol: float = 1e-9) -> list[list[np.ndarr
     >>> choi_mat = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
     >>> kraus_ops = choi_to_kraus(choi_mat)
     >>> kraus_ops
-    [array([[ 0.+0.j        ,  0.+0.70710678j],
-           [-0.-0.70710678j,  0.+0.j        ]]), array([[0.        , 0.70710678],
-           [0.70710678, 0.        ]]), array([[1., 0.],
-           [0., 0.]]), array([[0., 0.],
-           [0., 1.]])]
+    [
+        [
+            array([[0.,  0.70710678], [-0.70710678, 0.]]),
+            array([[0., -0.70710678], [ 0.70710678, 0.]])
+        ],
+        [
+            array([[0., 0.70710678], [0.70710678, 0.]]),
+            array([[0., 0.70710678], [0.70710678, 0.]])
+        ],
+        [array([[1., 0.], [0., 0.]]), array([[1., 0.], [0., 0.]])],
+        [array([[0., 0.], [0., 1.]]), array([[0., 0.], [0., 1.]])]
+    ]
 
     See Also
     ========
@@ -74,13 +90,36 @@ def choi_to_kraus(choi_mat: np.ndarray, tol: float = 1e-9) -> list[list[np.ndarr
     .. [Rigetti20] Forest Benchmarking (Rigetti).
         https://github.com/rigetti/forest-benchmarking
 
-    :param choi_mat: a dim**2 by dim**2 choi matrix
+    :param choi_mat: A Choi matrix
     :param tol: optional threshold parameter for eigenvalues/kraus ops to be discarded
+    :param dim: A scalar, vector or matrix containing the input and output dimensions of Choi matrix.
     :return: List of Kraus operators
     """
-    eigvals, v_mat = np.linalg.eigh(choi_mat)
-    return [
-        np.lib.scimath.sqrt(eigval) * unvec(np.array([evec]).T)
-        for eigval, evec in zip(eigvals, v_mat.T)
-        if abs(eigval) > tol
-    ]
+    d_in, d_out, _ = channel_dim(choi_mat, dim=dim, compute_env_dim=False)
+    if is_hermitian(choi_mat):
+        eigvals, v_mat = np.linalg.eigh(choi_mat)
+        kraus_0 = [
+            np.sqrt(abs(eigval)) * unvec(evec, shape=(d_out[0], d_in[0]))
+            for eigval, evec in zip(eigvals, v_mat.T)
+            if abs(eigval) > tol
+        ]
+
+        if is_positive_semidefinite(choi_mat):
+            return kraus_0
+
+        kraus_1 = [np.sign(eigval) * k_mat for eigval, k_mat in zip(eigvals, kraus_0)]
+    else:
+        u_mat, singular_values, vh_mat = np.linalg.svd(choi_mat, full_matrices=False)
+        kraus_0 = [
+            np.sqrt(s_val) * unvec(evec, shape=(d_out[0], d_in[0]))
+            for s_val, evec in zip(singular_values, u_mat.T)
+            if abs(s_val) > tol
+        ]
+
+        kraus_1 = [
+            np.sqrt(s_val) * unvec(evec.conj(), shape=(d_out[1], d_in[1]))
+            for s_val, evec in zip(singular_values, vh_mat)
+            if abs(s_val) > tol
+        ]
+
+    return [[ka, kb] for ka, kb in zip(kraus_0, kraus_1)]

--- a/toqito/matrix_ops/unvec.py
+++ b/toqito/matrix_ops/unvec.py
@@ -85,5 +85,5 @@ def unvec(vector: np.ndarray, shape: list[int] = None) -> np.ndarray:
     if shape is None:
         dim = int(np.sqrt(vector.size))
         shape = dim, dim
-    mat = vector.reshape(*shape).T
+    mat = vector.reshape(*shape, order="F")
     return mat


### PR DESCRIPTION
## Description
Previously `choi_to_kraus` was able to output a correct answer only for completely positive channels.
This commit drops this constraint and adds support for all channels which are generally described by
pairs of left and right Kraus operators.

Related to #74.
-  [x] Ready to go