### PR TITLE
Minor fix in `choi_to_kraus`.

### DIFF
--- a/tests/test_channel_ops/test_choi_to_kraus.py
+++ b/tests/test_channel_ops/test_choi_to_kraus.py
@@ -109,5 +109,39 @@ def test_choi_to_kraus_general_map():
     np.testing.assert_equal(np.all(bool_mat), True)
 
 
+def test_choi_to_kraus_reduced_rank():
+    """Choi matrix of a hermicity preserving map with reduced rank."""
+    choi_mat = np.array(
+        [
+            [1, 0, 1, 0],
+            [0, 1, 0, 1],
+            [1, 0, 1, 0],
+            [0, 1, 0, -1],
+        ]
+    )
+    c0 = np.sqrt(1 / (2 + 2 * np.sqrt(2)))
+    c1 = np.sqrt(1 / (2 + 2 * np.sqrt(2)) + 1)
+    kraus_ops = [
+        [
+            np.array([[0, 0], [c0, -c1]]),
+            np.array([[0, 0], [-c0, c1]]),
+        ],
+        [
+            np.array([[0, 0], [c1, c0]]),
+            np.array([[0, 0], [c1, c0]]),
+        ],
+        [np.array([[-1, -1], [0, 0]]), np.array([[-1, -1], [0, 0]])],
+    ]
+
+    res_kraus_ops = choi_to_kraus(choi_mat)
+    np.testing.assert_equal(
+        all(
+            np.allclose(k_op[0], res_k_op[0]) and np.allclose(k_op[1], res_k_op[1])
+            for k_op, res_k_op in zip(kraus_ops, res_kraus_ops)
+        ),
+        True,
+    )
+
+
 if __name__ == "__main__":
     np.testing.run_module_suite()

--- a/toqito/channel_ops/choi_to_kraus.py
+++ b/toqito/channel_ops/choi_to_kraus.py
@@ -107,7 +107,10 @@ def choi_to_kraus(
         if is_positive_semidefinite(choi_mat):
             return kraus_0
 
-        kraus_1 = [np.sign(eigval) * k_mat for eigval, k_mat in zip(eigvals, kraus_0)]
+        kraus_1 = [
+            np.sign(eigval) * k_mat
+            for eigval, k_mat in zip(filter(lambda eigval: abs(eigval) > tol, eigvals), kraus_0)
+        ]
     else:
         u_mat, singular_values, vh_mat = np.linalg.svd(choi_mat, full_matrices=False)
         kraus_0 = [


### PR DESCRIPTION
## Description
This commit fixes an oversight in `choi_to_kraus` where we failed to build correctly the right Kraus operators for non-positive hermitian-preserving channels. (we forgot to discard small eigenvalues!!)

## Status
-  [x] Ready to go