### PR TITLE
Is unextendible product basis

### DIFF
--- a/docs/states.rst
+++ b/docs/states.rst
@@ -73,6 +73,7 @@ Properties of Quantum States
     toqito.state_props.is_ppt
     toqito.state_props.is_product
     toqito.state_props.is_pure
+    toqito.state_props.is_unextendible_product_basis
     toqito.state_props.l1_norm_coherence
     toqito.state_props.log_negativity
     toqito.state_props.negativity

--- a/tests/test_state_props/test_is_unextendible_product_basis.py
+++ b/tests/test_state_props/test_is_unextendible_product_basis.py
@@ -1,0 +1,142 @@
+"""Test is_unextendible_product_basis."""
+
+import numpy as np
+import pytest
+
+from toqito.state_props.is_unextendible_product_basis import (
+    is_unextendible_product_basis,
+)
+from toqito.matrix_ops import tensor
+from toqito.matrix_ops import inner_product
+
+
+def Tiles():
+    """Constructs Tiles UPB."""
+    tiles_A = np.zeros([3, 5])
+    tiles_A[:, 0] = [1, 0, 0]
+    tiles_A[:, 1] = [1 / np.sqrt(2), -1 / np.sqrt(2), 0]
+    tiles_A[:, 2] = [0, 0, 1]
+    tiles_A[:, 3] = [0, 1 / np.sqrt(2), -1 / np.sqrt(2)]
+    tiles_A[:, 4] = [1 / np.sqrt(3), 1 / np.sqrt(3), 1 / np.sqrt(3)]
+
+    tiles_B = np.zeros([3, 5])
+    tiles_B[:, 0] = [1 / np.sqrt(2), -1 / np.sqrt(2), 0]
+    tiles_B[:, 1] = [0, 0, 1]
+    tiles_B[:, 2] = [0, 1 / np.sqrt(2), -1 / np.sqrt(2)]
+    tiles_B[:, 3] = [1, 0, 0]
+    tiles_B[:, 4] = [1 / np.sqrt(3), 1 / np.sqrt(3), 1 / np.sqrt(3)]
+
+    return [tiles_A, tiles_B]
+
+
+def GenShifts(parties: int):
+    """Constructs GenShifts UPB for odd number of parties."""
+    if (parties % 2 == 0) or parties == 1:
+        raise ValueError("Input must be an odd int greater than 1.")
+
+    k = int((parties + 1) / 2)
+    num_states = 2 * k
+    upb = [np.zeros([2, num_states]) for _ in range(parties)]
+    angles = [(i / k) * np.pi / 2 for i in range(2 * k - 1, k, -1)]
+    local_states = [[np.cos(angle), np.sin(angle)] for angle in angles]
+    orth_angles = [(i / k) * np.pi / 2 for i in range(1, k)]
+    orth_local_states = [[np.cos(angle), np.sin(angle)] for angle in orth_angles]
+
+    state_list = []
+    state_list.append([0, 1])
+    state_list.extend(local_states)
+    state_list.extend(orth_local_states)
+
+    for party in upb:
+        party[:, 0] = [1, 0]
+
+    for state in range(1, num_states):
+        for i, party in enumerate(upb):
+            party[:, state] = state_list[i]
+        state_list = state_list[-1:] + state_list[:-1]
+
+    return upb
+
+
+def test_is_unextendible_product_basis_input_empty_list():
+    """Empty list as input."""
+    with np.testing.assert_raises(ValueError):
+        empty_list = []
+        is_unextendible_product_basis(empty_list)
+
+
+def test_is_unextendible_product_basis_input_not_numpy_arrays():
+    """List elements are not type numpy.ndarray."""
+    with np.testing.assert_raises(ValueError):
+        list_of_listarrays = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
+        is_unextendible_product_basis(list_of_listarrays)
+
+
+def test_is_unextendible_product_basis_input_arrays_not_two_dimensional():
+    """Arrays are not two-dimensional."""
+    with np.testing.assert_raises(ValueError):
+        array_1D = np.array([1, 2, 3, 4])
+        input = [array_1D, array_1D]
+        is_unextendible_product_basis(input)
+
+
+def test_is_unextendible_product_basis_input_arrays_not_same_num_columns():
+    """Arrays do not have the same number of columns"""
+    with np.testing.assert_raises(ValueError):
+        array_1 = np.array([[1, 2], [3, 4]])
+        array_2 = np.array([[1], [3]])
+        input = [array_1, array_2]
+        is_unextendible_product_basis(input)
+
+
+def test_is_unextendable_product_basis_tiles():
+    """Verify if Tiles UPB is a UPB"""
+    res = is_unextendible_product_basis(Tiles())
+    expected_res = [True, None]
+    np.testing.assert_array_equal(res, expected_res)
+
+
+@pytest.mark.parametrize("num_states", [1, 2, 3, 4])
+def test_is_unextendable_product_basis_tiles_remove_states_false(num_states):
+    """Check if Tiles UPB fails to be a UPB when 1, 2, 3, and 4 states are removed."""
+    tiles = Tiles()
+    res = is_unextendible_product_basis(
+        [tiles[0][0:, 0:num_states], tiles[1][:, 0:num_states]]
+    )
+    expected_res = False
+    np.testing.assert_equal(res[0], expected_res)
+
+
+@pytest.mark.parametrize("num_states", [1, 2, 3, 4])
+def test_is_unextendable_product_basis_tiles_remove_states_orthogonal_witness(
+    num_states,
+):
+    """Check if witness is orthogonal to Tiles UPB when 1, 2, 3, and 4 states are removed."""
+    tiles = Tiles()
+    witness = is_unextendible_product_basis(
+        [tiles[0][:, 0:num_states], tiles[1][:, 0:num_states]]
+    )[1]
+    witness_product = tensor(witness[0], witness[1])
+    # Perhaps we can use `toqito.state_props.is_mutually_orthogonal` to test orthogonallity
+    inner_product_list = []
+    for i in range(num_states):
+        UPB_state_product = tensor(
+            np.array([tiles[0][:, i]]).T, np.array([tiles[1][:, i]]).T
+        )
+        ip = inner_product(witness_product[:, 0], UPB_state_product[:, 0])
+        inner_product_list.append(ip)
+    res = inner_product_list
+    expected_res = [0] * num_states
+    np.testing.assert_array_almost_equal(res, expected_res)
+
+
+@pytest.mark.parametrize("num_parties", [3, 5, 7])
+def test_is_unextendable_product_basis_tiles_GenShifts(num_parties):
+    """Verify if GenShifts UPB is a UPB for 3, 5, and, 7 parties"""
+    res = is_unextendible_product_basis(GenShifts(num_parties))
+    expected_res = [True, None]
+    np.testing.assert_array_equal(res, expected_res)
+
+
+if __name__ == "__main__":
+    np.testing.run_module_suite()

--- a/tests/test_state_props/test_is_unextendible_product_basis.py
+++ b/tests/test_state_props/test_is_unextendible_product_basis.py
@@ -95,41 +95,51 @@ def test_is_unextendable_product_basis_tiles():
     expected_res = [True, None]
     np.testing.assert_array_equal(res, expected_res)
 
-
+# Test parameter ranges over number of states removed out of 5 original Tiles UPB states.
 @pytest.mark.parametrize("num_states", [1, 2, 3, 4])
 def test_is_unextendable_product_basis_tiles_remove_states_false(num_states):
     """Check if Tiles UPB fails to be a UPB when 1, 2, 3, and 4 states are removed."""
     tiles = Tiles()
-    res = is_unextendible_product_basis(
-        [tiles[0][0:, 0:num_states], tiles[1][:, 0:num_states]]
-    )
+    # Remove some number of states from the Tiles UPB.
+    tiles_with_states_removed  = [tiles[0][0:, 0:num_states], tiles[1][:, 0:num_states]]
+    res = is_unextendible_product_basis(tiles_with_states_removed)
+    # We expect these to not be a valid UPB.
     expected_res = False
     np.testing.assert_equal(res[0], expected_res)
 
-
+# Test parameter ranges over number of states removed out of 5 original Tiles UPB states.
 @pytest.mark.parametrize("num_states", [1, 2, 3, 4])
 def test_is_unextendable_product_basis_tiles_remove_states_orthogonal_witness(
     num_states,
 ):
     """Check if witness is orthogonal to Tiles UPB when 1, 2, 3, and 4 states are removed."""
     tiles = Tiles()
-    witness = is_unextendible_product_basis(
-        [tiles[0][:, 0:num_states], tiles[1][:, 0:num_states]]
-    )[1]
+    # Remove some number of states from the Tiles UPB.
+    tiles_with_states_removed  = [tiles[0][0:, 0:num_states], tiles[1][:, 0:num_states]]
+    # Get the returned witness state.
+    witness = is_unextendible_product_basis(tiles_with_states_removed)[1]
+    # Construct the global tensor product of the witness state.
     witness_product = tensor(witness[0], witness[1])
-    # Perhaps we can use `toqito.state_props.is_mutually_orthogonal` to test orthogonallity
+    # Here we construct a list of the inner products of the witness with each input Tiles state.
+    # Perhaps we can use `toqito.state_props.is_mutually_orthogonal` to test orthogonallity.
     inner_product_list = []
+    # Loop over the input Tiles states.
     for i in range(num_states):
-        UPB_state_product = tensor(
+        # Construct the global tensor product of the Tiles state.
+        # Is there a less convoluted way to do this?
+        tiles_product_state = tensor(
             np.array([tiles[0][:, i]]).T, np.array([tiles[1][:, i]]).T
         )
-        ip = inner_product(witness_product[:, 0], UPB_state_product[:, 0])
+        # Calculate the inner product of the witness state with the Tiles state.
+        ip = inner_product(witness_product[:, 0], tiles_product_state[:, 0])
+        # Add the inner product to the list.
         inner_product_list.append(ip)
     res = inner_product_list
+    # We expect all inner products to be zero since the witness state should be orthogonal.
     expected_res = [0] * num_states
     np.testing.assert_array_almost_equal(res, expected_res)
 
-
+# Test parameter ranges over number of parties of the UPB, which must be odd integer greatar than 1.
 @pytest.mark.parametrize("num_parties", [3, 5, 7])
 def test_is_unextendable_product_basis_tiles_GenShifts(num_parties):
     """Verify if GenShifts UPB is a UPB for 3, 5, and, 7 parties"""

--- a/tests/test_state_props/test_is_unextendible_product_basis.py
+++ b/tests/test_state_props/test_is_unextendible_product_basis.py
@@ -51,6 +51,15 @@ def tiles_local_state_list():
         \end{align*}
 
     Here, these local collections :math:`\mathcal{C}_i1 of states are represented as two dimensional arrays of type `numpy.ndarray`, where the :math:`j1-th column of each array defines the local state :math:`|\varphi_{i,j}\rangle1 of the respective party. In this way, each array has the same number of columns corresponding to the number of product states :math:`n`.
+    
+    References
+    ==========
+    ..  [Ben99] Bennett, Charles H., et al.
+        "Unextendible product bases and bound entanglement."
+        Physical Review Letters 82.26 (1999): 5385.
+        https://arxiv.org/abs/quant-ph/9808030
+
+    :return: A list of arrays representing the local states of each party.
     """
     tiles_A = np.zeros([3, 5])
     tiles_A[:, 0] = [1, 0, 0]
@@ -71,7 +80,7 @@ def tiles_local_state_list():
 
 def genshifts_local_state_list(parties: int):
     """
-    Returns a list of arrays representing the local states of the GenShifts UPB (unextendible product basis) for an odd number of parties. DiV00.
+    Returns a list of arrays representing the local states of the GenShifts UPB (unextendible product basis) for an odd number of parties. [Div00].
 
     The GenShifts UPBs are a family of UPBs defined for an odd number :math:`m\geq 3` of parties each holding a qubit:
     
@@ -94,7 +103,7 @@ def genshifts_local_state_list(parties: int):
     With the exception of the first state :math:`|\Psi_0\rangle = |0, 0, \dots, 0\rangle`, the rest of the states are given by right-shifted cyclic permutations of :math:`|\Psi_1\rangle`.
 
 
-    In 'toqito', the particular choices made for the local states :math:`|\psi_j\rangle` and :math:`\psi_j^\perp\rangle` matches the implementation given in `QETLAB` (citeQETLAB). To be precise, consider the qubit states parameterized by an angle value
+    In :code:'toqito', the particular choices made for the local states :math:`|\psi_j\rangle` and :math:`\psi_j^\perp\rangle` matches the implementation given in QETLAB [Joh16]. To be precise, consider the qubit states parameterized by an angle value
 
     .. math::
         |\theta(j)\rangle = \cos(j\frac{\pi}{2k})|0\rangle + \sin(j\frac{\pi}{2k})|1\rangle.
@@ -120,6 +129,20 @@ def genshifts_local_state_list(parties: int):
         \end{align*}
 
     where :math:`|+\rangle = \frac{1}{\sqrt{2}}(|0\rangle + |1\rangle)` and :math:`|-\rangle = \frac{1}{\sqrt{2}}(|0\rangle - |1\rangle)`.
+    
+    References
+    ==========
+    ..  [Div00] DiVincenzo, David P., et al.
+        "Unextendible Product Bases, Uncompletable Product Bases and Bound Entanglement."
+        Communications in Mathematical Physics volume 238, (2003)
+        https://arxiv.org/abs/quant-ph/9908070v3
+    .. [Joh16] Nathaniel Johnston.
+        "QETLAB: A MATLAB toolbox for quantum entanglement"
+        http://www.qetlab.com
+        
+    :raises ValueError: If input is not an odd integer greater than 1.
+    :param num_parties: The number of parties of the UPB.
+    :return: A list of arrays representing the local states of each party.
     """
     if (parties % 2 == 0) or parties == 1:
         raise ValueError("Input must be an odd int greater than 1.")

--- a/tests/test_state_props/test_is_unextendible_product_basis.py
+++ b/tests/test_state_props/test_is_unextendible_product_basis.py
@@ -7,10 +7,51 @@ from toqito.state_props.is_unextendible_product_basis import is_unextendible_pro
 from toqito.state_props.is_unextendible_product_basis import item_partitions
 from toqito.matrix_ops import tensor
 from toqito.matrix_ops import inner_product
+from toqito.state_props import is_mutually_orthogonal
+from numpy.linalg import matrix_rank
 
 
 def tiles_local_state_list():
-    """Constructs Tiles UPB."""
+    """
+    Returns a list of arrays representing the local states of the Tiles UPB (unextendible product basis) [Ben99]_.
+
+    The Tiles UPB is a set of $5$ pure product states of the bipartite qutrit space :math:`\mathbb{C}^3\otimes\mathbb{C}^3` given by:
+
+    .. math::
+        \begin{align*}
+        |\psi_0\rangle &= \tfrac{1}{\sqrt{2}}|0\rangle \otimes \left(|0\rangle - |1\rangle \right), \\
+        |\psi_1\rangle &= \tfrac{1}{\sqrt{2}}\left(|0\rangle - |1\rangle \right) \otimes |2\rangle, \\
+        |\psi_2\rangle &= \tfrac{1}{\sqrt{2}}|2\rangle \otimes \left(|1\rangle - |2\rangle \right), \\
+        |\psi_3\rangle &= \tfrac{1}{\sqrt{2}}\left(|1\rangle - |2\rangle \right) \otimes |0\rangle, \\
+        |\psi_4\rangle &= \tfrac{1}{3}\left(|0\rangle + |1\rangle + |2\rangle \right) \otimes \left(|0\rangle + |1\rangle + |2\rangle \right).
+        \end{align*}
+
+    The product states of the Tiles UPB can be factored into two sets, :math:`\mathcal{C}_0$ and $\mathcal{C}_1`, of local qutrit states over the biparition :math:`\mathbb{C}^3\otimes \mathbb{C}^3` as follows.
+
+    The first party has states :math:`\mathcal{C}_0 = \{|\varphi_{0,j}\rangle\}_j` in :math:`\mathbb{C}^3`:
+
+    .. math::
+        \begin{align*}
+        |\varphi_{0, 0}\rangle &= |0\rangle , \\
+        |\varphi_{0, 1}\rangle &= \tfrac{1}{\sqrt{2}}\left(|0\rangle - |1\rangle \right), \\
+        |\varphi_{0, 2}\rangle &= |2\rangle , \\
+        |\varphi_{0, 3}\rangle &= \tfrac{1}{\sqrt{2}}\left(|1\rangle - |2\rangle \right), \\
+        |\varphi_{0, 4}\rangle &= \tfrac{1}{\sqrt{3}}\left(|0\rangle + |1\rangle + |2\rangle \right).
+        \end{align*}
+
+    The second party has states :math:`\mathcal{C}_1 = \{|\varphi_{1,j}\rangle\}_j` in :math:`\mathbb{C}^3`:
+
+    .. math::
+        \begin{align*}
+        |\varphi_{1, 0}\rangle &= \tfrac{1}{\sqrt{2}}\left(|0\rangle - |1\rangle \right), \\
+        |\varphi_{1, 1}\rangle &= |2\rangle,  \\
+        |\varphi_{1, 1}\rangle &= \tfrac{1}{\sqrt{2}}\left(|1\rangle - |2\rangle \right), \\
+        |\varphi_{1, 3}\rangle &= |0\rangle, \\
+        |\varphi_{1, 4}\rangle &= \tfrac{1}{\sqrt{3}}\left(|0\rangle + |1\rangle + |2\rangle \right).
+        \end{align*}
+
+    Here, these local collections :math:`\mathcal{C}_i1 of states are represented as two dimensional arrays of type `numpy.ndarray`, where the :math:`j1-th column of each array defines the local state :math:`|\varphi_{i,j}\rangle1 of the respective party. In this way, each array has the same number of columns corresponding to the number of product states :math:`n`.
+    """
     tiles_A = np.zeros([3, 5])
     tiles_A[:, 0] = [1, 0, 0]
     tiles_A[:, 1] = [1 / np.sqrt(2), -1 / np.sqrt(2), 0]
@@ -29,7 +70,57 @@ def tiles_local_state_list():
 
 
 def genshifts_local_state_list(parties: int):
-    """Constructs GenShifts UPB for odd number of parties."""
+    """
+    Returns a list of arrays representing the local states of the GenShifts UPB (unextendible product basis) for an odd number of parties. DiV00.
+
+    The GenShifts UPBs are a family of UPBs defined for an odd number :math:`m\geq 3` of parties each holding a qubit:
+    
+    .. math::
+        \mathcal{H} = \bigotimes_{i=1}^{m} \mathbb{C}^2.
+
+    The GenShifts UPB for :math:`m=2k-1` parties contains $2k$ product states which are comprised of specially chosen local qubit states. Although there is some freedom in how to define these local states, they must satisfy the following property. These local qubit states, say :math:`|\psi_j\rangle1 for :math:`1\leq j\leq k-11, are chosen such that all are neither identical nor orthogonal to each other or the computational basis states :math:`|0\rangle` and :math:`|1\rangle`. Moreover, states :math:`|\psi_j^\perp\rangle` for :math:`1\leq j\leq k-1` are also chosen to be orthogonal to their respective pairs so that :math:`\langle \psi_j^\perp  |\psi_j\rangle = 0`.
+
+    Having made proper choices for states :math:`|\psi_j\rangle` and :math:`|\psi_j^\perp\rangle`, for :math:`1\leq j\leq k-1`, the product states of the GenShifts UPB for :math:`2k-1` parties are given by:
+
+    .. math::
+        \begin{align*}
+            |\Psi_0\rangle &= |0, 0, \dots, 0\rangle \\
+            |\Psi_1\rangle &= |1,\psi_1, \psi_2, \dots, \psi_{k-1}, \psi_{k-1}^\perp, \dots, \psi_{1}^\perp \rangle \\
+            |\Psi_2\rangle &= |\psi_{1}^\perp, 1,\psi_1, \psi_2, \dots, \psi_{k-1}, \psi_{k-1}^\perp, \dots, \psi_{2}^\perp \rangle \\
+            &\vdots \\
+            |\Psi_{2k-1}\rangle &= |\psi_1, \psi_2, \dots, \psi_{k-1}^\perp, \psi_{k-2}^\perp, \dots, \psi_{1}^\perp , 1\rangle, \\
+        \end{align*}
+
+    With the exception of the first state :math:`|\Psi_0\rangle = |0, 0, \dots, 0\rangle`, the rest of the states are given by right-shifted cyclic permutations of :math:`|\Psi_1\rangle`.
+
+
+    In 'toqito', the particular choices made for the local states :math:`|\psi_j\rangle` and :math:`\psi_j^\perp\rangle` matches the implementation given in `QETLAB` (citeQETLAB). To be precise, consider the qubit states parameterized by an angle value
+
+    .. math::
+        |\theta(j)\rangle = \cos(j\frac{\pi}{2k})|0\rangle + \sin(j\frac{\pi}{2k})|1\rangle.
+
+    Then the states :math:`|\theta(j)\rangle1 defined for integers values in the range :math:`1\leq j \leq 2k`, can be uniquely paired as orthogonal states :math:`|\psi_j\rangle` and :math:`|\psi_j^\perp\rangle` given as:
+
+    .. math::
+        \begin{align*}
+        |\psi_j\rangle &= |\theta(2k-j)\rangle, \\
+        |\psi_j^{\perp}\rangle &= |\theta(j)\rangle, 
+        \end{align*}
+
+    for :math:`1 \leq j \leq k-1`.
+
+    For example, in the case of :math:`3` parties the GenShifts UPB states are given by the following :math:`4` product states:
+
+    .. math::
+        \begin{align*}
+            |\Psi_0\rangle &= |0, 0, 0\rangle \\
+            |\Psi_1\rangle &= |1, -, + \rangle \\
+            |\Psi_2\rangle &= |+, 1, - \rangle \\
+            |\Psi_3\rangle &= |-, +, 1 \rangle, \\
+        \end{align*}
+
+    where :math:`|+\rangle = \frac{1}{\sqrt{2}}(|0\rangle + |1\rangle)` and :math:`|-\rangle = \frac{1}{\sqrt{2}}(|0\rangle - |1\rangle)`.
+    """
     if (parties % 2 == 0) or parties == 1:
         raise ValueError("Input must be an odd int greater than 1.")
 
@@ -55,6 +146,79 @@ def genshifts_local_state_list(parties: int):
         state_list = state_list[-1:] + state_list[:-1]
 
     return upb
+
+
+def test_tiles_mutually_orthogonal():
+    tiles = tiles_local_state_list()
+    tiles_product_state_list = []
+    for i in range(5):
+        tiles_product_state = tensor(
+            np.array([tiles[0][:, i]]).T, np.array([tiles[1][:, i]]).T
+        )
+        tiles_product_state_list.append(tiles_product_state)
+    res = is_mutually_orthogonal(tiles_product_state_list)
+    expected_res = True
+    np.testing.assert_equal(res, expected_res)
+
+
+def test_tiles_incomplete_span():
+    tiles = tiles_local_state_list()
+    tiles_product_state_matrix = np.zeros([9, 5])
+    for i in range(5):
+        tiles_product_state = tensor(
+            np.array([tiles[0][:, i]]).T, np.array([tiles[1][:, i]]).T
+        )
+        print(tiles_product_state, np.shape(tiles_product_state))
+        tiles_product_state_matrix[:, [i]] = tiles_product_state
+    rank = matrix_rank(tiles_product_state_matrix)
+    res = rank < 9
+    expected_res = True
+    np.testing.assert_equal(res, expected_res)
+
+
+# Test parameter ranges over number of parties of the UPB, which must be odd integer greatar than 1.
+@pytest.mark.parametrize("num_parties", [3, 5, 7])
+def test_genshifts_mutually_orthogonal(num_parties):
+    num_states = num_parties + 1
+    genshifts = genshifts_local_state_list(num_parties)
+    # Initialize a list to populate with global product states.
+    genshifts_product_state_list = []
+    for i in range(num_states):
+        # Initialize the global product state with first tensor factor.
+        genshifts_product_state = np.array([genshifts[0][:, i]]).T
+        # Tensor remaining parties' states.
+        for party in range(1, num_parties):
+            genshifts_product_state = tensor(
+                genshifts_product_state, np.array([genshifts[party][:, i]]).T
+            )
+        genshifts_product_state_list.append(genshifts_product_state)
+    res = is_mutually_orthogonal(genshifts_product_state_list)
+    expected_res = True
+    np.testing.assert_equal(res, expected_res)
+
+
+# Test parameter ranges over number of parties of the UPB, which must be odd integer greatar than 1.
+@pytest.mark.parametrize("num_parties", [3, 5, 7])
+def test_genshifts_incomplete_span(num_parties):
+    num_states = num_parties + 1
+    global_dim = 2**num_parties
+    genshifts = genshifts_local_state_list(num_parties)
+    # Initialize a matrix to populate with global product states.
+    genshifts_product_state_matrix = np.zeros([global_dim, num_states])
+    for i in range(num_states):
+        # Initialize the global product state with first tensor factor.
+        genshifts_product_state = np.array([genshifts[0][:, i]]).T
+        # Tensor remaining parties' states.
+        for party in range(1, num_parties):
+            genshifts_product_state = tensor(
+                genshifts_product_state, np.array([genshifts[party][:, i]]).T
+            )
+        # Set i-th colum of matrix to i-th global state.
+        genshifts_product_state_matrix[:, [i]] = genshifts_product_state
+    rank = matrix_rank(genshifts_product_state_matrix)
+    res = rank < global_dim
+    expected_res = True
+    np.testing.assert_equal(res, expected_res)
 
 
 def test_is_unextendible_product_basis_input_empty_list():

--- a/toqito/state_props/is_unextendible_product_basis.py
+++ b/toqito/state_props/is_unextendible_product_basis.py
@@ -23,22 +23,35 @@ def item_partitions(items: list, parts: int, sizes: list[int] = None) -> list:
     :return: A list of partitions.
     """
 
+    # Set optional argument default for the size of each part of the partition to be at least 1.
     if sizes == None:
         sizes = [1] * parts
 
+    # Trivial case when the number of parts of the partitions is 1.
     if parts == 1:
         return [[items]]
 
+    # Initialize and construct a list of partitions recusively.
     partitions = []
+    # Minimum and maximum number of choices for the first part of a partition.
     min_choices = sizes[0]
     max_choices = len(items) - sum(sizes[i] for i in range(1, parts))
     for j in range(min_choices, max_choices + 1):
+        # Start by choosing items for the first part of the partition.
         first_part = combinations(items, j)
+        # Loop over all possible choices for the first part.
         for part1 in first_part:
+            # Get the unchosen items from the first part.
             unchosen_items = list(set(items) - set(part1))
+            # Construct the remaining parts of the partition recursively.
+            # The other parts are another partition of the unchosen items with just one less parts.
+            # Remove the first item of the original sizes list.
             other_parts = item_partitions(unchosen_items, parts - 1, sizes[1:])
+            # Loop over all possible partitions for the second part of the partition.
             for part2 in other_parts:
+                # Construct full partition by adding the second part to the first part.
                 partition = [list(part1)] + part2
+                # Append the partition to the partitions list
                 partitions.append(partition)
     return partitions
 
@@ -83,60 +96,130 @@ def is_unextendible_product_basis(local_states_list: list[np.ndarray]):
         if not states.shape[1] == num_cols_first_party:
             raise ValueError("Input list arrays must have the same number of columns.")
 
+    # Number of parties of the UPB
     num_parties = len(local_states_list)
+    # Number of states of the UPB.
     num_states = local_states_list[0].shape[1]
+    # A list of local dimensions of respective parties.
     local_dimensions = [party.shape[0] for party in local_states_list]
+    # A list that indexes the states for constructing the partitions.
     state_index = [i for i in range(num_states)]
 
+    # Get a list of all permissibe partitions subject to local dimension constraints.
     partitions = item_partitions(
         state_index, num_parties, [dim - 1 for dim in local_dimensions]
     )
+    # The number of permissible partitions.
     num_partitions = len(partitions)
 
+    # The remaining code consists of two Blocks "A" and "B" coresponding to two different cases.
+    # Block "A" runs if there are no partitions to search.
+    # Block "B" runs if there are partitions to search.
+
+    # BLOCK "A" begins here.
+    # If there are no partitions, then we know it is not a UPB right away.
+    # The following block constructs a witness state
     if num_partitions == 0:
+        # Set the boolean for not a UPB
         isUPB = False
+        # Initialize a list of empty lists for each party which will contain a local state.
         orth_states = [[]] * num_parties
+        # Initialize a count for constructing the orthogonal witness state.
         num_orth_states = 0
+
+        # Loop over each party and construct a local state for the witness.
+        # Note: The loop range does not have to be reversed. 
+        # A different but valid wittness state is constructed either way.
+        # We loop in reverse here to match the QETLAB implementation.
         for party in reversed(range(num_parties)):
+            # The party's local witness state depends on if the count is less than the number of states.
             if num_orth_states >= num_states:
+                # In this case we trivially construct a computational basis vector.
                 orth_state = np.zeros((local_dimensions[party], 1))
                 orth_state[party][0] = 1
                 orth_states[party] = orth_state
             else:
+                # In this case we choose some input states for the party and find another orthogonal state as witness.
+                # Number of input states to choose
                 more_orth_states = min(
                     [local_dimensions[party] - 1, num_states - num_orth_states]
                 )
+                # A list of the state indices in the corresponding range.
                 local_choices = [num_orth_states + i for i in range(more_orth_states)]
+                # Get array of local states chosen by the party.
                 local_states = local_states_list[party][:, local_choices]
-                local_orth_states = null_space(local_states.T)
-                if local_orth_states.size == 0:
+                # Get the orthogonal complement of chosen local states using Scipy's linalg.null_space.
+                # Note: We transpose the array since the original arrays states are given by columns.
+                # The null_space() function returns a list of vectors that span the null space.
+                local_orth_space = null_space(local_states.T)
+                # Check if the null space trivial (0 dimensional) or not.
+                if local_orth_space.size == 0:
+                    # If so, append empty list for that party.
                     orth_states[party] = []
                 else:
-                    orth_states[party] = np.array([local_orth_states[:, 0]]).T
+                    # If the null space is not trivial, pick any state from the null space.
+                    # Here we just choose the first state returned in the null space basis.
+                    # We cast the state as a column vector of type numpy.ndarray.
+                    local_orth_state = np.array([local_orth_space[:, 0]]).T
+                    # Add the local state to the list.
+                    orth_states[party] = local_orth_state
+                # Increment the count.
                 num_orth_states += more_orth_states
+        # Set the returned witness variable to the constructed list of orthogonal states.
         witness = orth_states
+        # Return output.
         return (isUPB, witness)
+        # BLOCK "A" ends here.
 
+    # Block "B" starts here.
+    # Loop over all partitions.
     for partition in partitions:
+        # Initialize an empty list for the orthogonal witness state.
         orth_states = []
+        # Initialize a counter.
         num_orth_states = 1
+        # Loop over the local states of the respective parties.
         for party, states in enumerate(local_states_list):
+            # Choose state indices given by the party's part of the partition.
             local_choices = partition[party]
+            # Get array of the chosen states for the party
             local_states = states[:, local_choices]
-            local_orth_states = null_space(local_states.T)
-            if local_orth_states.size == 0:
+            # Get the orthogonal complement of chosen local states using Scipy's linalg.null_space.
+            # Note: We transpose the array since the original arrays states are given by columns.
+            # The null_space() function returns a list of vectors that span the null space.
+            local_orth_space = null_space(local_states.T)
+            # Check if the null space trivial (0 dimensional) or not.
+            if local_orth_space.size == 0:
+                # If so, there are no local orthogonal states for the party.
                 num_local_orth_states = 0
             else:
-                num_local_orth_states = local_orth_states.shape[1]
+                # Get the dimension of local orthogonal space.
+                num_local_orth_states = local_orth_space.shape[1]
+            # Increase the count.
+            # Note: We multiply since space dimensions are multiplicative over tensor products.
             num_orth_states *= num_local_orth_states
+            # Break our of the inner loop if there are no orthogonal states.
             if num_orth_states == 0:
                 break
-            orth_states.append(np.array([local_orth_states[:, 0]]).T)
+            # If the null space is not trivial, pick any state from the null space.
+            # Here we just choose the first state returned in the null space basis.
+            # We cast the state as a column vector of type numpy.ndarray.
+            local_orth_state = np.array([local_orth_space[:, 0]]).T
+            orth_states.append(local_orth_state)
+        # If there are orthogonal states, we have our counter example.
         if num_orth_states >= 1:
+            # Set the returned boolean for not a UPB.
             isUPB = False
+            # Set the returned witness variable to the constructed list of orthogonal states.
             witness = orth_states
+            # Return output.
             return (isUPB, witness)
 
+    # If we reach this point, we managed to search over all partitions without finding a counter example.
+    # Set the returned boolean for UPB.
     isUPB = True
+    # There is no witness in this case, so we return None.
     witness = None
+    # Return output.
     return (isUPB, witness)
+    # Block "B" ends here.

--- a/toqito/state_props/is_unextendible_product_basis.py
+++ b/toqito/state_props/is_unextendible_product_basis.py
@@ -1,0 +1,142 @@
+"""Check if a collection of states is an Unextendable Product Basis (UBP)."""
+
+from itertools import combinations
+import numpy as np
+from scipy.linalg import null_space
+
+
+def item_partitions(items: list, parts: int, sizes: list[int] = None) -> list:
+    r"""
+    Constructs all partitions of a given list into a specified number of parts with given sizes.
+
+    This function was adapted from QETLAB [Joh16]_.
+
+    References
+    ==========
+    .. [Joh16] Nathaniel Johnston.
+        "QETLAB: A MATLAB toolbox for quantum entanglement"
+        http://www.qetlab.com
+
+    :param items: The list of items to partition.
+    :param parts: The number of parts in the partition.
+    :param sizes: A list of positive integers specifying the minimum sizes of the parts.
+    :return: A list of partitions.
+    """
+
+    if sizes == None:
+        sizes = [1] * parts
+
+    if parts == 1:
+        return [[items]]
+
+    partitions = []
+    min_choices = sizes[0]
+    max_choices = len(items) - sum(sizes[i] for i in range(1, parts))
+    for j in range(min_choices, max_choices + 1):
+        first_part = combinations(items, j)
+        for part1 in first_part:
+            unchosen_items = list(set(items) - set(part1))
+            other_parts = item_partitions(unchosen_items, parts - 1, sizes[1:])
+            for part2 in other_parts:
+                partition = [list(part1)] + part2
+                partitions.append(partition)
+    return partitions
+
+
+def is_unextendible_product_basis(local_states_list: list[np.ndarray]):
+    r"""
+    Determine if a collection of states is an Unextendible Product Basis (UBP) [UPB99]_.
+
+    This function was adapted from QETLAB [Joh16]_.
+
+    References
+    ==========
+    ..  [UPB99] Bennett, Charles H., et al.
+        "Unextendible product bases and bound entanglement."
+        Physical Review Letters 82.26 (1999): 5385.
+        https://arxiv.org/abs/quant-ph/9808030
+    .. [Joh16] Nathaniel Johnston.
+        "QETLAB: A MATLAB toolbox for quantum entanglement"
+        http://www.qetlab.com
+
+    :raises ValueError: If list elements are not of type numpy.ndarray with two dimensions and the same number of columns.
+    :param local_states_list: The list of states to check.
+    :return: :code:`(True, None)` if states form an a UPB and :code:`(False, wittness)` otherwise.
+    """
+
+    # Input error handling
+    if len(local_states_list) == 0:
+        raise ValueError("Input must be a nonempty list.")
+    for party, states in enumerate(local_states_list):
+        if not isinstance(states, np.ndarray):
+            raise ValueError(
+                "Input list elements must be arrays of type numpy.ndarray."
+            )
+        if not len(states.shape) == 2:
+            raise ValueError("Input list arrays must be 2 dimensional.")
+        if states.shape[0] == 0 or states.shape[1] == 0:
+            raise ValueError(
+                "Input list arrays must have nonzero components in each dimension."
+            )
+        if party == 0:
+            num_cols_first_party = states.shape[1]
+        if not states.shape[1] == num_cols_first_party:
+            raise ValueError("Input list arrays must have the same number of columns.")
+
+    num_parties = len(local_states_list)
+    num_states = local_states_list[0].shape[1]
+    local_dimensions = [party.shape[0] for party in local_states_list]
+    state_index = [i for i in range(num_states)]
+
+    partitions = item_partitions(
+        state_index, num_parties, [dim - 1 for dim in local_dimensions]
+    )
+    num_partitions = len(partitions)
+
+    if num_partitions == 0:
+        isUPB = False
+        orth_states = [[]] * num_parties
+        num_orth_states = 0
+        for party in reversed(range(num_parties)):
+            if num_orth_states >= num_states:
+                orth_state = np.zeros((local_dimensions[party], 1))
+                orth_state[party][0] = 1
+                orth_states[party] = orth_state
+            else:
+                more_orth_states = min(
+                    [local_dimensions[party] - 1, num_states - num_orth_states]
+                )
+                local_choices = [num_orth_states + i for i in range(more_orth_states)]
+                local_states = local_states_list[party][:, local_choices]
+                local_orth_states = null_space(local_states.T)
+                if local_orth_states.size == 0:
+                    orth_states[party] = []
+                else:
+                    orth_states[party] = np.array([local_orth_states[:, 0]]).T
+                num_orth_states += more_orth_states
+        witness = orth_states
+        return (isUPB, witness)
+
+    for partition in partitions:
+        orth_states = []
+        num_orth_states = 1
+        for party, states in enumerate(local_states_list):
+            local_choices = partition[party]
+            local_states = states[:, local_choices]
+            local_orth_states = null_space(local_states.T)
+            if local_orth_states.size == 0:
+                num_local_orth_states = 0
+            else:
+                num_local_orth_states = local_orth_states.shape[1]
+            num_orth_states *= num_local_orth_states
+            if num_orth_states == 0:
+                break
+            orth_states.append(np.array([local_orth_states[:, 0]]).T)
+        if num_orth_states >= 1:
+            isUPB = False
+            witness = orth_states
+            return (isUPB, witness)
+
+    isUPB = True
+    witness = None
+    return (isUPB, witness)

--- a/toqito/state_props/is_unextendible_product_basis.py
+++ b/toqito/state_props/is_unextendible_product_basis.py
@@ -5,9 +5,65 @@ import numpy as np
 from scipy.linalg import null_space
 
 
-def item_partitions(items: list, parts: int, sizes: list[int] = None) -> list:
+def item_partitions(items: list, num_parts: int, sizes: list[int] = None) -> list[list]:
     r"""
-    Constructs all partitions of a given list into a specified number of parts with given sizes.
+    Constructs all partitions of a given list into a specified number of parts, with each part of a partition having a specified minimum size.
+
+    A partition of a set :math:`S` into :math:`p` parts is defined as a collection of :math:`p` disjoint sets :math:`P_1, P_2, ..., P_p` such that the union covers the full set :math:`P`:
+
+    .. math::
+        S = P_1 \cup P_2 \cup ... \cup P_p.
+
+    In this context, we call the subsets :math:`P_i` the "parts" of the partition of :math:`S`, and the number of elements of a part :math:`P_i` is called the "size" of a part :math:`P_i`.
+
+    Here, a partition of :math:`S` into :math:`p` parts is represented as a ordered list of unordered lists. Members of the ordered outer list index the parts :math:`P_1, P_2, ..., P_p` of the partition, and the 
+    unordered inner lists correspond to a particular part :math:`P_i`.  For instance, consider the set :math:`S =\{1,2,3\}`. Then the following are some (but not all) examples of valid partitions:
+
+    .. math::
+        \begin{align*}
+        A &= [ [1], [2,3,4] ], \\
+        B &= [ [1], [3,4,2] ], \\
+        C &= [ [1,2], [3,4] ], \\
+        D &= [ [3,4], [1,2] ], \\
+        \end{align*}
+
+    where partitions :math:`A` and :math:`B` represent the same partition, but partitions :math:`C` and :math:`D` are distinct.
+
+    The following demonstrates usage of :code:`item_partitions()` in various cases.
+
+    Construct all partitions of the list :math`[1, 2, 3]` with :math`2` parts:
+    
+    >>> # List of items to partition.
+    >>> my_list = [1,2,3]
+    >>> # Number of parts in the partition.
+    >>> num_parts = 2
+    >>> # Construct all partitions having 2 parts
+    >>> partitions = item_partitions(my_list, 2)
+    [[[1], [2, 3]], [[2], [1, 3]], [[3], [1, 2]], [[1, 2], [3]], [[1, 3], [2]], [[2, 3], [1]]]
+
+    Construct all partitions of the list :math`[1, 2, 3]` with :math`2` parts, and with the first part having size at least :math`2`:
+
+    >>> # List of items to partition.
+    >>> my_list = [1,2,3]
+    >>> # Number of parts in the partition.
+    >>> num_parts = 2
+    >>> # List of minimum sizes for respective parts.
+    >>> sizes = [2,2]
+    >>> # Construct all partitions having 2 parts with at least 2 items in the first part.
+    >>> partitions = item_partitions(my_list, 2, [2,1])
+    [[[1, 2], [3]], [[1, 3], [2]], [[2, 3], [1]]]
+
+    Constructing all partitions of the list :math`[1, 2, 3]` with :math`2` parts, and with both part having size at least :math`2` returns an empty list. This is because there are fewer items in the input list than demanded by the part size constraints: 
+
+    >>> # List of items to partition.
+    >>> my_list = [1,2,3]
+    >>> # Number of parts in the partition.
+    >>> num_parts = 2
+    >>> # List of minimum sizes for respective parts.
+    >>> sizes = [2,2]
+    >>> # Construct all partitions having 2 parts with at least 2 items each part.
+    >>> partitions = item_partitions(my_list, 2, [2,2])
+    []
 
     This function was adapted from QETLAB [Joh16]_.
 
@@ -17,25 +73,42 @@ def item_partitions(items: list, parts: int, sizes: list[int] = None) -> list:
         "QETLAB: A MATLAB toolbox for quantum entanglement"
         http://www.qetlab.com
 
-    :param items: The list of items to partition.
-    :param parts: The number of parts in the partition.
-    :param sizes: A list of positive integers specifying the minimum sizes of the parts.
+    :raises ValueError: If input `num_parts` or list elements of input `sizes` are not positive integers.
+    :param items: A list of unique items to partition.
+    :param numparts: The number of parts in the partition.
+    :param sizes: A optional list of positive integers specifying the minimum sizes of the parts. If no argument is provided, the minimum size of each part is 1.
     :return: A list of partitions.
     """
 
+
+
+    # Input error handling
+    if not isinstance(num_parts, int) or num_parts < 1:
+        raise ValueError("Input `parts` must be a positive integer.")
+    
     # Set optional argument default for the size of each part of the partition to be at least 1.
     if sizes == None:
-        sizes = [1] * parts
+        sizes = [1] * num_parts
+
+    # More input error handling
+    if len(sizes) == 0:
+        raise ValueError("Input `sizes` can not be an empty list.")
+    if len(sizes) < num_parts:
+        raise ValueError("Input `sizes` list must have length `num_parts`.")     
+    for size in sizes:
+        if not isinstance(size, int) or size < 1:
+            raise ValueError("Input `sizes` list must contain only positive integers.")
+
 
     # Trivial case when the number of parts of the partitions is 1.
-    if parts == 1:
+    if num_parts == 1:
         return [[items]]
 
     # Initialize and construct a list of partitions recusively.
     partitions = []
     # Minimum and maximum number of choices for the first part of a partition.
     min_choices = sizes[0]
-    max_choices = len(items) - sum(sizes[i] for i in range(1, parts))
+    max_choices = len(items) - sum(sizes[i] for i in range(1, num_parts))
     for j in range(min_choices, max_choices + 1):
         # Start by choosing items for the first part of the partition.
         first_part = combinations(items, j)
@@ -46,7 +119,7 @@ def item_partitions(items: list, parts: int, sizes: list[int] = None) -> list:
             # Construct the remaining parts of the partition recursively.
             # The other parts are another partition of the unchosen items with just one less parts.
             # Remove the first item of the original sizes list.
-            other_parts = item_partitions(unchosen_items, parts - 1, sizes[1:])
+            other_parts = item_partitions(unchosen_items, num_parts - 1, sizes[1:])
             # Loop over all possible partitions for the second part of the partition.
             for part2 in other_parts:
                 # Construct full partition by adding the second part to the first part.
@@ -56,15 +129,126 @@ def item_partitions(items: list, parts: int, sizes: list[int] = None) -> list:
     return partitions
 
 
-def is_unextendible_product_basis(local_states_list: list[np.ndarray]):
+def is_unextendible_product_basis(local_states_list: list[np.ndarray]) -> tuple[bool, list[np.ndarray] | None]:
     r"""
-    Determine if a collection of states is an Unextendible Product Basis (UBP) [UPB99]_.
+    Determine if a collection of pure states is an Unextendible Product Basis (UBP) [Ben99]_.
+
+    A UPB is a set of mutually orthogonal product states spanning a proper subspace of a multipartite system whose complementary subspace contains no product state.
+        
+    Let :math:`\mathcal{H} = \bigotimes_{i=1}^{m} \mathcal{H}_{i}` be an :math:`m`-party system, where :math:`\mathcal{H}_{i} = \mathbb{C}^{d_i}` is a complex Euclidean space of dimension :math:`d_i` of the :math:`i`-th party. Consider a collection :math:`\mathcal{C}=\{|\psi_j\rangle\}_j` of product states of :math:`\mathcal{H}1 expressed as
+
+    .. math::
+        \begin{align*}
+        |\psi_j\rangle = \bigotimes_{i=1}^{m} |\varphi_{i,j}\rangle,
+        \end{align*}
+
+    where :math:`|\varphi_{i,j}\rangle \in \mathcal{H}_i` are local states belonging to the :math:`i`-th party. Then then collection :math:`\mathcal{C}` is a UPB if the following hold.
+
+    (i) The states are mutually orthogonal:
+
+    .. math::
+        \langle \psi_j\|\psi_k\rangle = 0 \text{ if} j \neq k.
+
+    (ii) The states span a proper subspace:
+
+    .. math::
+        \mathcal{H}_\mathcal{C} = span(|\psi_j\rangle))  \subset \mathcal{H}.
+
+    (iii) The complementary subspace contains no product state:
+
+    .. math::
+    |\psi\rangle \in \mathcal{H} - \mathcal{H}_\mathcal{C} \implies |\psi\rangle \text{ is entangled.} 
+
+
+    Examples
+    ==========
+
+    For example, the Tiles UPB is a set of :math:`5` states in the bipartite qutrit space :math:`\mathbb{C}^3\otimes \mathbb{C}^3` given by:
+
+    .. math::
+        \begin{align*}
+        |\psi_0\rangle &= \tfrac{1}{\sqrt{2}}|0\rangle \otimes \left(|0\rangle - |1\rangle \right), \\
+        |\psi_1\rangle &= \tfrac{1}{\sqrt{2}}\left(|0\rangle - |1\rangle \right) \otimes |2\rangle, \\
+        |\psi_2\rangle &= \tfrac{1}{\sqrt{2}}|2\rangle \otimes \left(|1\rangle - |2\rangle \right), \\
+        |\psi_3\rangle &= \tfrac{1}{\sqrt{2}}\left(|1\rangle - |2\rangle \right) \otimes |0\rangle, \\
+        |\psi_4\rangle &= \tfrac{1}{3}\left(|0\rangle + |1\rangle + |2\rangle \right) \otimes \left(|0\rangle + |1\rangle + |2\rangle \right).
+        \end{align*}
+
+    The product states of the Tiles UPB can be factored into two sets, :math:`\mathcal{C}_0` and :math:`\mathcal{C}_1`, of local qutrit states over the biparition :math:`\mathbb{C}^3\otimes \mathbb{C}^3` as follows.
+
+    The first party has states :math:`\mathcal{C}_0 = \{|\varphi_{0,j}\rangle\}_j` in :math:`\mathbb{C}^3`:
+
+    .. math::
+        \begin{align*}
+        |\varphi_{0, 0}\rangle &= |0\rangle , \\
+        |\varphi_{0, 1}\rangle &= \tfrac{1}{\sqrt{2}}\left(|0\rangle - |1\rangle \right), \\
+        |\varphi_{0, 2}\rangle &= |2\rangle , \\
+        |\varphi_{0, 3}\rangle &= \tfrac{1}{\sqrt{2}}\left(|1\rangle - |2\rangle \right), \\
+        |\varphi_{0, 4}\rangle &= \tfrac{1}{\sqrt{3}}\left(|0\rangle + |1\rangle + |2\rangle \right).
+        \end{align*}
+
+    The second party has states :math:`\mathcal{C}_1 = \{|\varphi_{1,j}\rangle\}_j` in :math:`\mathbb{C}^3`:
+
+    .. math::
+        \begin{align*}
+        |\varphi_{1, 0}\rangle &= \tfrac{1}{\sqrt{2}}\left(|0\rangle - |1\rangle \right), \\
+        |\varphi_{1, 1}\rangle &= |2\rangle,  \\
+        |\varphi_{1, 1}\rangle &= \tfrac{1}{\sqrt{2}}\left(|1\rangle - |2\rangle \right), \\
+        |\varphi_{1, 3}\rangle &= |0\rangle, \\
+        |\varphi_{1, 4}\rangle &= \tfrac{1}{\sqrt{3}}\left(|0\rangle + |1\rangle + |2\rangle \right).
+        \end{align*}
+
+    When using :code:`toqito` to determine if a collection of :math:`n` product states :math:`\mathcal{C}=\{|\psi_j\rangle\}_j` of a :math:`m`-party system is a UPB, the states in question must be provided as an ordered list of :math:`m` local collections :math:`\mathcal{C}_i=\{|\varphi_{i,j}\rangle\}_j` comprising each of the product state's local factors (as shown above for the Tiles UPB). 
+
+    The particular data structure used here to represent the local collections :math:`\mathcal{C}_i` of states are two dimensional arrays of type `numpy.ndarray`, where the :math:`j`-th column of each array defines the local state :math:`|\varphi_{i,j}\rangle` of the respective party. In this way, each array has the same number of columns corresponding to the number of product states :math:`n`. Moreover, the array representing the local collection :math:`\mathcal{C}_i` of the :math:`i`-th party must have :math:`d_i` many rows corresponding to the local dimension :math:`d_i` of the :math:`i`-th party.
+
+    Below we verify that the Tiles states are indeed a UPB.
+
+    >>> # Array for the first party's local states of Tiles UPB.
+    >>> C_0 = np.array( [[1,  1/np.sqrt(2), 0,             0, 1/np.sqrt(3)],
+    >>>                 [0, -1/np.sqrt(2), 0,  1/np.sqrt(2), 1/np.sqrt(3)],
+    >>>                 [0,             0, 1, -1/np.sqrt(2), 1/np.sqrt(3)]]
+    >>>                 )
+    >>> # Array for the second party's local states of Tiles UPB.
+    >>> C_1 = np.array( [[ 1/np.sqrt(2), 0,             0, 1,  1/np.sqrt(3)],
+    >>>                 [-1/np.sqrt(2), 0,  1/np.sqrt(2), 0, 1/np.sqrt(3)],
+    >>>                 [            0, 1, -1/np.sqrt(2), 0,  1/np.sqrt(3)]]
+    >>>                 )
+    >>> # Construct list of local states of all parties.
+    >>> tiles = [C_0, C_1]
+    >>> # Verify Tiles is a UPB.
+    >>> isUPB, witness = is_unextendible_product_basis(tiles)
+    (True, None)
+
+    If any number of states from the Tiles UPB are removed, then the remaining collection of states is no longer a UPB. Here we demonstrate this by removing the :math:`5`-th state from the Tiles UPB.
+
+    >>> # Remove the 5th state from the Tiles UPB
+    >>> tiles_state_removed = [C_0[:, 0:4], C_1[:, 0:4]]
+    >>> # Verify Tiles with a state removed is not a UPB.
+    >>> isUPB, witness = is_unextendible_product_basis(tiles_state_removed)
+    (False, [array([[0.],
+                    [0.],
+                    [1.]]),
+             array([[1.11022302e-16],
+                    [7.07106781e-01],
+                    [7.07106781e-01]])] )
+         
+    When it exists, the witness state returned is given as an ordered list of column vectors defining a local state for the respective party. The product state resulting from tensoring the local states together is orthogonal to all product states of the input collection. 
+
+    In the example above the output witness is (within numerical precision) given by the two local states :math:`|\phi_0\rangle = |2\rangle` and :math:`|\phi_1\rangle = \frac{1}{\sqrt{2}}(|1\rangle + |2\rangle)` that produce the product state
+
+    .. math::
+        |\phi\rangle = \tfrac{1}{\sqrt{2}} |2\rangle \otimes \left(|1\rangle + |2\rangle \right),
+
+    which is orthogonal to all input states considered.
+
+    Note that the when a witness state exists it in general not unique, and the implementation used here only returns one particular reproducible state.
 
     This function was adapted from QETLAB [Joh16]_.
 
     References
     ==========
-    ..  [UPB99] Bennett, Charles H., et al.
+    ..  [Ben99] Bennett, Charles H., et al.
         "Unextendible product bases and bound entanglement."
         Physical Review Letters 82.26 (1999): 5385.
         https://arxiv.org/abs/quant-ph/9808030


### PR DESCRIPTION
## Description
Adds a new feature: "Is UPB (unextendible product basis)" requested in #33 .

The implementation closely follows the one given in QETLAB: [IsUPB](https://qetlab.com/IsUPB).
The function decides `True` or `False` if the input is a UPB or not, and when `False` also returns a witness state which is a product state orthogonal to all states of the non-UPB. Note that the existence of a witness state is in general not unique, and that our implementation returns just one particular reproducible example. 

The main function has the following signature:
`is_unextendible_product_basis(local_states_list: list[np.ndarray]): -> (isUPB, witness)`

([View the DOCSTRING here on this comment](https://github.com/vprusso/toqito/pull/175#issuecomment-1588115488))
(Note: Some minor formatting changes were made to conform to GitHub markdown, but otherwise this is the docstring verbatim)

**Input:**

The input `local_states_list` specifies the supposed UPB as a list of 2D arrays of type `numpy.ndarray`, whose length corresponds to the number of parties with each party associated to its corresponding list index.  Each array corresponds to that respective parties local states comprising the UPB, with the number of rows of each array corresponding to the local dimension of that party. The number of columns of each array must be identical and corresponds to the number of product states in the UPB.
In this way, the k-th product state of the UPB is constructed by taking the tensor product of the local states given by the k-th column of each array.

* (1?) The form this input is specified following the same convention made in the QETLAB implementation. This form is just fine in my opinion, but we can consider other forms.  Same goes for the form of the output `witness` state when it exists. For example, instead of represented the input local states as column vectors of the arrays, we can do row vectors. If anything would maybe amount to like 2 - 4 less lines of code i think!
*  (1.1?) Another important point to consider is representing the input product states in this factored "local form" VS "global form". Although a bit contrived, the "local form" we require as input in this implementation guarantees that the states conform to the parties product structure. Otherwise, if we allow input to be expresssed in a more general "global form" what guarantees that the input actually has the appropriate product structure? I need to think a bit more about how the implementation would need to be modified... We could check for the product structure within the function's implementation, but that would require hard separability tests in general. Perhaps we can consider this optional functionality and give the user the option of specifying the input states in "local form" vs "global form". 

**Return:**

The function returns a Tuple of the form `(isUPB, witness)`.
Here `isUPB` is a boolean which is `True` if the input is a UPB, and `False` otherwise.
If `isUPB` is `True`, then `witness` is `None`.
If  `isUPB` is `False`, then `witness` is a list containing a local state for each party. The product state resulting from taking the tensor product of all the local states in `witness` is orthogonal to all the  nonUPB input states.

**Comments for helper function:**

The main function `is_unextendible_product_basis()` makes use of a helper function named `item_partitions()` also contained in the module `toqito/state_props/is_unextendible_product_basis.py`, which is based off the  QETLAB function [`vec_partitions()`](https://qetlab.com/vec_partitions).
* (2?) Should this helper function `item_partitions()` be moved into its own file from the main module `is_unextendible_product_basis.py`, and  with a separate test file to test it?

In regards to the functions complexity (not too sure about this) i think non poly time and space comes from searching through a stored list of permissible partitions, which is constructed with a single call of the helper function `item_partitions()`. The relevant problem size parameter in this context is "the number of product states of the UPB" in question, which corresponds to the "number of items" we partition. In general this list would be huge for a relatively small number of items, say 10 - 30. However in practice,  the main function `is_unextendible_product_basis()` calls the helper `item_partitions()` with partition size constraints which typically makes the list of partitions smaller (not sure by how much though).
* (3?) Perhaps there is a way to improve space performance here. Already, in the implementation of `item_partitions()` I took advantage of Python's `itertools.combinations` to use an iterator for the loop over relevant item combinations. Does it make sense, or is it even possible, to also implement `item_partitions()` as some type of custom Python "Generator" or "Iterator" object? (Please excuse my ignorance here!). Regarding time complexity,  it seems necessary to iterate through the permissible partitions. So I am not sure how to speed this up unless we come up with a more clever way of eliminating permissible partitions.


**Testing Methodology:**

Currently all new tests are in a single file  `tests/test_state_props/test_is_unextendible_product_basis.py`. ~~Tests for the helper function `item_paritions()` still need to be written in either the same or different file. ~~

My testing of the function `is_unextendible_product_basis()` is quite extensive but can maybe still be improved. In particular, there are several tests for verifying a `ValueError` is raised upon invalid input. 
* (4?) The input error handling implemented in the function `is_unextendible_product_basis()` seems excessive and can maybe be consolidated. 

To test UPB properties I used two main cases of UPBs: Tiles and GenShifts described further below (and in [this paper](https://arxiv.org/abs/quant-ph/9908070v3)).
These two UPBs are constructed in the  functions `tiles_local_state_list()` and `genshifts_local_state_list()` defined in the same test file `test_is_unextendible_product_basis.py`.
* (5?) Is it worth moving the functions into their own module files in `toqito/states`, and writing docs and unit tests for them? _EDIT:_ I noticed there is already a file `toqito/states/tile.py',  but that function returns the states in global form and this UPB implementation requires the local state factors as input. So maybe we can add optional functionality to return the states in a desired form: either"local" or "global". 

Tiles is a 5 state UPB of two parties each holding a qutrit. A unit test verifies this case.
If any number of product states from Tiles is removed, the set is no longer a UPB.
Unit tests are done to check Tiles for each of these cases with 1, 2, 3, and 4 states removed.
For each case, the generated witness is tested to be orthogonal to each input product state of the nonUPB.
The TIles UPB (with states removed) are good test cases, because they cover all the control flow branches of the function's implementation. This includes the positive case when `is_unextendible_product_basis()`returns `(True, None)`, and two instances of the negative case when `(False, witness)` returned. These two negative cases correspond to whether or not there are any permissible partitions to search through, and the returned `witness` is constructed differently depending on the case.

GenShifts is a family of UPBs of a m-party system (with odd m >=3 ) each consisting of a qubit, that has a m+1 product states in its UPB. Unit tests verify this in the case of 3, 5, and 7 parties. Note that there is freedom in specifying the exact form of the local states involved in this UPB, but ours follows the same choice used in the QETLAB implementation. (I can add details about this representation in the functions TODO docstring.)
The GenShifts UPB family is a good test case, because it allows to test our implementation with variable number of parties (not just 2 parties as in the Tiles UPB).


**Files added:**
1) `toqito/state_props/is_unextendible_product_basis.py`
2) `tests/test_state_props/test_is_unextendible_product_basis.py`

**Files modified:**
1) `docs/states.rst`

## Todos
(A) Things that still need to be done:
  -  [x] Add more thorough docstrings with theory and code examples.
           (I am having some issues viewing rendered docs, so I am concerned of typos)
  -  [x] Add inline code commentary for sake of explanation
  -  [x] Write unit tests for helper function `item_partitions()`
          (These tests are all in the same file: `test_is_unextendible_product_basis.py` )
          (Hopefully sufficient, but maybe even excessive, but whatever ... they are easy to delete!)

(B) Things that maybe should be done:
  -  [ ] (1?) Discuss if we are satisfied with the form of functions input and output.
  -  [ ] (2?) Move the helper function `item_partitions` into its own file from the main module `is_unextendible_product_basis.py`, ~~and write tests/docs for it~~.
  -  [ ] (3?) Improve algorithm performance by improving performance of `item_partitions()`.
  -  [ ] (4?) Improve input error handling of `is_unextendible_product_basis()`.
  -  [ ] (5?) Move the functions `tiles_local_state_list()` and `genshifts_local_state_list()` in  `test_is_unextendible_product_basis.py` that construct the Tiles and GenShifts UPBs into the folder `toqito/states`, and ~~write unit tests/docs for them~~.


## Questions
-  [ ] Pease advise regarding Todos (B).

## Status
-  [x] Ready to go