### PR TITLE
Add is_unextendible_product_basis()

### DIFF
--- a/docs/states.rst
+++ b/docs/states.rst
@@ -73,6 +73,7 @@ Properties of Quantum States
     toqito.state_props.is_ppt
     toqito.state_props.is_product
     toqito.state_props.is_pure
+    toqito.state_props.is_unextendible_product_basis
     toqito.state_props.l1_norm_coherence
     toqito.state_props.log_negativity
     toqito.state_props.negativity

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ keywords = ["quantum information", "quantum computing", "nonlocal games"]
 python = "^3.9"
 cvxpy = "^1.2.1"
 cvxopt = "^1.2.5"
+more-itertools = "^9.1.0"
 numpy = "^1.19.4"
 scipy = "^1.8.0"
 #scs = "^2.1.2"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-requirements = ["cvx", "cvxpy", "numpy", "picos", "scipy", "scikit-image"]
+requirements = ["cvx", "cvxpy", "more-itertools", "numpy", "picos", "scipy", "scikit-image"]
 
 setuptools.setup(
     name="toqito",

--- a/tests/test_state_props/test_is_unextendible_product_basis.py
+++ b/tests/test_state_props/test_is_unextendible_product_basis.py
@@ -12,37 +12,41 @@ def test_is_unextensible_product_state_non_product_state():
     np.testing.assert_raises(ValueError, is_unextendible_product_basis, bell_states, dims)
 
 def test_is_unextensible_product_state_wrong_size():
+    """Check if exception raised if size of a vector does not match product of dims."""
     bell_states = [bell(i) for i in range(4)]
     dims = [2, 3]
     np.testing.assert_raises(ValueError, is_unextendible_product_basis, bell_states, dims)
 
 def test_is_unextensible_product_state_small_set():
+    """Check if correct answer returned when there are too few vectors."""
     ket_0 = basis(2,0)
     ket_1 = basis(2,1)
     ket_plus = (ket_0 + ket_1) / np.sqrt(2)
     ket_minus = (ket_0 - ket_1) / np.sqrt(2)
     # {|0, 1, +>, |1, +, 0>, |+, 0, 1>, |−, −, −>}
     vec_1 = tensor([ket_0, ket_1, ket_plus])
-    vec_2 = tensor([ket_1, ket_plus, ket_0])
     vec_4 = tensor([ket_minus, ket_minus, ket_minus])
-    vecs = [vec_1, vec_2, vec_3, vec_4]
+    vecs = [vec_1, vec_4]
     dims = [2, 2, 2]
     res = is_unextendible_product_basis(vecs, dims)
     np.assert_equal(res[0], False)
 
 def test_is_unextensible_product_state_tiles_5():
+    """Check if Tiles[0, 1, 2, 3, 4] is correctly identified as UPB."""
     upb_tiles = [tile(i) for i in range(5)]
     dims = [3, 3]
     res = is_unextendible_product_basis(upb_tiles, dims)
     np.assert_equal(res[0], True)
 
 def test_is_unextensible_product_state_tiles_4():
+    """Check if Tiles[0, 1, 2, 3] is correctly identified as non-UPB."""
     non_upb_tiles = [tile(i) for i in range(4)]
     dims = [3, 3]
     res = is_unextendible_product_basis(non_upb_tiles, dims)
     np.assert_equal(res[0], False)
 
 def test_is_unextensible_product_state_pyramid():
+    """Check if Pyramid is correctly identified as UPB."""
     N = 2 / np.sqrt(5 + np.sqrt(5))
     h = np.sqrt(1 + np.sqrt(5)) / 2
     vecs = N * np.array([
@@ -56,6 +60,7 @@ def test_is_unextensible_product_state_pyramid():
     np.assert_equal(res[0], False)
 
 def test_is_unextensible_product_state_shifts():
+    """Check if Shifts is correctly identified as UPB."""
     ket_0 = basis(2, 0)
     ket_1 = basis(2, 1)
     ket_plus = (ket_0 + ket_1) / np.sqrt(2)

--- a/tests/test_state_props/test_is_unextendible_product_basis.py
+++ b/tests/test_state_props/test_is_unextendible_product_basis.py
@@ -1,0 +1,74 @@
+"""Test is_unextendible_product_basis."""
+import numpy as np
+
+from toqito.state_props import is_unextendible_product_basis
+from toqito.states import bell, basis
+from toqito.matrix_ops import tensor
+
+def test_is_unextensible_product_state_non_product_state():
+    """Check if exception raised if non-product state is passed."""
+    bell_states = [bell(i) for i in range(4)]
+    dims = [2, 2]
+    np.testing.assert_raises(ValueError, is_unextendible_product_basis, bell_states, dims)
+
+def test_is_unextensible_product_state_wrong_size():
+    bell_states = [bell(i) for i in range(4)]
+    dims = [2, 3]
+    np.testing.assert_raises(ValueError, is_unextendible_product_basis, bell_states, dims)
+
+def test_is_unextensible_product_state_small_set():
+    ket_0 = basis(2,0)
+    ket_1 = basis(2,1)
+    ket_plus = (ket_0 + ket_1) / np.sqrt(2)
+    ket_minus = (ket_0 - ket_1) / np.sqrt(2)
+    # {|0, 1, +>, |1, +, 0>, |+, 0, 1>, |−, −, −>}
+    vec_1 = tensor([ket_0, ket_1, ket_plus])
+    vec_2 = tensor([ket_1, ket_plus, ket_0])
+    vec_4 = tensor([ket_minus, ket_minus, ket_minus])
+    vecs = [vec_1, vec_2, vec_3, vec_4]
+    dims = [2, 2, 2]
+    res = is_unextendible_product_basis(vecs, dims)
+    np.assert_equal(res[0], False)
+
+def test_is_unextensible_product_state_tiles_5():
+    upb_tiles = [tile(i) for i in range(5)]
+    dims = [3, 3]
+    res = is_unextendible_product_basis(upb_tiles, dims)
+    np.assert_equal(res[0], True)
+
+def test_is_unextensible_product_state_tiles_4():
+    non_upb_tiles = [tile(i) for i in range(4)]
+    dims = [3, 3]
+    res = is_unextendible_product_basis(non_upb_tiles, dims)
+    np.assert_equal(res[0], False)
+
+def test_is_unextensible_product_state_pyramid():
+    N = 2 / np.sqrt(5 + np.sqrt(5))
+    h = np.sqrt(1 + np.sqrt(5)) / 2
+    vecs = N * np.array([
+        basis(3, 0) * np.cos(2 * np.pi * j / 5) +
+        basis(3, 1) * np.sin(2 * np.pi * j / 5) +
+        basis(3, 2) * h for j in range(5)
+    ])
+    phis = [tensor(vecs[j], vecs[(2 * j) % 5]) for j in range(5)]
+    dims = [3, 3]
+    res = is_unextendible_product_basis(phis, dims)
+    np.assert_equal(res[0], False)
+
+def test_is_unextensible_product_state_shifts():
+    ket_0 = basis(2, 0)
+    ket_1 = basis(2, 1)
+    ket_plus = (ket_0 + ket_1) / np.sqrt(2)
+    ket_minus = (ket_0 - ket_1) / np.sqrt(2)
+    # {|0, 1, +>, |1, +, 0>, |+, 0, 1>, |−, −, −>}
+    vec_1 = tensor([ket_0, ket_1, ket_plus])
+    vec_2 = tensor([ket_1, ket_plus, ket_0])
+    vec_3 = tensor([ket_plus, ket_0, ket_1])
+    vec_4 = tensor([ket_minus, ket_minus, ket_minus])
+    vecs = [vec_1, vec_2, vec_3, vec_4]
+    dims = [2, 2, 2]
+    res = is_unextendible_product_basis(vecs, dims)
+    np.assert_equal(res, True)
+
+if __name__ == "__main__":
+    np.testing.run_module_suite()

--- a/toqito/state_props/__init__.py
+++ b/toqito/state_props/__init__.py
@@ -19,3 +19,4 @@ from toqito.state_props.in_separable_ball import in_separable_ball
 from toqito.state_props.is_separable import is_separable
 from toqito.state_props.has_symmetric_extension import has_symmetric_extension
 from toqito.state_props.sk_vec_norm import sk_vector_norm
+from toqito.state_props.is_unextendible_product_basis import is_unextendible_product_basis

--- a/toqito/state_props/is_product.py
+++ b/toqito/state_props/is_product.py
@@ -103,7 +103,7 @@ def _is_product(rho: np.ndarray, dim: int | list[int] = None) -> list[int, bool]
         if ipv:
             ipv, tdec = _is_product(dec[0], [dim[0], dim[1]])
             if ipv:
-                dec = [tdec, dec[1:]]
+                dec = [*tdec, *dec[1:]]
     return ipv, dec
 
 

--- a/toqito/state_props/is_unextendible_product_basis.py
+++ b/toqito/state_props/is_unextendible_product_basis.py
@@ -12,7 +12,11 @@ def is_unextendible_product_basis(vecs: np.ndarray, dims: np.ndarray, return_wit
     r"""
     Check if a set of vectors form an unextendible product basis (UPB) [UPB99]_.
 
-    
+    Consider a multipartite quantum system :math:`\mathfrak{H} = \bigotimes_{i=1}^{m} \mathfrak{H}_{i}
+    with :math:`m` parties with respective dimensions :math:`d_i, i=1,2,..,m`. An (incomplete orthogonal)
+    product basis (PB) is a set :math:`S` of pure orthogonal product states spanning a proper subspace
+    :math:`H_S` of :math:`H`. An unextendible product basis (UPB) is a PB whose complementary subspace
+    :math:`H_S-H` contains no product state.
 
     This function is inspired from :code:`IsUPB` in QETLAB.
 

--- a/toqito/state_props/is_unextendible_product_basis.py
+++ b/toqito/state_props/is_unextendible_product_basis.py
@@ -13,13 +13,13 @@ def is_unextendible_product_basis(vecs: list | np.ndarray, dims: list | np.ndarr
     r"""
     Check if a set of vectors form an unextendible product basis (UPB) [UPB99]_.
 
-    Consider a multipartite quantum system :math:`\mathfrak{H} = \bigotimes_{i=1}^{m} \mathfrak{H}_{i}
+    Consider a multipartite quantum system :math:`\mathcal{H} = \bigotimes_{i=1}^{m} \mathcal{H}_{i}`
     with :math:`m` parties with respective dimensions :math:`d_i, i=1,2,..,m`. An (incomplete orthogonal)
     product basis (PB) is a set :math:`S` of pure orthogonal product states spanning a proper subspace
-    :math:`H_S` of :math:`H`. An unextendible product basis (UPB) is a PB whose complementary subspace
-    :math:`H_S-H` contains no product state.
+    :math:`\mathcal{H}_S` of :math:`\mathcal{H}`. An unextendible product basis (UPB) is a PB whose
+    complementary subspace :math:`\mathcal{H}_S-\mathcal{H}` contains no product state.
 
-    This function is inspired from :code:`IsUPB` in QETLAB.
+    This function is inspired from `IsUPB <https://qetlab.com/IsUPB>`_ in QETLAB.
 
     Examples
     ==========

--- a/toqito/state_props/is_unextendible_product_basis.py
+++ b/toqito/state_props/is_unextendible_product_basis.py
@@ -1,0 +1,114 @@
+import numpy as np
+from scipy.linalg import null_space
+
+from itertools import permutations
+from more_itertools import set_partitions
+
+from toqito.state_props import is_product
+from toqito.matrix_ops import tensor
+
+
+def is_unextendible_product_basis(vecs: np.ndarray, dims: np.ndarray, return_witness: bool = False) -> tuple[bool, np.ndarray | None]:
+    r"""
+    Check if a set of vectors form an unextendible product basis (UPB) [UPB99]_.
+
+    
+
+    This function is inspired from :code:`IsUPB` in QETLAB.
+
+    Examples
+    ==========
+
+    See :func:`toqito.states.tile`.
+
+    All the states together form a UPB:
+
+    >>> import numpy as np
+    >>> from toqito.states import tile
+    >>> from toqito.state_props import is_unextendible_product_basis
+    >>> upb_tiles = np.array([tile(i) for i in range(5)])
+    >>> dims = np.array([3, 3])
+    >>> is_unextendible_product_basis(upb_tiles, dims)
+    (True, None)
+
+    However, the first 4 do not:
+
+    >>> import numpy as np
+    >>> from toqito.states import tile
+    >>> from toqito.state_props import is_unextendible_product_basis
+    >>> non_upb_tiles = np.array([tile(i) for i in range(4)])
+    >>> dims = np.array([3, 3])
+    >>> is_unextendible_product_basis(non_upb_tiles, dims, return_witness=True)
+    (False, array([-0.00000000e+00,  0.00000000e+00,  0.00000000e+00, -0.00000000e+00,
+        0.00000000e+00,  0.00000000e+00, -1.11022302e-16,  7.07106781e-01,
+        7.07106781e-01]))
+
+    The orthogonal state is given by
+
+    .. math::
+        \frac{1}{\sqrt{2}} |2\rangle \left( |1\rangle + |2\rangle \right)
+
+    References
+    ==========
+    .. [UPB99] Bennett, Charles H., et al.
+        "Unextendible product bases and bound entanglement."
+        Physical Review Letters 82.26 (1999): 5385.
+        https://arxiv.org/abs/quant-ph/9808030
+
+    :param vecs: The list of basis vectors.
+    :param dims: The list of dimensions.
+    :param return_witness: Return a witness if :code:`True` and input is not a UPB.
+                           Return :code:`None` otherwise. 
+    """
+    # Some error handling:
+    if np.prod(dims) != vecs.shape[1]:
+        raise ValueError("Product of dimensions does not equal the size of each vector")
+
+    if not all(is_product(vec, dims)[0] for vec in vecs):
+        raise ValueError("At least one vector is not a product state")
+    
+    # Number of parties (m)
+    num_parties = dims.shape[0]
+
+    # Number of vectors (n)
+    num_vecs = vecs.shape[0]
+
+    # If n<m vectors are provided, then we cannot generate set partitions,
+    # so it is not a UPB. We will extend the set with m-n null vectors and
+    # run the same algorithm.
+    if num_vecs < num_parties:
+        vecs = np.append(vecs, np.zeros(shape=(num_parties - num_vecs, *vecs.shape[1:])), axis=0)
+        num_vecs = vecs.shape[0]
+
+    # Split products
+    vecs_split = np.array([is_product(vec, dims)[1] for vec in vecs])
+
+    # Acquire generator to m-partitions of [0,n-1]
+    parts_unordered = set_partitions(list(range(num_vecs)), num_parties)
+
+    for part_unordered in parts_unordered:
+        for part_ordered in permutations(part_unordered):
+            # Witness vectors
+            wit = []
+            witness_found = True
+            for i in range(num_parties):
+                # For the i-th party, acquire the matrix
+                mat = np.stack([vecs_split[col , i, :] for col in part_ordered[i]])
+                # Find the basis of the null space
+                null_basis = null_space(mat)
+                # If null space is empty then break
+                if null_basis.shape[1] == 0:
+                    witness_found = False
+                    break
+                # If null space is non-empty, add a basis vector of null space to witness
+                wit.append(null_basis[:, 0])
+            # If witness was found, then it is not a UPB, return tensor product of witness vectors
+            if witness_found:
+                if return_witness:
+                    return (False, tensor(wit))
+                else:
+                    return (False, None)
+    
+    # If no witness was found, it is a UPB
+    return (True, None)
+


### PR DESCRIPTION
## Description
Adding a function for checking if a set of vectors is an unextendible product basis (UPB). Resolves #33.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  -  [x] Fixed a bug in `is_product` for more than 2 elements in `dims`. It didn't unpack the results after recursion properly.
  -  [x] Added `is_unextensible_product_basis` and related documentation and tests.
  -  [ ] Complete and check documentation
  -  [ ] Check type hints

## Drawbacks
  -  Introduces a dependency on `more-itertools` for the function `set_partitions` used in implementing `is_unextensible_product_basis`.

## Status
-  [ ] Ready to go