### PR TITLE
Ensure compatibility of black and flake8 (#180)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+extend-ignore = E203


### PR DESCRIPTION
The config file for flake8has been added. The rule E203 is now excluded to ensure compatibility of black and flake8.