### PR TITLE
Doc Build Warnings

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -50,3 +50,11 @@ Quantum State Exclusion
    :maxdepth: 5
 
    tutorials.state_exclusion
+
+Superdense Coding
+-----------------------
+
+.. toctree::
+   :maxdepth: 5
+
+   tutorials.superdense_coding

--- a/toqito/channel_metrics/completely_bounded_spectral_norm.py
+++ b/toqito/channel_metrics/completely_bounded_spectral_norm.py
@@ -11,16 +11,15 @@ def completely_bounded_spectral_norm(phi: np.ndarray) -> float:
 
     References
     ==========
-
     .. [WatSDP09]:   Watrous, John.
-    "Semidefinite Programs for Completely Bounded Norms"
-    Theory of Computing, 2009
-    http://theoryofcomputing.org/articles/v005a011/v005a011.pdf
+        "Semidefinite Programs for Completely Bounded Norms"
+        Theory of Computing, 2009
+        http://theoryofcomputing.org/articles/v005a011/v005a011.pdf
 
     .. [NJ]: Nathaniel Johnston. QETLAB:
-    A MATLAB toolbox for quantum entanglement, version 0.9.
-    https://github.com/nathanieljohnston/QETLAB/blob/master/CBNorm.m
-    http://www.qetlab.com, January 12, 2016. doi:10.5281/zenodo.44637
+        A MATLAB toolbox for quantum entanglement, version 0.9.
+        https://github.com/nathanieljohnston/QETLAB/blob/master/CBNorm.m
+        http://www.qetlab.com, January 12, 2016. doi:10.5281/zenodo.44637
 
     :param phi: superoperator
     :return: The completely bounded spectral norm of the channel

--- a/toqito/channel_metrics/completely_bounded_trace_norm.py
+++ b/toqito/channel_metrics/completely_bounded_trace_norm.py
@@ -9,8 +9,9 @@ from toqito.matrix_props import trace_norm
 
 def completely_bounded_trace_norm(phi: np.ndarray) -> float:
     r"""
-    Compute the completely bounded trace norm / diamond norm of a quantum channel [WatCBNorm18].
-    The algorithm in p.11 of [WatSDP12] with implementation in QETLAB [JohQET] is used.
+    Compute the completely bounded trace norm / diamond norm of a quantum
+    channel [WatCNorm18]_. The algorithm in p.11 of [WatSDP09] with
+    implementation in QETLAB [JohQET] is used.
 
     References
     ==========

--- a/toqito/channel_metrics/completely_bounded_trace_norm.py
+++ b/toqito/channel_metrics/completely_bounded_trace_norm.py
@@ -16,17 +16,17 @@ def completely_bounded_trace_norm(phi: np.ndarray) -> float:
     References
     ==========
     .. [WatCNorm18] : Watrous, John.
-    “The theory of quantum information.” Section 3.3.2: “The completely bounded trace norm”.
-    Cambridge University Press, 2018.
+        “The theory of quantum information.” Section 3.3.2: “The completely bounded trace norm”.
+        Cambridge University Press, 2018.
 
     .. [WatSDP09]:   Watrous, John.
-    "Simpler semidefinite programs for completely bounded norms"
-    https://arxiv.org/pdf/1207.5726.pdf
+        "Simpler semidefinite programs for completely bounded norms"
+        https://arxiv.org/pdf/1207.5726.pdf
 
     .. [JohQET]: Nathaniel Johnston. QETLAB:
-    A MATLAB toolbox for quantum entanglement, version 0.9.
-    https://github.com/nathanieljohnston/QETLAB/blob/master/DiamondNorm.m
-    http://www.qetlab.com, January 12, 2016. doi:10.5281/zenodo.44637
+        A MATLAB toolbox for quantum entanglement, version 0.9.
+        https://github.com/nathanieljohnston/QETLAB/blob/master/DiamondNorm.m
+        http://www.qetlab.com, January 12, 2016. doi:10.5281/zenodo.44637
 
     :raises ValueError: If matrix is not square.
     :param phi: superoperator as choi matrix

--- a/toqito/channel_metrics/fidelity_of_separability.py
+++ b/toqito/channel_metrics/fidelity_of_separability.py
@@ -16,12 +16,12 @@ def fidelity_of_separability(
     psi: np.ndarray, psi_dims: list[int], k: int = 1, verbosity_option=2, solver_option="cvxopt"
 ) -> float:
     r"""
-    Define the first benchmark introduced in Appendix I of [Phil23]_ .
+    Define the first benchmark introduced in Appendix I of [Phil23.1]_ .
 
     If you would like to instead use the benchmark introduced in Appendix H,
     go to :obj:`toqito.state_metrics.fidelity_of_separability`.
 
-    In [Phil23]_ a variational quantum algorithm (VQA) is introduced to test
+    In [Phil23.1]_ a variational quantum algorithm (VQA) is introduced to test
     the separability of a general bipartite state. The algorithm utilizes
     quantum steering between two separated systems such that the separability
     of the state is quantified.
@@ -30,13 +30,13 @@ def fidelity_of_separability(
     optimization semidefinite programs (SDP) benchmarks were introduced to
     maximize the fidelity of separability subject to some state constraints
     (Positive Partial Transpose (PPT), symmetric extensions (k-extendibility
-    ) [Hay12]_ ). Entangled states do not have k-symmetric extensions. If an
+    ) [Hay12.1]_ ). Entangled states do not have k-symmetric extensions. If an
     extension exists, it cannot be assumed directly that the state is
     separable. This function approximites the fidelity of separability by
     maximizing over PPT channels & k-extendible entanglement breaking channels
-    i.e. an optimization problem over channels [TBWat18]_ .
+    i.e. an optimization problem over channels [TBWat18.1]_ .
 
-    The following expression (Equation (I4) from [Phil23]_ ) defines the
+    The following expression (Equation (I4) from [Phil23.1]_ ) defines the
     constraints for approximating
     :math:`\frac{1}{2}(1+\widetilde{F}_s^2(\rho_{AB})) {:}=`
 
@@ -67,7 +67,7 @@ def fidelity_of_separability(
     :math:`\mathcal{P}_{A^{\prime k}}` is the permutation operator over
     k-extensions :math:`A^{\prime k}`.
 
-    The other constraints are due to the PPT condition [Per96]_.
+    The other constraints are due to the PPT condition [Per96.1]_.
 
     Examples
     ==========
@@ -95,20 +95,20 @@ def fidelity_of_separability(
 
     References
     ==========
-    .. [Hay12] Hayden, Patrick et.al.
+    .. [Hay12.1] Hayden, Patrick et.al.
         "Two-message quantum interactive proofs and the quantum separability problem."
         Proceedings of the 28th IEEE Conference on Computational Complexity, pages 156-167.
         https://arxiv.org/abs/1211.6120
 
-    .. [Per96] Peres, Asher.
+    .. [Per96.1] Peres, Asher.
         "Separability Criterion for Density Matrices"
         https://arxiv.org/abs/quant-ph/9604005
 
-    .. [Phil23] Philip, Aby et.al.
+    .. [Phil23.1] Philip, Aby et.al.
         "Quantum Steering Algorithm for Estimating Fidelity of Separability"
         https://arxiv.org/abs/2303.07911
 
-    .. [TBWat18] Watrous, John.
+    .. [TBWat18.1] Watrous, John.
         “The Theory of Quantum Information”
         Cambridge University Press, 2018
 

--- a/toqito/matrices/standard_basis.py
+++ b/toqito/matrices/standard_basis.py
@@ -3,16 +3,19 @@ import numpy as np
 
 
 def standard_basis(dim: int, flatten: bool = False) -> list[np.ndarray]:
-    """Create standard basis of dimension `dim`.
+    """Create standard basis of dimension :code:`dim`.
 
     Create a list containing the elements of the standard basis for the
     given dimension:
-    |1> = (1, 0, 0, ..., 0)^T
-    |2> = (0, 1, 0, ..., 0)^T
-    .
-    .
-    .
-    |n> = (0, 0, 0, ..., 1)^T
+
+    .. math::
+
+        |1> = (1, 0, 0, ..., 0)^T
+        |2> = (0, 1, 0, ..., 0)^T
+        .
+        .
+        .
+        |n> = (0, 0, 0, ..., 1)^T
 
     This function was inspired by:
     https://github.com/akshayseshadri/minimax-fidelity-estimation

--- a/toqito/matrix_ops/outer_product.py
+++ b/toqito/matrix_ops/outer_product.py
@@ -34,6 +34,7 @@ def outer_product(v1: np.ndarray, v2: np.ndarray) -> np.ndarray:
     ==========
     .. [WikOuter] Wikipedia: Outer Product
         https://en.wikipedia.org/wiki/Outer_product
+    
     :raises ValueError: Vector dimensions are mismatched.
     :param args: v1 and v2, both vectors of dimensions :math:`(n,1)` where :math:`n>1`.
     :return: The computed outer product."""

--- a/toqito/matrix_ops/outer_product.py
+++ b/toqito/matrix_ops/outer_product.py
@@ -5,6 +5,7 @@ import numpy as np
 def outer_product(v1: np.ndarray, v2: np.ndarray) -> np.ndarray:
     r"""
     Compute the outer product :math:`|v_1\rangle\langle v_2|` of two vectors.
+    [WikOuter]_
 
     The outer product is calculated as follows:
 

--- a/toqito/matrix_props/sk_norm.py
+++ b/toqito/matrix_props/sk_norm.py
@@ -36,7 +36,7 @@ def sk_operator_norm(
             \text{Schmidt - rank}(|w\rangle) \leq k
         \Big\}
 
-    Since computing the exact value of S(k)-norm is in the general case
+    Since computing the exact value of S(k)-norm [2]_ is in the general case
     an intractable problem, this function tries to find some good lower and
     upper bounds. You can control the amount of computation you want to
     devote to computing the bounds by `effort` input argument. Note that if

--- a/toqito/state_metrics/hilbert_schmidt_inner_product.py
+++ b/toqito/state_metrics/hilbert_schmidt_inner_product.py
@@ -4,7 +4,7 @@ import numpy as np
 
 def hilbert_schmidt_inner_product(a_mat: np.ndarray, b_mat: np.ndarray) -> complex:
     r"""
-    Compute the Hilbert-Schmidt inner product between two matrices [WikHSO].
+    Compute the Hilbert-Schmidt inner product between two matrices [WikHSO]_.
 
     The Hilbert-Schmidt inner product between :code:`a_mat` and :code:`b_mat` is
     defined as

--- a/toqito/state_props/is_npt.py
+++ b/toqito/state_props/is_npt.py
@@ -12,7 +12,7 @@ def is_npt(mat: np.ndarray, sys: int = 2, dim: int | list[int] = None, tol: floa
 
     Yields either :code:`True` or :code:`False`, indicating that :code:`mat` does or does not have
     negative partial transpose (within numerical error). The variable :code:`mat` is assumed to act
-    on bipartite space.
+    on bipartite space. [NPT]_
 
     A state has negative partial transpose if it does not have positive partial transpose.
 

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -21,6 +21,7 @@ def is_separable(
     Examples
     ==========
     Consider the following separable (by construction) state:
+
     .. math::
         \rho = \rho_1 \otimes \rho_2.
         \rho_1 = \frac{1}{2} \left( |0 \rangle \langle 0| + |0 \rangle \langle 1| + |1 \rangle \langle 0| + |1 \rangle \langle 1| \right)


### PR DESCRIPTION
## Description
Fixes #152 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  -  [ ] TODO 1

## Questions for the future
-  [x] It might be better to have a reference file labeled `refs.bib` instead of manually inserting a reference list in docstrings of functions. 
- [ ] Why does a local `make html` add new files? Is there a way to build the documentation in a different way? Or should the instructions for contributors be updated that these files are to be ignored?
- [ ] Citation warnings in the docs build are not consistent. Sometimes `[some_ref]_` gets flagged as reference not found but other times `[some_ref_link]` does not get flagged as an error. This should be made consistent. 

## Status
-  [x] Ready to go