### PR TITLE
Attempt to fix deprecation for RTD.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@
 version: 2
 
 build:
-  image: testing
+  os: testing
   apt_packages:
     - libblas-dev
     - liblapack-dev


### PR DESCRIPTION
Fixes deprecation from https://blog.readthedocs.com/use-build-os-config/