### PR TITLE
Fix #478 : Rename shift and clock matrices to gen_pauli_x and gen_pauli_z

### DIFF
--- a/toqito/matrices/__init__.py
+++ b/toqito/matrices/__init__.py
@@ -1,6 +1,6 @@
 """Matrices."""
-from toqito.matrices.gen_pauli_z import gen_pauli_z
 from toqito.matrices.gen_pauli_x import gen_pauli_x
+from toqito.matrices.gen_pauli_z import gen_pauli_z
 from toqito.matrices.cnot import cnot
 from toqito.matrices.fourier import fourier
 from toqito.matrices.gell_mann import gell_mann

--- a/toqito/matrices/__init__.py
+++ b/toqito/matrices/__init__.py
@@ -1,6 +1,6 @@
 """Matrices."""
-from toqito.matrices.clock import clock
-from toqito.matrices.shift import shift
+from toqito.matrices.gen_pauli_z import gen_pauli_z
+from toqito.matrices.gen_pauli_x import gen_pauli_x
 from toqito.matrices.cnot import cnot
 from toqito.matrices.fourier import fourier
 from toqito.matrices.gell_mann import gell_mann

--- a/toqito/matrices/gen_pauli.py
+++ b/toqito/matrices/gen_pauli.py
@@ -1,7 +1,7 @@
 """Generalized Pauli matrices."""
 import numpy as np
 
-from toqito.matrices import clock, shift
+from toqito.matrices import gen_pauli_z, gen_pauli_x
 
 
 def gen_pauli(k_1: int, k_2: int, dim: int) -> np.ndarray:
@@ -9,7 +9,7 @@ def gen_pauli(k_1: int, k_2: int, dim: int) -> np.ndarray:
 
     Generates a :code:`dim`-by-:code:`dim` unitary operator. More specifically,
     it is the operator :math:`X^k_1 Z^k_2`, where :math:`X` and :math:`Z` are
-    the "shift" and "clock" operators that naturally generalize the Pauli X and
+    the "gen_pauli_x" and "gen_pauli_z" operators that naturally generalize the Pauli X and
     Z operators. These matrices span the entire space of
     :code:`dim`-by-:code:`dim` matrices as :code:`k_1` and :code:`k_2` range
     from 0 to :code:`dim-1`, inclusive.
@@ -71,8 +71,8 @@ def gen_pauli(k_1: int, k_2: int, dim: int) -> np.ndarray:
     :return: A generalized Pauli operator.
 
     """
-    gen_pauli_x = shift(dim)
-    gen_pauli_z = clock(dim)
+    gen_pauli_x = gen_pauli_x(dim)
+    gen_pauli_z = gen_pauli_z(dim)
 
     gen_pauli_w = np.linalg.matrix_power(gen_pauli_x, k_1) @ np.linalg.matrix_power(
         gen_pauli_z, k_2

--- a/toqito/matrices/gen_pauli.py
+++ b/toqito/matrices/gen_pauli.py
@@ -1,7 +1,7 @@
 """Generalized Pauli matrices."""
 import numpy as np
 
-from toqito.matrices import gen_pauli_z, gen_pauli_x
+from toqito.matrices import gen_pauli_x, gen_pauli_z
 
 
 def gen_pauli(k_1: int, k_2: int, dim: int) -> np.ndarray:
@@ -71,11 +71,9 @@ def gen_pauli(k_1: int, k_2: int, dim: int) -> np.ndarray:
     :return: A generalized Pauli operator.
 
     """
-    gen_pauli_x = gen_pauli_x(dim)
-    gen_pauli_z = gen_pauli_z(dim)
+    gpx_val = gen_pauli_x(dim)
+    gpz_val = gen_pauli_z(dim)
 
-    gen_pauli_w = np.linalg.matrix_power(gen_pauli_x, k_1) @ np.linalg.matrix_power(
-        gen_pauli_z, k_2
-    )
+    gen_pauli_w = np.linalg.matrix_power(gpx_val, k_1) @ np.linalg.matrix_power(gpz_val, k_2)
 
     return gen_pauli_w

--- a/toqito/matrices/gen_pauli_x.py
+++ b/toqito/matrices/gen_pauli_x.py
@@ -1,12 +1,12 @@
-"""Shift matrix."""
+"""Generalized Pauli-X matrix."""
 import numpy as np
 
 
-def shift(dim: int) -> np.ndarray:
-    r"""Produce a :code:`dim`-by-:code:`dim` shift matrix :cite:`WikiPauliGen`.
+def gen_pauli_x(dim: int) -> np.ndarray:
+    r"""Produce a :code:`dim`-by-:code:`dim` gen_pauli_x matrix :cite:`WikiPauliGen`.
 
-    Returns the shift matrix of dimension :code:`dim` described in :cite:`WikiPauliGen`.
-    The shift matrix generates the following :code:`dim`-by-:code:`dim` matrix:
+    Returns the gen_pauli_x matrix of dimension :code:`dim` described in :cite:`WikiPauliGen`.
+    The gen_pauli_x matrix generates the following :code:`dim`-by-:code:`dim` matrix:
 
     .. math::
         \Sigma_{1, d} = \begin{pmatrix}
@@ -18,13 +18,13 @@ def shift(dim: int) -> np.ndarray:
                         0 & 0 & 0 & \ldots & 1 & 0
                     \end{pmatrix}
 
-    The shift matrix is primarily used in the construction of the generalized
+    The gen_pauli_x matrix is primarily used in the construction of the generalized
     Pauli operators.
 
     Examples
     ==========
 
-    The shift matrix generated from :math:`d = 3` yields the following matrix:
+    The gen_pauli_x matrix generated from :math:`d = 3` yields the following matrix:
 
     .. math::
         \Sigma_{1, 3} =
@@ -34,8 +34,8 @@ def shift(dim: int) -> np.ndarray:
             0 & 1 & 0
         \end{pmatrix}
 
-    >>> from toqito.matrices import shift
-    >>> shift(3)
+    >>> from toqito.matrices import gen_pauli_x
+    >>> gen_pauli_x(3)
     array([[0., 0., 1.],
            [1., 0., 0.],
            [0., 1., 0.]])
@@ -47,12 +47,12 @@ def shift(dim: int) -> np.ndarray:
 
 
     :param dim: Dimension of the matrix.
-    :return: :code:`dim`-by-:code:`dim` shift matrix.
+    :return: :code:`dim`-by-:code:`dim` gen_pauli_x matrix.
 
     """
-    shift_mat = np.identity(dim)
-    shift_mat = np.roll(shift_mat, -1)
-    shift_mat[:, -1] = np.array([0] * dim)
-    shift_mat[0, -1] = 1
+    gen_pauli_x_mat = np.identity(dim)
+    gen_pauli_x_mat = np.roll(gen_pauli_x_mat, -1)
+    gen_pauli_x_mat[:, -1] = np.array([0] * dim)
+    gen_pauli_x_mat[0, -1] = 1
 
-    return shift_mat
+    return gen_pauli_x_mat

--- a/toqito/matrices/gen_pauli_z.py
+++ b/toqito/matrices/gen_pauli_z.py
@@ -1,14 +1,14 @@
-"""Clock matrix."""
+"""Generalized Pauli-Z matrix."""
 from cmath import exp, pi
 
 import numpy as np
 
 
-def clock(dim: int) -> np.ndarray:
-    r"""Produce clock matrix :cite:`WikiClock`.
+def gen_pauli_z(dim: int) -> np.ndarray:
+    r"""Produce gen_pauli_z matrix :cite:`WikiClock`.
 
-    Returns the clock matrix of dimension :code:`dim` described in :cite:`WikiClock`.
-    The clock matrix generates the following :code:`dim`-by-:code:`dim` matrix
+    Returns the gen_pauli_z matrix of dimension :code:`dim` described in :cite:`WikiClock`.
+    The gen_pauli_z matrix generates the following :code:`dim`-by-:code:`dim` matrix
 
     .. math::
         \Sigma_{1, d} = \begin{pmatrix}
@@ -21,13 +21,13 @@ def clock(dim: int) -> np.ndarray:
 
     where :math:`\omega` is the n-th primitive root of unity.
 
-    The clock matrix is primarily used in the construction of the generalized
+    The gen_pauli_z matrix is primarily used in the construction of the generalized
     Pauli operators.
 
     Examples
     ==========
 
-    The clock matrix generated from :math:`d = 3` yields the following matrix:
+    The gen_pauli_z matrix generated from :math:`d = 3` yields the following matrix:
 
     .. math::
         \Sigma_{1, 3} = \begin{pmatrix}
@@ -36,8 +36,8 @@ def clock(dim: int) -> np.ndarray:
             0 & 0 & \omega^2
         \end{pmatrix}
 
-    >>> from toqito.matrices import clock
-    >>> clock(3)
+    >>> from toqito.matrices import gen_pauli_z
+    >>> gen_pauli_z(3)
     array([[ 1. +0.j       ,  0. +0.j       ,  0. +0.j       ],
            [ 0. +0.j       , -0.5+0.8660254j,  0. +0.j       ],
            [ 0. +0.j       ,  0. +0.j       , -0.5-0.8660254j]])
@@ -49,7 +49,7 @@ def clock(dim: int) -> np.ndarray:
 
 
     :param dim: Dimension of the matrix.
-    :return: :code:`dim`-by-:code:`dim` clock matrix.
+    :return: :code:`dim`-by-:code:`dim` gen_pauli_z matrix.
 
     """
     c_var = 2j * pi / dim


### PR DESCRIPTION
## Description
As requested in #478, I have replaced all the variables/comments/function-names/file-names occurrences from shift to gen_pauli_x and clock to gen_pauli_z.
If at all there are any issues regarding these code changes, then do let me know.
Sincere apologies if I have missed any code to be changed or implemented a code incorrectly.
Kindly let me know if any changes are required.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  -  [X] Name change of shift/clock to gen_pauli_x/gen_pauli_z.

## Questions
-  [ ] Question1

## Status
-  [ ] Ready to go