### PR TITLE
pauli refactor

### DIFF
--- a/toqito/matrices/pauli.py
+++ b/toqito/matrices/pauli.py
@@ -2,10 +2,13 @@
 
 import numpy as np
 
+#from scipy import sparse
+from scipy.sparse import csr_array
+
 from toqito.matrix_ops import tensor
 
 
-def pauli(ind: int | str | list[int] | list[str], is_sparse: bool = False) -> np.ndarray:
+def pauli(ind: int | str | list[int] | list[str], is_sparse: bool = False) -> csr_array:
     r"""Produce a Pauli operator :cite:`WikiPauli`.
 
     Provides the 2-by-2 Pauli matrix indicated by the value of :code:`ind`. The
@@ -77,8 +80,8 @@ def pauli(ind: int | str | list[int] | list[str], is_sparse: bool = False) -> np
         :filter: docname in docnames
 
     :param ind: The index to indicate which Pauli operator to generate.
-    :param is_sparse: Returns a sparse matrix if set to True and a non-sparse
-                      matrix if set to False.
+    :param is_sparse: Returns a compressed sparse row array if set to True 
+                      and a non compressed sparse row array if set to False.
 
     """
     if isinstance(ind, (int, str)):
@@ -90,6 +93,9 @@ def pauli(ind: int | str | list[int] | list[str], is_sparse: bool = False) -> np
             pauli_mat = np.array([[1, 0], [0, -1]])
         else:
             pauli_mat = np.identity(2)
+
+        if is_sparse:
+            pauli_mat = csr_array(pauli_mat)  # pylint: disable=redefined-variable-type
 
         return pauli_mat
 

--- a/toqito/matrices/pauli.py
+++ b/toqito/matrices/pauli.py
@@ -6,7 +6,7 @@ from scipy.sparse import csr_array
 from toqito.matrix_ops import tensor
 
 
-def pauli(ind: int | str | list[int] | list[str], is_sparse: bool = False) -> csr_array:
+def pauli(ind: int | str | list[int] | list[str], is_sparse: bool = False) -> np.ndarray | csr_array:
     r"""Produce a Pauli operator :cite:`WikiPauli`.
 
     Provides the 2-by-2 Pauli matrix indicated by the value of :code:`ind`. The

--- a/toqito/matrices/pauli.py
+++ b/toqito/matrices/pauli.py
@@ -1,12 +1,11 @@
 """Pauli matrices."""
 
 import numpy as np
-from scipy import sparse
 
 from toqito.matrix_ops import tensor
 
 
-def pauli(ind: int | str | list[int] | list[str], is_sparse: bool = False) -> np.ndarray | sparse.csr_matrix:
+def pauli(ind: int | str | list[int] | list[str], is_sparse: bool = False) -> np.ndarray:
     r"""Produce a Pauli operator :cite:`WikiPauli`.
 
     Provides the 2-by-2 Pauli matrix indicated by the value of :code:`ind`. The
@@ -91,9 +90,6 @@ def pauli(ind: int | str | list[int] | list[str], is_sparse: bool = False) -> np
             pauli_mat = np.array([[1, 0], [0, -1]])
         else:
             pauli_mat = np.identity(2)
-
-        if is_sparse:
-            pauli_mat = sparse.csr_matrix(pauli_mat)  # pylint: disable=redefined-variable-type
 
         return pauli_mat
 

--- a/toqito/matrices/pauli.py
+++ b/toqito/matrices/pauli.py
@@ -1,8 +1,6 @@
 """Pauli matrices."""
 
 import numpy as np
-
-#from scipy import sparse
 from scipy.sparse import csr_array
 
 from toqito.matrix_ops import tensor
@@ -80,8 +78,9 @@ def pauli(ind: int | str | list[int] | list[str], is_sparse: bool = False) -> cs
         :filter: docname in docnames
 
     :param ind: The index to indicate which Pauli operator to generate.
-    :param is_sparse: Returns a compressed sparse row array if set to True 
-                      and a non compressed sparse row array if set to False.
+    :param is_sparse: Returns a compressed sparse row array if set to True and a non compressed
+                      sparse row array if set to False.
+
 
     """
     if isinstance(ind, (int, str)):

--- a/toqito/matrices/tests/test_pauli.py
+++ b/toqito/matrices/tests/test_pauli.py
@@ -1,6 +1,7 @@
 """Test pauli."""
 
 import numpy as np
+from scipy.sparse import issparse
 
 from toqito.matrices import pauli
 
@@ -8,13 +9,13 @@ from toqito.matrices import pauli
 def test_pauli_str_sparse():
     """Pauli-I operator with argument "I"."""
     res = pauli("I", True)
-    np.testing.assert_equal(isinstance(res, np.ndarray) and res.ndim == 2, True)
+    np.testing.assert_equal(issparse(res), True)
 
 
 def test_pauli_int_sparse():
     """Pauli-I operator with argument "I"."""
     res = pauli(0, True)
-    np.testing.assert_equal(isinstance(res, np.ndarray) and res.ndim == 2, True)
+    np.testing.assert_equal(issparse(res), True)
 
 
 def test_pauli_i():

--- a/toqito/matrices/tests/test_pauli.py
+++ b/toqito/matrices/tests/test_pauli.py
@@ -1,7 +1,6 @@
 """Test pauli."""
 
 import numpy as np
-from scipy.sparse import issparse
 
 from toqito.matrices import pauli
 
@@ -9,13 +8,13 @@ from toqito.matrices import pauli
 def test_pauli_str_sparse():
     """Pauli-I operator with argument "I"."""
     res = pauli("I", True)
-    np.testing.assert_equal(issparse(res), True)
+    np.testing.assert_equal(isinstance(res, np.ndarray) and res.ndim == 2, True)
 
 
 def test_pauli_int_sparse():
     """Pauli-I operator with argument "I"."""
     res = pauli(0, True)
-    np.testing.assert_equal(issparse(res), True)
+    np.testing.assert_equal(isinstance(res, np.ndarray) and res.ndim == 2, True)
 
 
 def test_pauli_i():


### PR DESCRIPTION
## Description
Closes: https://github.com/vprusso/toqito/issues/529

I left `is_sparse` in for the moment even though it's not technically being used in `pauli.py` due to the test cases relying on True or False. Would it make sense to completely remove `is_sparse` and drop `True` from the test cases? @purva-thakre  I believe so, but drafting this for PR for now.

## Changes
  -  [x] Remove `csr_matrix`

## Checklist

  -  [x] Use `ruff` and `pylint` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
