### PR TITLE
Random doctest failures

### DIFF
--- a/toqito/state_props/has_symmetric_extension.py
+++ b/toqito/state_props/has_symmetric_extension.py
@@ -4,7 +4,7 @@ import numpy as np
 from picos import partial_trace
 
 from toqito.matrix_props import is_positive_semidefinite
-from toqito.state_opt import symmetric_extension_hierarchy
+from toqito.state_opt.symmetric_extension_hierarchy import symmetric_extension_hierarchy
 from toqito.state_props import is_ppt
 
 

--- a/toqito/state_props/has_symmetric_extension.py
+++ b/toqito/state_props/has_symmetric_extension.py
@@ -5,6 +5,9 @@ from picos import partial_trace
 
 from toqito.matrix_props import is_positive_semidefinite
 from toqito.state_opt.symmetric_extension_hierarchy import symmetric_extension_hierarchy
+
+# The full import path was specified here because the doctest workflow was failing when the above function could not be
+# imported https://github.com/vprusso/toqito/issues/473
 from toqito.state_props import is_ppt
 
 

--- a/toqito/state_props/is_antidistinguishable.py
+++ b/toqito/state_props/is_antidistinguishable.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from toqito.state_opt import state_exclusion
+from toqito.state_opt.state_exclusion import state_exclusion
 
 
 def is_antidistinguishable(states: list[np.ndarray]) -> bool:

--- a/toqito/state_props/is_antidistinguishable.py
+++ b/toqito/state_props/is_antidistinguishable.py
@@ -4,6 +4,9 @@ import numpy as np
 
 from toqito.state_opt.state_exclusion import state_exclusion
 
+# The full import path was specified here because the doctest workflow was failing when the above function could not be
+# imported https://github.com/vprusso/toqito/issues/473
+
 
 def is_antidistinguishable(states: list[np.ndarray]) -> bool:
     r"""Check whether a collection of vectors are antidistinguishable or not.

--- a/toqito/state_props/is_distinguishable.py
+++ b/toqito/state_props/is_distinguishable.py
@@ -4,6 +4,9 @@ import numpy as np
 
 from toqito.state_opt.state_distinguishability import state_distinguishability
 
+# The full import path was specified here because the doctest workflow was failing when the above function could not be
+# imported https://github.com/vprusso/toqito/issues/473
+
 
 def is_distinguishable(states: list[np.ndarray], probs: list[float] = None) -> bool:
     r"""Check whether a collection of vectors are (perfectly) distinguishable or not.

--- a/toqito/state_props/is_distinguishable.py
+++ b/toqito/state_props/is_distinguishable.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from toqito.state_opt import state_distinguishability
+from toqito.state_opt.state_distinguishability import state_distinguishability
 
 
 def is_distinguishable(states: list[np.ndarray], probs: list[float] = None) -> bool:


### PR DESCRIPTION
## Description
Fixes #473 

This is technically **not a fix** as we have to specify the full import path for a bunch of files only. If this is indeed the source of the issue where Python could not distinguish between the module and functions, we should rename all `.py` files to not have the same names as the functions in them. 

For example, rename `toqito/state_props/is_antidistinguishable.py` to `toqito/state_props/is_antidistinguishable_function.py`

## Changes
Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below.

  -  [x] Added full import path for the failing doctest examples

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` and `pylint` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
