### PR TITLE
Fix for Issue #401

### DIFF
--- a/docs/articles.bib
+++ b/docs/articles.bib
@@ -90,19 +90,6 @@
 
 
 #Last name begins with C
-@article{Cavalcanti_2015_Detection,
-   title={Detection of entanglement in asymmetric quantum networks and multipartite quantum steering},
-   volume={6},
-   ISSN={2041-1723},
-   url={http://dx.doi.org/10.1038/ncomms8941},
-   DOI={10.1038/ncomms8941},
-   number={1},
-   journal={Nature Communications},
-   publisher={Springer Science and Business Media LLC},
-   author={Cavalcanti, D. and Skrzypczyk, P. and Aguilar, G. H. and Nery, R. V. and Ribeiro, P.H. Souto and Walborn, S. P.},
-   year={2015},
-   month=aug }
-
 @article{Cabello_2002_NParticle,
   title = {$N$-Particle $N$-Level Singlet States: Some Properties and Applications},
   author = {Cabello, Ad\'an},
@@ -116,6 +103,19 @@
   publisher = {American Physical Society},
   url = {https://arxiv.org/abs/quant-ph/0203119}
 }
+
+@article{Cavalcanti_2015_Detection,
+   title={Detection of entanglement in asymmetric quantum networks and multipartite quantum steering},
+   volume={6},
+   ISSN={2041-1723},
+   url={http://dx.doi.org/10.1038/ncomms8941},
+   DOI={10.1038/ncomms8941},
+   number={1},
+   journal={Nature Communications},
+   publisher={Springer Science and Business Media LLC},
+   author={Cavalcanti, D. and Skrzypczyk, P. and Aguilar, G. H. and Nery, R. V. and Ribeiro, P.H. Souto and Walborn, S. P.},
+   year={2015},
+   month=aug }
 
 @misc{Chen_2003_Matrix,
       title={A matrix realignment method for recognizing entanglement}, 

--- a/docs/articles.bib
+++ b/docs/articles.bib
@@ -90,6 +90,19 @@
 
 
 #Last name begins with C
+@article{Cavalcanti_2015_Detection,
+   title={Detection of entanglement in asymmetric quantum networks and multipartite quantum steering},
+   volume={6},
+   ISSN={2041-1723},
+   url={http://dx.doi.org/10.1038/ncomms8941},
+   DOI={10.1038/ncomms8941},
+   number={1},
+   journal={Nature Communications},
+   publisher={Springer Science and Business Media LLC},
+   author={Cavalcanti, D. and Skrzypczyk, P. and Aguilar, G. H. and Nery, R. V. and Ribeiro, P.H. Souto and Walborn, S. P.},
+   year={2015},
+   month=aug }
+
 @article{Cabello_2002_NParticle,
   title = {$N$-Particle $N$-Level Singlet States: Some Properties and Applications},
   author = {Cabello, Ad\'an},
@@ -187,6 +200,15 @@ abstract = {We consider a class of positive linear maps in the three-dimensional
       author={Cosentino, Alessandro},
       year={2015},
       howpublished = {https://uwspace.uwaterloo.ca/handle/10012/9572}
+}
+
+@misc{Cosentino_2014_Small,
+      title={Small sets of locally indistinguishable orthogonal maximally entangled states}, 
+      author={Alessandro Cosentino and Vincent Russo},
+      year={2014},
+      eprint={1307.3232},
+      archivePrefix={arXiv},
+      primaryClass={quant-ph}
 }
 
 @misc{Riley_2022_CVXPYKron,
@@ -665,6 +687,13 @@ author = {Gisin, N.},
       primaryClass={quant-ph}
 }
 
+@misc{Sikora_2019_Semidefinite,
+	title={Semidefinite programming in quantum theory (lecture series)},
+  author={Sikora, Jamie},
+  year={2019},
+	journal={Lecture 2: Semidefinite programs for nice problems and popular functions, Perimeter Institute for Theoretical Physics}
+}
+
 @misc{SO_43884189,
   author  = "Stack Overflow Post",
   title   = "Check if a large matrix is diagonal matrix in python",
@@ -706,6 +735,20 @@ journal = {New Journal of Physics},
    author={Terhal, Barbara M. and DiVincenzo, David P. and Leung, Debbie W.},
    year={2001},
    month=jun, pages={5807-5810} }
+
+@article{Tomamichel_2013_AMonogamy,
+   title={A monogamy-of-entanglement game with applications to device-independent quantum cryptography},
+   volume={15},
+   ISSN={1367-2630},
+   url={http://dx.doi.org/10.1088/1367-2630/15/10/103002},
+   DOI={10.1088/1367-2630/15/10/103002},
+   number={10},
+   journal={New Journal of Physics},
+   publisher={IOP Publishing},
+   author={Tomamichel, Marco and Fehr, Serge and Kaniewski, Jędrzej and Wehner, Stephanie},
+   year={2013},
+   month=oct, pages={103002} }
+
 
 #Last name begins with U
 

--- a/docs/tutorials.extended_nonlocal_games.rst
+++ b/docs/tutorials.extended_nonlocal_games.rst
@@ -14,12 +14,12 @@ resources. We will be using :code:`toqito` to calculate these quantities.
 
 We will also look at existing results in the literature on these values and be
 able to replicate them using :code:`toqito`. Much of the written content in
-this tutorial will be directly taken from [tRusso17]_.
+this tutorial will be directly taken from :cite:`Russo_2017_Extended`.
 
 Extended nonlocal games have a natural physical interpretation in the setting
-of tripartite steering [tCSAN15]_ and in device-independent quantum scenarios [tTFKW13]_. For
-more information on extended nonlocal games, please refer to [tJMRW16]_ and
-[tRusso17]_.
+of tripartite steering :cite:`Cavalcanti_2015_Detection` and in device-independent quantum scenarios :cite:`Tomamichel_2013_AMonogamy`. For
+more information on extended nonlocal games, please refer to :cite:`Johnston_2016_Extended` and
+:cite:`Russo_2017_Extended`.
 
 The extended nonlocal game model
 --------------------------------
@@ -305,7 +305,7 @@ arrays where :code:`prob_mat` corresponds to the probability distribution
 The unentangled value of the BB84 extended nonlocal game
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-It was shown in [tTFKW13]_ and [tJMRW16]_ that
+It was shown in :cite:`Tomamichel_2013_AMonogamy` and :cite:`Johnston_2016_Extended` that
 
 .. math::
     \omega(G_{BB84}) = \cos^2(\pi/8).
@@ -356,7 +356,7 @@ example of two parallel repetitions for the BB84 game.
         `float` output to a certain amount of precision such that the value deviates after a few digits
         of accuracy.
 
-It was shown in [tJMRW16]_ that the BB84 game possesses the property of strong
+It was shown in :cite:`Johnston_2016_Extended` that the BB84 game possesses the property of strong
 parallel repetition. That is,
 
 .. math::
@@ -390,7 +390,7 @@ using :code:`toqito` as well.
         `float` output to a certain amount of precision such that the value deviates after a few digits
         of accuracy.
 
-From [tJMRW16]_, it is known that :math:`\omega(G_{BB84}) =
+From :cite:`Johnston_2016_Extended`, it is known that :math:`\omega(G_{BB84}) =
 \omega^*(G_{BB84})`, however, if we did not know this beforehand, we could
 attempt to calculate upper bounds on the standard quantum value. 
 
@@ -430,7 +430,7 @@ So we have the relationship that
     \omega(G_{BB84}) = \omega^*(G_{BB84}) = \omega_{ns}(G_{BB84}) = \cos^2(\pi/8).
 
 It turns out that strong parallel repetition does *not* hold in the
-non-signaling scenario for the BB84 game. This was shown in [tRusso17]_, and we
+non-signaling scenario for the BB84 game. This was shown in :cite:`Russo_2017_Extended`, and we
 can observe this by the following snippet.
 
 .. code-block:: python
@@ -787,27 +787,10 @@ but the value of such a strategy is bounded as follows
 
     2/3 \geq \omega^*(G) \geq 0.6609.
 
-For further information on the :math:`G_{MUB}` game, consult [tRusso17]_.
+For further information on the :math:`G_{MUB}` game, consult :cite:`Russo_2017_Extended`.
 
 References
 ------------------------------
 
-.. [tJMRW16] Johnston, Nathaniel, Mittal, Rajat, Russo, Vincent, Watrous, John
-    "Extended non-local games and monogamy-of-entanglement games"
-    Proceedings of the Royal Society A: Mathematical, Physical and Engineering Sciences 472.2189 (2016),
-    https://arxiv.org/abs/1510.02083
-
-.. [tCSAN15] Cavalcanti, Daniel, Skrzypczyk, Paul, Aguilar, Gregory, Nery, Ranieri
-    "Detection of entanglement in asymmetric quantum networks and multipartite quantum steering"
-    Nature Communications, 6(7941), 2015
-    https://arxiv.org/abs/1412.7730
-
-.. [tTFKW13] Tomamichel, Marco, Fehr, Serge, Kaniewski, Jkedrzej, and Wehner, Stephanie.
-    "A Monogamy-of-Entanglement Game With Applications to Device-Independent Quantum Cryptography"
-    New Journal of Physics 15.10 (2013): 103002,
-    https://arxiv.org/abs/1210.4359
-
-.. [tRusso17] Russo, Vincent
-    "Extended nonlocal games"
-    https://arxiv.org/abs/1704.07375
-
+.. bibliography:: 
+    :filter: docname in docnames

--- a/docs/tutorials.nonlocal_games.rst
+++ b/docs/tutorials.nonlocal_games.rst
@@ -29,8 +29,8 @@ directly calculate the classical value and also place lower bounds on the
 quantum value.
 
 Further information beyond the scope of this tutorial on nonlocal games can be
-found in [tCHTW04]_. Further information on the lower bound technique can be found in
-[tLD07]_.
+found in :cite:`Cleve_2010_Consequences`. Further information on the lower bound technique can be found in
+:cite:`Liang_2007_Bounds`.
 
 Two-player nonlocal games
 --------------------------
@@ -199,7 +199,7 @@ cases for certain nonlocal games.
 
 For an arbitrary nonlocal game, there exist approaches that place upper and
 lower bounds on the quantum value. The lower bound approach is calculated using
-the technique of semidefinite programming [tLD07]_. While this method is efficient
+the technique of semidefinite programming :cite:`Liang_2007_Bounds`. While this method is efficient
 to carry out, it does not guarantee convergence to the quantum value (although
 in certain cases, it is attained).
 
@@ -392,7 +392,7 @@ satisfied
         \end{equation}
 
 It is well-known that both the classical and quantum value of this nonlocal
-game is :math:`2/3` [tCHTW04]_. We can verify this fact using :code:`toqito`.
+game is :math:`2/3` :cite:`Cleve_2010_Consequences`. We can verify this fact using :code:`toqito`.
 The following example encodes the FFL game. We then calculate the classical
 value and calculate lower bounds on the quantum value of the FFL game.
 
@@ -453,12 +453,5 @@ for the CHSH game, that is:
 References
 ------------------------------
 
-.. [tCHTW04] Cleve, Richard, Hoyer, Peter, Toner, Benjamin, and Watrous, John
-    "Consequences and limits of nonlocal strategies"
-    Computational Complexity 2004. Proceedings. 19th IEEE Annual Conference.
-    https://arxiv.org/abs/quant-ph/0404076
-
-.. [tLD07] Liang, Yeong-Cherng, and Andrew C. Doherty.
-    "Bounds on quantum correlations in Bell-inequality experiments."
-    Physical Review A 75.4 (2007): 042103.
-    https://arxiv.org/abs/quant-ph/0608128
+.. bibliography:: 
+    :filter: docname in docnames

--- a/docs/tutorials.state_distinguishability.rst
+++ b/docs/tutorials.state_distinguishability.rst
@@ -9,7 +9,7 @@ with which this problem can be solved when given access to certain
 measurements.
 
 Further information beyond the scope of this tutorial can be found in the text
-[tWatrousQI]_ as well as the course [tSikoraSDP]_.
+:cite:`Watrous_2018_TQI` as well as the course :cite:`Sikora_2019_Semidefinite`.
 
 The state distinguishability problem
 -------------------------------------
@@ -160,7 +160,7 @@ transpose).
 
 The problem of state distinguishability with respect to PPT measurements can
 also be framed as an SDP and was initially presented in this manner in
-[tCosentino13]_
+:cite:`Cosentino_2013_PPT`
 
 .. math::
 
@@ -190,7 +190,7 @@ Consider the following Bell states
         \end{aligned}
     \end{equation}
 
-It was shown in [tCosentino13]_ and later extended in [tCR13]_ that for the following set of states
+It was shown in :cite:`Cosentino_2013_PPT` and later extended in :cite:`Cosentino_2014_Small` that for the following set of states
 
 .. math::
     \begin{equation}
@@ -206,7 +206,7 @@ that the optimal probability of distinguishing via a PPT measurement should yiel
 :math:`7/8 \approx 0.875`.
 
 This ensemble of states and some of its properties with respect to
-distinguishability were initially considered in [tYDY12]_. In :code:`toqito`,
+distinguishability were initially considered in :cite:`Yu_2012_Four`. In :code:`toqito`,
 we can calculate the probability with which Bob can distinguish these states
 via PPT measurements in the following manner.
 
@@ -221,7 +221,7 @@ via PPT measurements in the following manner.
     >>> psi_2 = bell(3)
     >>> psi_3 = bell(1)
     >>>
-    >>> # YDY vectors from [tYDY12]_:
+    >>> # YDY vectors from :cite:`Yu_2012_Four`:
     >>> x_1 = np.kron(psi_0, psi_0)
     >>> x_2 = np.kron(psi_1, psi_3)
     >>> x_3 = np.kron(psi_2, psi_3)
@@ -252,37 +252,41 @@ As previously mentioned, optimizing over the set of separable measurements is
 NP-hard. However, there does exist a hierarchy of semidefinite programs which
 eventually does converge to the separable value. This hierarchy is based off
 the notion of symmetric extensions. More information about this hierarchy of
-SDPs can be found here [tNav08]_.
+SDPs can be found here :cite:`Navascues_2008_Pure`.
 
 References
 ------------------------------
-.. [tWatrousQI] Watrous, John
-    "The theory of quantum information"
-    Section: "A semidefinite program for optimal measurements"
-    Cambridge University Press, 2018
 
-.. [tNav08] Navascués, Miguel.
-    "Pure state estimation and the characterization of entanglement."
-    Physical review letters 100.7 (2008): 070503.
-    https://arxiv.org/abs/0707.4398
+.. bibliography:: 
+    :filter: docname in docnames
 
-.. [tSikoraSDP] Sikora, Jamie
-    "Semidefinite programming in quantum theory (lecture series)"
-    Lecture 2: Semidefinite programs for nice problems and popular functions
-    Perimeter Institute for Theoretical Physics, 2019
+.. .. [tWatrousQI] Watrous, John
+..     "The theory of quantum information"
+..     Section: "A semidefinite program for optimal measurements"
+..     Cambridge University Press, 2018
 
-.. [tCosentino13] Cosentino, Alessandro,
-    "Positive-partial-transpose-indistinguishable states via semidefinite programming",
-    Physical Review A 87.1 (2013): 012321.
-    https://arxiv.org/abs/1205.1031
+.. .. [tNav08] Navascués, Miguel.
+..     "Pure state estimation and the characterization of entanglement."
+..     Physical review letters 100.7 (2008): 070503.
+..     https://arxiv.org/abs/0707.4398
 
-.. [tCR13] Cosentino, Alessandro and Russo, Vincent
-    "Small sets of locally indistinguishable orthogonal maximally entangled states",
-    Quantum Information & Computation, Volume 14, 
-    https://arxiv.org/abs/1307.3232
+.. .. [tSikoraSDP] Sikora, Jamie
+..     "Semidefinite programming in quantum theory (lecture series)"
+..     Lecture 2: Semidefinite programs for nice problems and popular functions
+..     Perimeter Institute for Theoretical Physics, 2019
 
-.. [tYDY12] Yu, Nengkun, Runyao Duan, and Mingsheng Ying.
-    "Four locally indistinguishable ququad-ququad orthogonal
-    maximally entangled states."
-    Physical review letters 109.2 (2012): 020506.
-    https://arxiv.org/abs/1107.3224
+.. .. [tCosentino13] Cosentino, Alessandro,
+..     "Positive-partial-transpose-indistinguishable states via semidefinite programming",
+..     Physical Review A 87.1 (2013): 012321.
+..     https://arxiv.org/abs/1205.1031
+
+.. .. [tCR13] Cosentino, Alessandro and Russo, Vincent
+..     "Small sets of locally indistinguishable orthogonal maximally entangled states",
+..     Quantum Information & Computation, Volume 14, 
+..     https://arxiv.org/abs/1307.3232
+
+.. .. [tYDY12] Yu, Nengkun, Runyao Duan, and Mingsheng Ying.
+..     "Four locally indistinguishable ququad-ququad orthogonal
+..     maximally entangled states."
+..     Physical review letters 109.2 (2012): 020506.
+..     https://arxiv.org/abs/1107.3224

--- a/docs/tutorials.state_exclusion.rst
+++ b/docs/tutorials.state_exclusion.rst
@@ -13,7 +13,7 @@ covers quantum state distinguishability:
 * `Quantum State Distinguishability <https://toqito.readthedocs.io/en/latest/tutorials.state_distinguishability.html>`_
 
 Further information beyond the scope of this tutorial can be found in the text
-[tPBR12]_ as well as the course [tBJOP14]_.
+:cite:`Pusey_2012_On` as well as the course :cite:`Bandyopadhyay_2014_Conclusive`.
 
 
 The state exclusion problem
@@ -65,13 +65,5 @@ Optimal probability of unambiguously excluding a quantum state
 References
 ------------------------------
 
-.. [tPBR12] Pusey, Matthew, Barret, Jonathan, and Rudolph, Terry
-    "On the reality of the quantum state"
-    Nature Physics 8.6 (2012): 475-478.
-    arXiv:1111.3328
-
-.. [tBJOP14] Bandyopadhyay, Somshubhro, Jain, Rahul, Oppenheim, Jonathan, Perry, Christopher
-    "Conclusive exclusion of quantum states"
-    Physical Review A 89.2 (2014): 022336.
-    arXiv:1306.4683
-
+.. bibliography:: 
+    :filter: docname in docnames

--- a/docs/tutorials.xor_quantum_value.rst
+++ b/docs/tutorials.xor_quantum_value.rst
@@ -14,7 +14,7 @@ documentation page, and more specifically the function `xor\_game\_value
 
 Further information beyond the scope of this tutorial on the notion of XOR
 games along with the method of computing their quantum value may be found in
-[tCSUU08]_.
+:cite:`Cleve_2008_Strong`.
 
 Two-player XOR games
 --------------------
@@ -391,8 +391,6 @@ for every XOR game :math:`G`.
 References
 ------------------------------
 
-.. [tCSUU08] Cleve, Richard, Slofstra, William, Unger, Falk, and Upadhyay, Sarvagya
-    "Perfect parallel repetition theorem for quantum XOR proof systems"
-    Computational Complexity 17.2 (2008): 282-299.
-    https://arxiv.org/abs/quant-ph/0608146
+.. bibliography:: 
+    :filter: docname in docnames
 


### PR DESCRIPTION
## Description
References in the tutorials have been fixed as per the guidelines in #401. Fix is part of the Unitary Hack 2024.

Fixes #401 

## Changes
The changes are listed below.

- The references have automatically been updated in each tutorial using the Spinx tool.
- Some references in the tutorials were missing from the articles.bib file, so I have added them using the same style as recommended. 

