### PR TITLE
Add more conditions for checking `is_separable`

### DIFF
--- a/docs/articles.bib
+++ b/docs/articles.bib
@@ -1226,3 +1226,170 @@ numpages = {11}
   url = {https://link.aps.org/doi/10.1103/PhysRevA.88.062330}
 }
 
+@article{Peres_1996_PPT,
+  title = {Separability Criterion for Density Matrices},
+  author = {Peres, Asher},
+  journal = {Phys. Rev. Lett.},
+  volume = {77},
+  issue = {8},
+  pages = {1413--1415},
+  numpages = {0},
+  year = {1996},
+  month = {Aug},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevLett.77.1413},
+  url = {https://link.aps.org/doi/10.1103/PhysRevLett.77.1413}
+}
+
+@article{Gühne_2009_Horodecki,
+title = {Entanglement detection},
+journal = {Physics Reports},
+volume = {474},
+number = {1},
+pages = {1-75},
+year = {2009},
+issn = {0370-1573},
+doi = {https://doi.org/10.1016/j.physrep.2009.02.004},
+url = {https://www.sciencedirect.com/science/article/pii/S0370157309000623},
+author = {Otfried Gühne and Géza Tóth},
+keywords = {Entanglement detection, Separability criteria, Genuine multipartite entanglement},
+abstract = {How can one prove that a given quantum state is entangled? In this paper we review different methods that have been proposed for entanglement detection. We first explain the basic elements of entanglement theory for two or more particles and then entanglement verification procedures such as Bell inequalities, entanglement witnesses, the determination of nonlinear properties of a quantum state via measurements on several copies, and spin squeezing inequalities. An emphasis is given to the theory and application of entanglement witnesses. We also discuss several experiments, where some of the presented methods have been implemented.}
+}
+
+@article{Horodecki_1996_PPT_small_dimensions,
+title = {Separability of mixed states: necessary and sufficient conditions},
+journal = {Physics Letters A},
+volume = {223},
+number = {1},
+pages = {1-8},
+year = {1996},
+issn = {0375-9601},
+doi = {https://doi.org/10.1016/S0375-9601(96)00706-2},
+url = {https://www.sciencedirect.com/science/article/pii/S0375960196007062},
+author = {Michał Horodecki and Paweł Horodecki and Ryszard Horodecki},
+abstract = {We provide necessary and sufficient conditions for the separability of mixed states. As a result we obtain a simple criterion of the separability for 2 × 2 and 2 × 3 systems. Here, the positivity of the partial transposition of a state is necessary and sufficient for its separability. However, this is not the case in general. Some examples of mixtures which demonstrate the utility of the criterion are considered.}
+}
+
+@article{Horodecki_2000_PPT_low_rank,
+  title = {Operational criterion and constructive checks for the separability of low-rank density matrices},
+  author = {Horodecki, Pawe\l{} and Lewenstein, Maciej and Vidal, Guifr\'e and Cirac, Ignacio},
+  journal = {Phys. Rev. A},
+  volume = {62},
+  issue = {3},
+  pages = {032310},
+  numpages = {10},
+  year = {2000},
+  month = {Aug},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevA.62.032310},
+  url = {https://link.aps.org/doi/10.1103/PhysRevA.62.032310}
+}
+
+@misc{Chen_2003_Realignment,
+      title={A matrix realignment method for recognizing entanglement}, 
+      author={Kai Chen and Ling-An Wu},
+      year={2003},
+      eprint={quant-ph/0205017},
+      archivePrefix={arXiv},
+      primaryClass={quant-ph}
+}
+
+@article{Zhang_2008_Beyond_realignment,
+  title = {Entanglement detection beyond the computable cross-norm or realignment criterion},
+  author = {Zhang, Cheng-Jie and Zhang, Yong-Sheng and Zhang, Shun and Guo, Guang-Can},
+  journal = {Phys. Rev. A},
+  volume = {77},
+  issue = {6},
+  pages = {060301},
+  numpages = {4},
+  year = {2008},
+  month = {Jun},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevA.77.060301},
+  url = {https://link.aps.org/doi/10.1103/PhysRevA.77.060301}
+}
+
+@misc{Hildebrand_2005_Cone,
+  author  = "Roland Hildebrand",
+  title   = "Comparison of the PPT cone and the separable cone for 2-by-n systems.",
+  year = {2005},
+  howpublished = {https://membres-ljk.imag.fr/Roland.Hildebrand/coreMPseminar2005_slides.pdf}
+  
+}
+
+@article{Gurvits_2002_Ball,
+  title = {Largest separable balls around the maximally mixed bipartite quantum state},
+  author = {Gurvits, Leonid and Barnum, Howard},
+  journal = {Phys. Rev. A},
+  volume = {66},
+  issue = {6},
+  pages = {062311},
+  numpages = {7},
+  year = {2002},
+  month = {Dec},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevA.66.062311},
+  url = {https://link.aps.org/doi/10.1103/PhysRevA.66.062311}
+}
+
+@article{Vidal_1999_Robust,
+  title = {Robustness of entanglement},
+  author = {Vidal, Guifr\'e and Tarrach, Rolf},
+  journal = {Phys. Rev. A},
+  volume = {59},
+  issue = {1},
+  pages = {141--155},
+  numpages = {0},
+  year = {1999},
+  month = {Jan},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevA.59.141},
+  url = {https://link.aps.org/doi/10.1103/PhysRevA.59.141}
+}
+
+@misc{Cariello_2013_Weak_irreducible,
+      title={Separability for Weak Irreducible matrices}, 
+      author={Daniel Cariello},
+      year={2013},
+      eprint={1311.7275},
+      archivePrefix={arXiv},
+      primaryClass={quant-ph}
+}
+
+@article{Ha_2011_Positive_map,
+author = {Ha, Kil-Chan and Kye, Seung-Hyeok},
+title = {Entanglement Witnesses Arising from Exposed Positive Linear Maps},
+journal = {Open Systems \& Information Dynamics},
+volume = {18},
+number = {04},
+pages = {323-337},
+year = {2011},
+doi = {10.1142/S1230161211000224},
+URL = {https://doi.org/10.1142/S1230161211000224},
+eprint = {https://doi.org/10.1142/S1230161211000224},
+abstract = {We consider entanglement witnesses arising from positive linear maps which generate exposed extremal rays. We show that every entangled state can be detected by one of these witnesses, and this witness detects a unique set of entangled states among those. Therefore, they provide a minimal set of witnesses to detect any kind of entanglement in a sense. Furthermore, if those maps are indecomposable then they detect large classes of entangled states with positive partial transposes which have nonempty relative interiors in the cone generated by all PPT states. We also provide a one-parameter family of indecomposable positive linear maps which generate exposed extremal rays. This gives the first examples of such maps in three-dimensional matrix algebra. }
+}
+
+@article{Breuer_2006_Mixed,
+  title = {Optimal Entanglement Criterion for Mixed Quantum States},
+  author = {Breuer, Heinz-Peter},
+  journal = {Phys. Rev. Lett.},
+  volume = {97},
+  issue = {8},
+  pages = {080501},
+  numpages = {4},
+  year = {2006},
+  month = {Aug},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevLett.97.080501},
+  url = {https://link.aps.org/doi/10.1103/PhysRevLett.97.080501}
+}
+
+@misc{Hall_2006_Indecomposable,
+      title={Constructions of indecomposable positive maps based on a new criterion for indecomposability}, 
+      author={William Hall},
+      year={2006},
+      eprint={quant-ph/0607035},
+      archivePrefix={arXiv},
+      primaryClass={quant-ph}
+}

--- a/docs/articles.bib
+++ b/docs/articles.bib
@@ -1209,3 +1209,20 @@ numpages = {11}
 
 
 #Last name begins with Z
+
+
+@article{Johnston_2013_Spectrum,
+  title = {Separability from spectrum for qubit-qudit states},
+  author = {Johnston, Nathaniel},
+  journal = {Phys. Rev. A},
+  volume = {88},
+  issue = {6},
+  pages = {062330},
+  numpages = {5},
+  year = {2013},
+  month = {Dec},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevA.88.062330},
+  url = {https://link.aps.org/doi/10.1103/PhysRevA.88.062330}
+}
+

--- a/docs/articles.bib
+++ b/docs/articles.bib
@@ -88,6 +88,20 @@
    year={2006},
    month={Aug} }
 
+@article{Breuer_2006_Mixed,
+  title = {Optimal Entanglement Criterion for Mixed Quantum States},
+  author = {Breuer, Heinz-Peter},
+  journal = {Phys. Rev. Lett.},
+  volume = {97},
+  issue = {8},
+  pages = {080501},
+  numpages = {4},
+  year = {2006},
+  month = {Aug},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevLett.97.080501},
+  url = {https://link.aps.org/doi/10.1103/PhysRevLett.97.080501}
+}
 
 #Last name begins with C
 @article{Cabello_2002_NParticle,
@@ -189,11 +203,32 @@ abstract = {We consider a class of positive linear maps in the three-dimensional
       howpublished = {https://uwspace.uwaterloo.ca/handle/10012/9572}
 }
 
-@misc{Riley_2022_CVXPYKron,
-  author  = {Murray, Riley J},
-  title   = {{PR:} Have kron support non-constant expressions in either argument from {CXPY:} A Python-embedded modeling language for convex optimization problems},
-  howpublished = {https://github.com/cvxpy/cvxpy/issues/457#issue-309891424}}
+@misc{Cosentino_2014_Small,
+      title={Small sets of locally indistinguishable orthogonal maximally entangled states}, 
+      author={Alessandro Cosentino and Vincent Russo},
+      year={2014},
+      eprint={1307.3232},
+      archivePrefix={arXiv},
+      primaryClass={quant-ph}
+}
 
+@misc{Chen_2003_Realignment,
+      title={A matrix realignment method for recognizing entanglement}, 
+      author={Kai Chen and Ling-An Wu},
+      year={2003},
+      eprint={quant-ph/0205017},
+      archivePrefix={arXiv},
+      primaryClass={quant-ph}
+}
+
+@misc{Cariello_2013_Weak_irreducible,
+      title={Separability for Weak Irreducible matrices}, 
+      author={Daniel Cariello},
+      year={2013},
+      eprint={1311.7275},
+      archivePrefix={arXiv},
+      primaryClass={quant-ph}
+}
 
 #Last name begins with D
 @article{DiVincenzo_2000_Evidence,
@@ -288,6 +323,35 @@ author = {Gisin, N.},
    year={2002},
    month={Dec} }
 
+@article{Gühne_2009_Horodecki,
+title = {Entanglement detection},
+journal = {Physics Reports},
+volume = {474},
+number = {1},
+pages = {1-75},
+year = {2009},
+issn = {0370-1573},
+doi = {https://doi.org/10.1016/j.physrep.2009.02.004},
+url = {https://www.sciencedirect.com/science/article/pii/S0370157309000623},
+author = {Otfried Gühne and Géza Tóth},
+keywords = {Entanglement detection, Separability criteria, Genuine multipartite entanglement},
+abstract = {How can one prove that a given quantum state is entangled? In this paper we review different methods that have been proposed for entanglement detection. We first explain the basic elements of entanglement theory for two or more particles and then entanglement verification procedures such as Bell inequalities, entanglement witnesses, the determination of nonlinear properties of a quantum state via measurements on several copies, and spin squeezing inequalities. An emphasis is given to the theory and application of entanglement witnesses. We also discuss several experiments, where some of the presented methods have been implemented.}
+}
+
+@article{Gurvits_2002_Ball,
+  title = {Largest separable balls around the maximally mixed bipartite quantum state},
+  author = {Gurvits, Leonid and Barnum, Howard},
+  journal = {Phys. Rev. A},
+  volume = {66},
+  issue = {6},
+  pages = {062311},
+  numpages = {7},
+  year = {2002},
+  month = {Dec},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevA.66.062311},
+  url = {https://link.aps.org/doi/10.1103/PhysRevA.66.062311}
+}
 
 #Last name begins with H
 @inproceedings{Hayden_2013_TwoMessage,
@@ -358,6 +422,67 @@ author = {Gisin, N.},
   year={1993},
   publisher={Elsevier}
 }
+
+@article{Horodecki_1996_PPT_small_dimensions,
+title = {Separability of mixed states: necessary and sufficient conditions},
+journal = {Physics Letters A},
+volume = {223},
+number = {1},
+pages = {1-8},
+year = {1996},
+issn = {0375-9601},
+doi = {https://doi.org/10.1016/S0375-9601(96)00706-2},
+url = {https://www.sciencedirect.com/science/article/pii/S0375960196007062},
+author = {Michał Horodecki and Paweł Horodecki and Ryszard Horodecki},
+abstract = {We provide necessary and sufficient conditions for the separability of mixed states. As a result we obtain a simple criterion of the separability for 2 × 2 and 2 × 3 systems. Here, the positivity of the partial transposition of a state is necessary and sufficient for its separability. However, this is not the case in general. Some examples of mixtures which demonstrate the utility of the criterion are considered.}
+}
+
+@article{Horodecki_2000_PPT_low_rank,
+  title = {Operational criterion and constructive checks for the separability of low-rank density matrices},
+  author = {Horodecki, Pawe\l{} and Lewenstein, Maciej and Vidal, Guifr\'e and Cirac, Ignacio},
+  journal = {Phys. Rev. A},
+  volume = {62},
+  issue = {3},
+  pages = {032310},
+  numpages = {10},
+  year = {2000},
+  month = {Aug},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevA.62.032310},
+  url = {https://link.aps.org/doi/10.1103/PhysRevA.62.032310}
+}
+
+@misc{Hildebrand_2005_Cone,
+  author  = "Roland Hildebrand",
+  title   = "Comparison of the PPT cone and the separable cone for 2-by-n systems.",
+  year = {2005},
+  howpublished = {https://membres-ljk.imag.fr/Roland.Hildebrand/coreMPseminar2005_slides.pdf}
+  
+}
+
+@article{Ha_2011_Positive_map,
+author = {Ha, Kil-Chan and Kye, Seung-Hyeok},
+title = {Entanglement Witnesses Arising from Exposed Positive Linear Maps},
+journal = {Open Systems \& Information Dynamics},
+volume = {18},
+number = {04},
+pages = {323-337},
+year = {2011},
+doi = {10.1142/S1230161211000224},
+URL = {https://doi.org/10.1142/S1230161211000224},
+eprint = {https://doi.org/10.1142/S1230161211000224},
+abstract = {We consider entanglement witnesses arising from positive linear maps which generate exposed extremal rays. We show that every entangled state can be detected by one of these witnesses, and this witness detects a unique set of entangled states among those. Therefore, they provide a minimal set of witnesses to detect any kind of entanglement in a sense. Furthermore, if those maps are indecomposable then they detect large classes of entangled states with positive partial transposes which have nonempty relative interiors in the cone generated by all PPT states. We also provide a one-parameter family of indecomposable positive linear maps which generate exposed extremal rays. This gives the first examples of such maps in three-dimensional matrix algebra. }
+}
+
+@misc{Hall_2006_Indecomposable,
+      title={Constructions of indecomposable positive maps based on a new criterion for indecomposability}, 
+      author={William Hall},
+      year={2006},
+      eprint={quant-ph/0607035},
+      archivePrefix={arXiv},
+      primaryClass={quant-ph}
+}
+
 #Last name begins with I
 
 #Last name begins with J
@@ -382,6 +507,21 @@ author = {Gisin, N.},
       eprint={1207.1479},
       archivePrefix={arXiv},
       primaryClass={quant-ph}
+}
+
+@article{Johnston_2013_Spectrum,
+  title = {Separability from spectrum for qubit-qudit states},
+  author = {Johnston, Nathaniel},
+  journal = {Phys. Rev. A},
+  volume = {88},
+  issue = {6},
+  pages = {062330},
+  numpages = {5},
+  year = {2013},
+  month = {Dec},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevA.88.062330},
+  url = {https://link.aps.org/doi/10.1103/PhysRevA.88.062330}
 }
 
 @article{Johnston_2016_Extended,
@@ -605,20 +745,6 @@ author = {Gisin, N.},
   doi = {10.1103/PhysRevA.96.052336},
   url = {https://link.aps.org/doi/10.1103/PhysRevA.96.052336}
 }
-@article{Werner_1989_QuantumStates,
-  title = {Quantum states with Einstein-Podolsky-Rosen correlations admitting a hidden-variable model},
-  author = {Werner, Reinhard F.},
-  journal = {Phys. Rev. A},
-  volume = {40},
-  issue = {8},
-  pages = {4277--4281},
-  numpages = {0},
-  year = {1989},
-  month = {Oct},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevA.40.4277},
-  url = {https://link.aps.org/doi/10.1103/PhysRevA.40.4277}
-}
 
 
 
@@ -637,6 +763,11 @@ author = {Gisin, N.},
       archivePrefix={arXiv},
       primaryClass={quant-ph}
 }
+
+@misc{Riley_2022_CVXPYKron,
+  author  = {Murray, Riley J},
+  title   = {{PR:} Have kron support non-constant expressions in either argument from {CXPY:} A Python-embedded modeling language for convex optimization problems},
+  howpublished = {https://github.com/cvxpy/cvxpy/issues/457#issue-309891424}}
 
 #Last name begins with S
 @misc{Seshadri_2021_Git,
@@ -711,6 +842,21 @@ journal = {New Journal of Physics},
 
 #Last name begins with V
 
+@article{Vidal_1999_Robust,
+  title = {Robustness of entanglement},
+  author = {Vidal, Guifr\'e and Tarrach, Rolf},
+  journal = {Phys. Rev. A},
+  volume = {59},
+  issue = {1},
+  pages = {141--155},
+  numpages = {0},
+  year = {1999},
+  month = {Jan},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevA.59.141},
+  url = {https://link.aps.org/doi/10.1103/PhysRevA.59.141}
+}
+
 #Last name begins with W
 @misc{Watrous_2009_Semidefinite,
       title={Semidefinite programs for completely bounded norms}, 
@@ -757,6 +903,20 @@ pages = {78-88},
 numpages = {11}
 }
 
+@article{Werner_1989_QuantumStates,
+  title = {Quantum states with Einstein-Podolsky-Rosen correlations admitting a hidden-variable model},
+  author = {Werner, Reinhard F.},
+  journal = {Phys. Rev. A},
+  volume = {40},
+  issue = {8},
+  pages = {4277--4281},
+  numpages = {0},
+  year = {1989},
+  month = {Oct},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevA.40.4277},
+  url = {https://link.aps.org/doi/10.1103/PhysRevA.40.4277}
+}
 
 
 @misc{WikiAsymmOp,
@@ -1209,91 +1369,6 @@ numpages = {11}
 
 
 #Last name begins with Z
-
-
-@article{Johnston_2013_Spectrum,
-  title = {Separability from spectrum for qubit-qudit states},
-  author = {Johnston, Nathaniel},
-  journal = {Phys. Rev. A},
-  volume = {88},
-  issue = {6},
-  pages = {062330},
-  numpages = {5},
-  year = {2013},
-  month = {Dec},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevA.88.062330},
-  url = {https://link.aps.org/doi/10.1103/PhysRevA.88.062330}
-}
-
-@article{Peres_1996_PPT,
-  title = {Separability Criterion for Density Matrices},
-  author = {Peres, Asher},
-  journal = {Phys. Rev. Lett.},
-  volume = {77},
-  issue = {8},
-  pages = {1413--1415},
-  numpages = {0},
-  year = {1996},
-  month = {Aug},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevLett.77.1413},
-  url = {https://link.aps.org/doi/10.1103/PhysRevLett.77.1413}
-}
-
-@article{Gühne_2009_Horodecki,
-title = {Entanglement detection},
-journal = {Physics Reports},
-volume = {474},
-number = {1},
-pages = {1-75},
-year = {2009},
-issn = {0370-1573},
-doi = {https://doi.org/10.1016/j.physrep.2009.02.004},
-url = {https://www.sciencedirect.com/science/article/pii/S0370157309000623},
-author = {Otfried Gühne and Géza Tóth},
-keywords = {Entanglement detection, Separability criteria, Genuine multipartite entanglement},
-abstract = {How can one prove that a given quantum state is entangled? In this paper we review different methods that have been proposed for entanglement detection. We first explain the basic elements of entanglement theory for two or more particles and then entanglement verification procedures such as Bell inequalities, entanglement witnesses, the determination of nonlinear properties of a quantum state via measurements on several copies, and spin squeezing inequalities. An emphasis is given to the theory and application of entanglement witnesses. We also discuss several experiments, where some of the presented methods have been implemented.}
-}
-
-@article{Horodecki_1996_PPT_small_dimensions,
-title = {Separability of mixed states: necessary and sufficient conditions},
-journal = {Physics Letters A},
-volume = {223},
-number = {1},
-pages = {1-8},
-year = {1996},
-issn = {0375-9601},
-doi = {https://doi.org/10.1016/S0375-9601(96)00706-2},
-url = {https://www.sciencedirect.com/science/article/pii/S0375960196007062},
-author = {Michał Horodecki and Paweł Horodecki and Ryszard Horodecki},
-abstract = {We provide necessary and sufficient conditions for the separability of mixed states. As a result we obtain a simple criterion of the separability for 2 × 2 and 2 × 3 systems. Here, the positivity of the partial transposition of a state is necessary and sufficient for its separability. However, this is not the case in general. Some examples of mixtures which demonstrate the utility of the criterion are considered.}
-}
-
-@article{Horodecki_2000_PPT_low_rank,
-  title = {Operational criterion and constructive checks for the separability of low-rank density matrices},
-  author = {Horodecki, Pawe\l{} and Lewenstein, Maciej and Vidal, Guifr\'e and Cirac, Ignacio},
-  journal = {Phys. Rev. A},
-  volume = {62},
-  issue = {3},
-  pages = {032310},
-  numpages = {10},
-  year = {2000},
-  month = {Aug},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevA.62.032310},
-  url = {https://link.aps.org/doi/10.1103/PhysRevA.62.032310}
-}
-
-@misc{Chen_2003_Realignment,
-      title={A matrix realignment method for recognizing entanglement}, 
-      author={Kai Chen and Ling-An Wu},
-      year={2003},
-      eprint={quant-ph/0205017},
-      archivePrefix={arXiv},
-      primaryClass={quant-ph}
-}
-
 @article{Zhang_2008_Beyond_realignment,
   title = {Entanglement detection beyond the computable cross-norm or realignment criterion},
   author = {Zhang, Cheng-Jie and Zhang, Yong-Sheng and Zhang, Shun and Guo, Guang-Can},
@@ -1307,89 +1382,4 @@ abstract = {We provide necessary and sufficient conditions for the separability 
   publisher = {American Physical Society},
   doi = {10.1103/PhysRevA.77.060301},
   url = {https://link.aps.org/doi/10.1103/PhysRevA.77.060301}
-}
-
-@misc{Hildebrand_2005_Cone,
-  author  = "Roland Hildebrand",
-  title   = "Comparison of the PPT cone and the separable cone for 2-by-n systems.",
-  year = {2005},
-  howpublished = {https://membres-ljk.imag.fr/Roland.Hildebrand/coreMPseminar2005_slides.pdf}
-  
-}
-
-@article{Gurvits_2002_Ball,
-  title = {Largest separable balls around the maximally mixed bipartite quantum state},
-  author = {Gurvits, Leonid and Barnum, Howard},
-  journal = {Phys. Rev. A},
-  volume = {66},
-  issue = {6},
-  pages = {062311},
-  numpages = {7},
-  year = {2002},
-  month = {Dec},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevA.66.062311},
-  url = {https://link.aps.org/doi/10.1103/PhysRevA.66.062311}
-}
-
-@article{Vidal_1999_Robust,
-  title = {Robustness of entanglement},
-  author = {Vidal, Guifr\'e and Tarrach, Rolf},
-  journal = {Phys. Rev. A},
-  volume = {59},
-  issue = {1},
-  pages = {141--155},
-  numpages = {0},
-  year = {1999},
-  month = {Jan},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevA.59.141},
-  url = {https://link.aps.org/doi/10.1103/PhysRevA.59.141}
-}
-
-@misc{Cariello_2013_Weak_irreducible,
-      title={Separability for Weak Irreducible matrices}, 
-      author={Daniel Cariello},
-      year={2013},
-      eprint={1311.7275},
-      archivePrefix={arXiv},
-      primaryClass={quant-ph}
-}
-
-@article{Ha_2011_Positive_map,
-author = {Ha, Kil-Chan and Kye, Seung-Hyeok},
-title = {Entanglement Witnesses Arising from Exposed Positive Linear Maps},
-journal = {Open Systems \& Information Dynamics},
-volume = {18},
-number = {04},
-pages = {323-337},
-year = {2011},
-doi = {10.1142/S1230161211000224},
-URL = {https://doi.org/10.1142/S1230161211000224},
-eprint = {https://doi.org/10.1142/S1230161211000224},
-abstract = {We consider entanglement witnesses arising from positive linear maps which generate exposed extremal rays. We show that every entangled state can be detected by one of these witnesses, and this witness detects a unique set of entangled states among those. Therefore, they provide a minimal set of witnesses to detect any kind of entanglement in a sense. Furthermore, if those maps are indecomposable then they detect large classes of entangled states with positive partial transposes which have nonempty relative interiors in the cone generated by all PPT states. We also provide a one-parameter family of indecomposable positive linear maps which generate exposed extremal rays. This gives the first examples of such maps in three-dimensional matrix algebra. }
-}
-
-@article{Breuer_2006_Mixed,
-  title = {Optimal Entanglement Criterion for Mixed Quantum States},
-  author = {Breuer, Heinz-Peter},
-  journal = {Phys. Rev. Lett.},
-  volume = {97},
-  issue = {8},
-  pages = {080501},
-  numpages = {4},
-  year = {2006},
-  month = {Aug},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevLett.97.080501},
-  url = {https://link.aps.org/doi/10.1103/PhysRevLett.97.080501}
-}
-
-@misc{Hall_2006_Indecomposable,
-      title={Constructions of indecomposable positive maps based on a new criterion for indecomposability}, 
-      author={William Hall},
-      year={2006},
-      eprint={quant-ph/0607035},
-      archivePrefix={arXiv},
-      primaryClass={quant-ph}
 }

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -91,10 +91,6 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
 
     if min_dim == 1:
         # Every positive semidefinite matrix is separable when one of the local dimensions is 1.
-        print(
-            "Determined to be separable since every positive semidefinite matrix is separable ",
-            "when one of the local dimensions is 1.",
-        )
         return True
 
     dim = [int(x) for x in dim]
@@ -110,8 +106,6 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         # Separability criterion for density matrices.
         # Phys. Rev. Lett., 77:1413-1415, 1996.
         # Also, see Horodecki Theorem in https://arxiv.org/pdf/0811.2803.pdf.
-        print("Determined to be entangled via the PPT criterion.")
-        print("A. Peres. Separability criterion for density matrices. Phys. Rev. Lett., 77:1413-1415, 1996.")
         return False
 
     # Sometimes the PPT criterion is also sufficient for separability.
@@ -120,11 +114,6 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         # M. Horodecki, P. Horodecki, and R. Horodecki.
         # Separability of mixed states: Necessary and sufficient conditions.
         # Also, see Horodecki Theorem in https://arxiv.org/pdf/0811.2803.pdf.
-        print("Determined to be separable via sufficiency of the PPT criterion in small dimensions.")
-        print(
-            "M. Horodecki, P. Horodecki, and R. Horodecki. Separability of mixed states: ",
-            "Necessary and sufficient conditions.",
-        )
         return is_ppt_state
 
     if (
@@ -146,11 +135,6 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         # K. Chen and L.-A. Wu.
         # A matrix realignment method for recognizing entanglement.
         # Quantum Inf. Comput., 3:193-202, 2003.
-        print("Determined to be entangled via the realignment criterion.")
-        print(
-            "K. Chen and L.-A. Wu. A matrix realignment method for recognizing entanglement. ",
-            "Quantum Inf. Comput., 3:193-202, 2003.",
-        )
         return False
 
     # Another test that is strictly stronger than the realignment criterion.
@@ -161,11 +145,6 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         # C.-J. Zhang, Y.-S. Zhang, S. Zhang, and G.-C. Guo.
         # Entanglement detection beyond the cross-norm or realignment criterion.
         # Phys. Rev. A, 77:060301(R), 2008.
-        print("Determined to be entangled by using Theorem 1 of reference.")
-        print(
-            "C.-J. Zhang, Y.-S. Zhang, S. Zhang, and G.-C. Guo. Entanglement detection beyond ",
-            "the cross-norm or realignment criterion. Phys. Rev. A, 77:060301(R), 2008.",
-        )
         return False
 
     # Obtain sorted list of eigenvalues in descending order.
@@ -177,8 +156,6 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
     if min_dim == 2:
         # Check if X is separable from spectrum.
         if (lam[0] - lam[2 * max_dim - 2]) ** 2 <= 4 * lam[2 * max_dim - 3] * lam[2 * max_dim - 1] + tol**2:
-            print("Determined to be separable by inspecting its eigenvalues.")
-            print("N. Johnston. Separability from spectrum for qubit-qudit states. Phys. Rev. A, 88:062330, 2013.")
             return True
 
         # For the rest of the block matrix tests, we need the 2-dimensional
@@ -191,23 +168,13 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         C = state_t[max_dim : 2 * max_dim, max_dim : 2 * max_dim]
 
         if np.linalg.matrix_rank(B - B.conj().T) <= 1 and is_ppt_state:
-            print("Determined to be separable by being a perturbed block Hankel matrix.")
-            print(
-                "R. Hildebrand. Comparison of the PPT cone and the separable cone for 2-by-n systems. http://www-ljk.imag.fr/membres/Roland.Hildebrand/coreMPseminar2005_slides.pdf"
-            )
             return True
 
         X_2n_ppt_check = np.vstack((np.hstack(((5 / 6) * A - C / 6, B)), np.hstack((B.conj().T, (5 / 6) * C - A / 6))))
         if is_positive_semidefinite(X_2n_ppt_check) and is_ppt(X_2n_ppt_check, 2, [2, max_dim]):
-            print("Determined to be separable via the homothetic images approach.")
-            print(
-                "R. Hildebrand. Comparison of the PPT cone and the separable cone for 2-by-n systems. http://www-ljk.imag.fr/membres/Roland.Hildebrand/coreMPseminar2005_slides.pdf"
-            )
             return True
 
         if np.linalg.norm(B) ** 2 <= np.min(np.real(np.linalg.eig(A))) * np.min(np.real(np.linalg.eig(C))) + tol**2:
-            print("Determined to be separable by using Lemma 1 of")
-            print("N. Johnston. Separability from spectrum for qubit-qudit states. Phys. Rev. A, 88:062330, 2013.")
             return True
 
     # For the rest of the block-matrix tests, we need the 2-dimensional subsystem to be the
@@ -289,11 +256,6 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         )
 
         condition = abs(F) < max(tol**2, eps ** (3 / 4))
-        print(f"Determined to be {'separable' if condition else 'entangled'} by checking the Chow form.")
-        print(
-            "L. Chen and D. Z. Djokovic. Separability problem for multipartite states of rank at most four. ",
-            "J. Phys. A: Math. Theor., 46:275304, 2013.",
-        )
         return condition
 
     # Check the proximity of X with the maximally mixed state.
@@ -301,11 +263,6 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         # Determined to be separable by closeness to the maximally mixed state.
         # L. Gurvits and H. Barnum. Largest separable balls around the maximally mixed bipartite quantum state.
         # Phys. Rev. A, 66:062311, 2002.
-        print("Determined to be separable by closeness to the maximally mixed state.")
-        print(
-            "L. Gurvits and H. Barnum. Largest separable balls around the maximally mixed bipartite quantum state. ",
-            "Phys. Rev. A, 66:062311, 2002.",
-        )
         return True
 
     # Check if X is a rank-1 perturbation of the identity, which is
@@ -314,14 +271,10 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         # Determined to be separable by being a small rank-1 perturbation of the maximally-mixed state.
         # G. Vidal and R. Tarrach. Robustness of entanglement.
         # Phys. Rev. A, 59:141-155, 1999.
-        print("Determined to be separable by being a small rank-1 perturbation of the maximally-mixed state.")
-        print("G. Vidal and R. Tarrach. Robustness of entanglement. Phys. Rev. A, 59:141-155, 1999.")
         return True
 
     # Check tensor rank equalling 2
     if schmidt_rank(state, dim) <= 2:
-        print("Determined to be separable by having operator Schmidt rank at most 2.")
-        print("D. Cariello. Separability for weak irreducible matrices. E-print: arXiv:1311.7275 [quant-ph], 2013.")
         return True
 
     # There is a family of known optimal positive maps in the qutrit-qutrit
@@ -342,11 +295,6 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
                 Phi = np.diag([a + 1, c, b, b, a + 1, c, c, b, a + 1]) - phi * phi.conj().T
 
                 if not is_positive_semidefinite(partial_channel(state, Phi, 2, dim)):
-                    print(f"Determined to be entangled via the positive map Phi[a,b,c] with a = {a}, b = {b}, c = {c}")
-                    print(
-                        "K.-C. Ha and S.-H. Kye. Entanglement witnesses arising from exposed positive linear maps. ",
-                        "Open Systems & Information Dynamics, 18:323-337, 2011.",
-                    )
                     return False
 
     # Use the Breuer-Hall positive maps (in even dimensions only) based on
@@ -360,31 +308,9 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
             Phi = np.diag(np.ones((dim[p] ** 2, 1))) - phi * phi.conj().T - U * swap_operator(dim[p]) * U.conj().T
 
             if not is_positive_semidefinite(partial_channel(state, Phi, p + 1, dim)):
-                print(
-                    "Determined to be entangled via the Breuer-Hall positive maps based on "
-                    "antisymmetric unitary matrices."
-                )
-                print(
-                    "1. H.-P. Breuer. Optimal entanglement criterion for mixed quantum states. ",
-                    "Phys. Rev. Lett., 97:080501, 2006.",
-                )
-                print(
-                    "2. W. Hall. Constructions of indecomposable positive maps based on a new ",
-                    "criterion for indecomposability. E-print: arXiv:quant-ph/0607035, 2006.",
-                )
                 return False
 
     # The search for symmetric extensions.
     if any(has_symmetric_extension(state, level) for _ in range(1, level)):
-        print("Determined to be separable via the semidefinite program based on PPT symmetric extensions.")
-        print(
-            "M. Navascues, M. Owari, and M. B. Plenio. A complete criterion for separability detection."
-            "Phys. Rev. Lett., 103:160404, 2009."
-        )
         return True
-    print("Determined to be entangled by not having a PPT symmetric extension.")
-    print(
-        "A. C. Doherty, P. A. Parrilo, and F. M. Spedalieri. A complete family of"
-        "separability criteria. Phys. Rev. A, 69:022308, 2004."
-    )
     return False

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -14,6 +14,8 @@ from toqito.state_props.has_symmetric_extension import has_symmetric_extension
 from toqito.state_props.schmidt_rank import schmidt_rank
 from toqito.states.max_entangled import max_entangled
 
+from itertools import product
+
 
 def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: int = 2, tol: float = 1e-8) -> bool:
     r"""Determine if a given state (given as a density matrix) is a separable state :cite:`WikiSepSt`.
@@ -195,11 +197,9 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         q = orth(state)
 
         # This loop does not access all positions in `p`, and that's expected.
-        for j in range(6, 0, -1):
-            for k in range(7, j, -1):
-                for n in range(8, k, -1):
-                    for m in range(9, n, -1):
-                        p[j - 1, k - 1, n - 1, m - 1] = np.linalg.det(q[[j - 1, k - 1, n - 1, m - 1], :])
+        for j, k, n, m in product(range(6, 0, -1), range(7, 0, -1), range(8, 0, -1), range(9, 0, -1)):
+            if j < k < n < m:
+                p[j - 1, k - 1, n - 1, m - 1] = np.linalg.det(q[[j - 1, k - 1, n - 1, m - 1], :])
 
         F = np.linalg.det(
             np.array(
@@ -315,7 +315,7 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
             # Determined to be entangled via the Breuer-Hall positive maps based on antisymmetric unitary matrices.
             # H.-P. Breuer. Optimal entanglement criterion for mixed quantum states. Phys. Rev. Lett., 97:080501, 2006.
             # W. Hall. Constructions of indecomposable positive maps based on a new criterion for indecomposability.
-            # E-print: arXiv:quant-ph/0607035, 2006.            
+            # E-print: arXiv:quant-ph/0607035, 2006.
             if not is_positive_semidefinite(partial_channel(state, Phi, p + 1, dim)):
                 return False
 

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -2,11 +2,17 @@
 
 import numpy as np
 from picos import partial_trace
+from scipy.linalg import orth
 
 from toqito.channels import realignment
 from toqito.matrix_props import is_positive_semidefinite, trace_norm
+from toqito.perms.swap import swap
+from toqito.perms.swap_operator import swap_operator
 from toqito.state_props import in_separable_ball, is_ppt
 from toqito.state_props.has_symmetric_extension import has_symmetric_extension
+from toqito.state_props.schmidt_rank import schmidt_rank
+from toqito.states.max_entangled import max_entangled
+from toqito.channel_ops.partial_channel import partial_channel
 
 
 def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: int = 2, tol: float = 1e-8) -> bool:
@@ -93,6 +99,7 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
     pt_state_bob = partial_trace(state, [0], dim)
 
     # Check the PPT criterion.
+    is_ppt_state = is_ppt(state, 2, dim, tol)
     if not is_ppt(state, 2, dim, tol):
         # Determined to be entangled via the PPT criterion.
         # A. Peres.
@@ -107,7 +114,7 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         # M. Horodecki, P. Horodecki, and R. Horodecki.
         # Separability of mixed states: Necessary and sufficient conditions.
         # Also, see Horodecki Theorem in https://arxiv.org/pdf/0811.2803.pdf.
-        return is_ppt(state, 2, dim, tol)
+        return is_ppt_state
 
     if (
         state_rank + np.linalg.matrix_rank(pt_state_alice)
@@ -148,10 +155,43 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
     # Check these tests.
     if min_dim == 2:
         # Check if X is separable from spectrum.
-        if (lam[0] - lam[2 * max_dim - 1]) ** 2 <= 4 * lam[2 * max_dim - 2] * lam[2 * max_dim] + tol**2:
+        if (lam[0] - lam[2 * max_dim - 2]) ** 2 <= 4 * lam[2 * max_dim - 3] * lam[2 * max_dim - 1] + tol**2:
             print("Determined to be separable by inspecting its eigenvalues.")
             print("N. Johnston. Separability from spectrum for qubit-qudit states. Phys. Rev. A, 88:062330, 2013.")
             return True
+
+        # For the rest of the block matrix tests, we need the 2-dimensional
+        # subsystem to be the *first* subsystem, so swap accordingly.
+        state_t = swap(state, [1, 2], dim) if dim[0] > 2 else state
+
+        # Check if Lemma 1 of refs{13} applies to X. Also check the Hildebrand 2xn results.
+        A = state_t[:max_dim,:max_dim]
+        B = state_t[:max_dim,max_dim:2*max_dim]
+        C = state_t[max_dim:2*max_dim,max_dim:2*max_dim]
+
+        if np.linalg.matrix_rank(B - B.conj().T) <= 1 and is_ppt_state:
+            return True
+
+        X_2n_ppt_check = np.vstack(
+            (
+                np.hstack(((5/6)*A-C/6, B)),
+                np.hstack((B.conj().T, (5/6)*C-A/6))
+            )
+        )
+        if is_positive_semidefinite(X_2n_ppt_check) and is_ppt(X_2n_ppt_check, 2, [2, max_dim]):
+            print("Determined to be separable via the homothetic images approach.")
+            print("R. Hildebrand. Comparison of the PPT cone and the separable cone for 2-by-n systems. http://www-ljk.imag.fr/membres/Roland.Hildebrand/coreMPseminar2005_slides.pdf")
+            return True
+
+        if (
+            np.linalg.norm(B)**2
+            <= np.min(np.real(np.linalg.eig(A))) * np.min(np.real(np.linalg.eig(C))) + tol**2
+        ):
+            print("Determined to be separable by using Lemma 1 of")
+            print("N. Johnston. Separability from spectrum for qubit-qudit states. Phys. Rev. A, 88:062330, 2013.")
+            return True
+
+
 
     # For the rest of the block-matrix tests, we need the 2-dimensional subsystem to be the
     # first subsystem, so swap accordingly.
@@ -160,6 +200,37 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
     # else:
     #    Xt = state
     # commented out because pylint flagged this as an unused variable
+
+    # There are conditions that are both necessary and sufficient when both
+    # dimensions are 3 and the rank is 4
+    if state_rank == 4 and min_dim == 3 and max_dim == 3:
+        # This method computes more determinants than are actually
+        # necessary, but the speed loss isn't too great
+        p = np.zeros((9, 9, 9, 9))  # initialize.
+        q = orth(state)
+
+        for j in range(6, 0, -1):
+            for k in range(7, j, -1):
+                for l in range(8, k, -1):
+                    for m in range(9, l, -1):
+                        p[j-1, k-1, l-1, m-1] = np.linalg.det(q[[j-1, k-1, l-1, m-1], :])
+
+        # TODO: Ensure all indices are correct.
+        F = np.linalg.det(
+            np.array(
+                [
+                    [p[0,1,3,4], p[0,2,3,5], p[1,2,4,5], p[0,1,3,5]+p[0,2,3,4], p[0,1,4,5]+p[1,2,3,4], p[0,2,4,5]+p[1,2,3,5]],
+                    [p[0,1,6,7], p[0,2,6,8], p[1,2,7,8], p[0,1,6,8]+p[0,2,6,7], p[0,1,7,8]+p[1,2,6,7], p[0,2,7,8]+p[1,2,6,8]],
+                    [p[3,4,6,7], p[3,5,6,8], p[4,5,7,8], p[3,4,6,8]+p[3,5,6,7], p[3,4,7,8]+p[4,5,6,7], p[3,5,7,8]+p[4,5,6,8]],
+                    [p[0,1,3,7]-p[0,1,4,6], p[0,2,3,8]-p[0,2,5,6], p[1,2,4,8]-p[1,2,5,7], p[0,1,3,8]-p[0,1,5,6]+p[0,2,3,7]-p[0,2,4,6], p[0,1,4,8]-p[0,1,5,7]+p[1,2,3,7]-p[1,2,4,6], p[0,2,4,8]-p[0,2,5,7]+p[1,2,3,8]-p[1,2,5,6]],
+                    [p[0,3,4,7]-p[1,3,4,6], p[0,3,5,8]-p[2,3,5,6], p[1,4,5,8]-p[2,4,5,7], p[0,3,4,8]-p[1,3,5,6]+p[0,3,5,7]-p[2,3,4,6], p[0,4,5,7]-p[1,4,5,6]+p[1,3,4,8]-p[2,3,4,7], p[0,4,5,8]-p[2,3,5,7]+p[1,3,5,8]-p[2,4,5,6]],
+                    [p[0,4,6,7]-p[1,3,6,7], p[0,5,6,8]-p[2,3,6,8], p[1,5,7,8]-p[2,4,7,8], p[0,4,6,8]-p[1,3,6,8]+p[0,5,6,7]-p[2,3,6,7], p[0,4,7,8]-p[1,3,7,8]+p[1,5,6,7]-p[2,4,6,7], p[0,5,7,8]-p[2,3,7,8]+p[1,5,6,8]-p[2,4,6,8]]
+                ]
+            )
+        )
+
+        return abs(F) < max(tol ** 2, eps ** (3 / 4))
+
 
     # Check the proximity of X with the maximally mixed state.
     if in_separable_ball(state):
@@ -175,6 +246,60 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         # G. Vidal and R. Tarrach. Robustness of entanglement.
         # Phys. Rev. A, 59:141-155, 1999.
         return True
+
+    # Check tensor rank equalling 2
+    if schmidt_rank(state, dim) <= 2:
+        print("Determined to be separable by having operator Schmidt rank at most 2.")
+        print("D. Cariello. Separability for weak irreducible matrices. E-print: arXiv:1311.7275 [quant-ph], 2013.")
+        return True
+
+    # There is a family of known optimal positive maps in the qutrit-qutrit
+    # case. Check for entanglement using these.
+    if dim[0] == 3 and dim[1] == 3:
+        phi = max_entangled(3, False, False)
+        for t in np.arange(0, 1.0, 0.1):
+            for j in range(2):
+                if t > 0:  # this is a weird way of using both t and 1/t as indices for the maps Phi we generate
+                    t = 1 / t
+                elif j > 0:
+                    break
+
+                a = (1 - t) ** 2 / (1 - t + t ** 2)
+                b = t ** 2 / (1 - t + t ** 2)
+                c = 1 / (1 - t + t ** 2)
+                Phi = np.diag([a + 1, c, b, b, a + 1, c, c, b, a + 1]) - phi * phi.conj().T
+
+                if not is_positive_semidefinite(
+                    partial_channel(state, Phi, 2, dim)
+                ):
+                    print(f"Determined to be entangled via the positive map Phi[a,b,c] with a = {a}, b = {b}, c = {c}")
+                    print("K.-C. Ha and S.-H. Kye. Entanglement witnesses arising from exposed positive linear maps. Open Systems & Information Dynamics, 18:323-337, 2011.")
+                    return False
+
+    # Use the Breuer-Hall positive maps (in even dimensions only) based on
+    # antisymmetric unitary matrices.
+    for p in range(2):
+        # See https://stackoverflow.com/questions/57085118/equivalent-matlab-function-mod-in-numpy-or-python
+        # But here not a problem. TODO: Remove this statement.
+        if np.remainder(dim[p], 2) == 0:
+            phi = max_entangled(dim[p], 0, 0)
+            U = np.kron(
+                np.eye(dim[p]),
+                np.fliplr(
+                    np.diag(
+                        np.array([[np.ones((dim[p] / 2, 1))], [-np.ones(dim(p)/2,1)]])
+                    )
+                )
+            )
+            Phi = np.diag(np.ones((dim[p] ** 2, 1))) - phi * phi.conj().T - U * swap_operator(dim[p]) * U.conj().T
+
+            if not is_positive_semidefinite(
+                    partial_channel(state, Phi, p+1, dim)
+                ):
+                    print("Determined to be entangled via the Breuer-Hall positive maps based on antisymmetric unitary matrices.")
+                    print("1. H.-P. Breuer. Optimal entanglement criterion for mixed quantum states. Phys. Rev. Lett., 97:080501, 2006.")
+                    print("2. W. Hall. Constructions of indecomposable positive maps based on a new criterion for indecomposability. E-print: arXiv:quant-ph/0607035, 2006.")
+                    return False
 
     # The search for symmetric extensions.
     if any(has_symmetric_extension(state, level) for _ in range(2, level)):

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -1,10 +1,11 @@
 """Check if state is separable."""
 
 import numpy as np
-from picos import partial_trace
 from scipy.linalg import orth
 
+from toqito.channel_ops.partial_channel import partial_channel
 from toqito.channels import realignment
+from toqito.channels.partial_trace import partial_trace
 from toqito.matrix_props import is_positive_semidefinite, trace_norm
 from toqito.perms.swap import swap
 from toqito.perms.swap_operator import swap_operator
@@ -12,7 +13,6 @@ from toqito.state_props import in_separable_ball, is_ppt
 from toqito.state_props.has_symmetric_extension import has_symmetric_extension
 from toqito.state_props.schmidt_rank import schmidt_rank
 from toqito.states.max_entangled import max_entangled
-from toqito.channel_ops.partial_channel import partial_channel
 
 
 def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: int = 2, tol: float = 1e-8) -> bool:
@@ -91,6 +91,10 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
 
     if min_dim == 1:
         # Every positive semidefinite matrix is separable when one of the local dimensions is 1.
+        print(
+            "Determined to be separable since every positive semidefinite matrix is separable ",
+            "when one of the local dimensions is 1."
+        )
         return True
 
     dim = [int(x) for x in dim]
@@ -100,12 +104,14 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
 
     # Check the PPT criterion.
     is_ppt_state = is_ppt(state, 2, dim, tol)
-    if not is_ppt(state, 2, dim, tol):
+    if not is_ppt_state:
         # Determined to be entangled via the PPT criterion.
         # A. Peres.
         # Separability criterion for density matrices.
         # Phys. Rev. Lett., 77:1413-1415, 1996.
         # Also, see Horodecki Theorem in https://arxiv.org/pdf/0811.2803.pdf.
+        print("Determined to be entangled via the PPT criterion.")
+        print("A. Peres. Separability criterion for density matrices. Phys. Rev. Lett., 77:1413-1415, 1996.")
         return False
 
     # Sometimes the PPT criterion is also sufficient for separability.
@@ -114,6 +120,11 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         # M. Horodecki, P. Horodecki, and R. Horodecki.
         # Separability of mixed states: Necessary and sufficient conditions.
         # Also, see Horodecki Theorem in https://arxiv.org/pdf/0811.2803.pdf.
+        print("Determined to be separable via sufficiency of the PPT criterion in small dimensions.")
+        print(
+            "M. Horodecki, P. Horodecki, and R. Horodecki. Separability of mixed states: ",
+            "Necessary and sufficient conditions."
+        )
         return is_ppt_state
 
     if (
@@ -135,6 +146,11 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         # K. Chen and L.-A. Wu.
         # A matrix realignment method for recognizing entanglement.
         # Quantum Inf. Comput., 3:193-202, 2003.
+        print("Determined to be entangled via the realignment criterion.")
+        print(
+            "K. Chen and L.-A. Wu. A matrix realignment method for recognizing entanglement. ",
+            "Quantum Inf. Comput., 3:193-202, 2003."
+        )
         return False
 
     # Another test that is strictly stronger than the realignment criterion.
@@ -145,6 +161,11 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         # C.-J. Zhang, Y.-S. Zhang, S. Zhang, and G.-C. Guo.
         # Entanglement detection beyond the cross-norm or realignment criterion.
         # Phys. Rev. A, 77:060301(R), 2008.
+        print("Determined to be entangled by using Theorem 1 of reference.")
+        print(
+            "C.-J. Zhang, Y.-S. Zhang, S. Zhang, and G.-C. Guo. Entanglement detection beyond ",
+            "the cross-norm or realignment criterion. Phys. Rev. A, 77:060301(R), 2008."
+        )
         return False
 
     # Obtain sorted list of eigenvalues in descending order.
@@ -165,33 +186,29 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         state_t = swap(state, [1, 2], dim) if dim[0] > 2 else state
 
         # Check if Lemma 1 of refs{13} applies to X. Also check the Hildebrand 2xn results.
-        A = state_t[:max_dim,:max_dim]
-        B = state_t[:max_dim,max_dim:2*max_dim]
-        C = state_t[max_dim:2*max_dim,max_dim:2*max_dim]
+        A = state_t[:max_dim, :max_dim]
+        B = state_t[:max_dim, max_dim : 2 * max_dim]
+        C = state_t[max_dim : 2 * max_dim, max_dim : 2 * max_dim]
 
         if np.linalg.matrix_rank(B - B.conj().T) <= 1 and is_ppt_state:
+            print("Determined to be separable by being a perturbed block Hankel matrix.")
+            print(
+                "R. Hildebrand. Comparison of the PPT cone and the separable cone for 2-by-n systems. http://www-ljk.imag.fr/membres/Roland.Hildebrand/coreMPseminar2005_slides.pdf"
+            )
             return True
 
-        X_2n_ppt_check = np.vstack(
-            (
-                np.hstack(((5/6)*A-C/6, B)),
-                np.hstack((B.conj().T, (5/6)*C-A/6))
-            )
-        )
+        X_2n_ppt_check = np.vstack((np.hstack(((5 / 6) * A - C / 6, B)), np.hstack((B.conj().T, (5 / 6) * C - A / 6))))
         if is_positive_semidefinite(X_2n_ppt_check) and is_ppt(X_2n_ppt_check, 2, [2, max_dim]):
             print("Determined to be separable via the homothetic images approach.")
-            print("R. Hildebrand. Comparison of the PPT cone and the separable cone for 2-by-n systems. http://www-ljk.imag.fr/membres/Roland.Hildebrand/coreMPseminar2005_slides.pdf")
+            print(
+                "R. Hildebrand. Comparison of the PPT cone and the separable cone for 2-by-n systems. http://www-ljk.imag.fr/membres/Roland.Hildebrand/coreMPseminar2005_slides.pdf"
+            )
             return True
 
-        if (
-            np.linalg.norm(B)**2
-            <= np.min(np.real(np.linalg.eig(A))) * np.min(np.real(np.linalg.eig(C))) + tol**2
-        ):
+        if np.linalg.norm(B) ** 2 <= np.min(np.real(np.linalg.eig(A))) * np.min(np.real(np.linalg.eig(C))) + tol**2:
             print("Determined to be separable by using Lemma 1 of")
             print("N. Johnston. Separability from spectrum for qubit-qudit states. Phys. Rev. A, 88:062330, 2013.")
             return True
-
-
 
     # For the rest of the block-matrix tests, we need the 2-dimensional subsystem to be the
     # first subsystem, so swap accordingly.
@@ -211,32 +228,84 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
 
         for j in range(6, 0, -1):
             for k in range(7, j, -1):
-                for l in range(8, k, -1):
-                    for m in range(9, l, -1):
-                        p[j-1, k-1, l-1, m-1] = np.linalg.det(q[[j-1, k-1, l-1, m-1], :])
+                for n in range(8, k, -1):
+                    for m in range(9, n, -1):
+                        p[j - 1, k - 1, n - 1, m - 1] = np.linalg.det(q[[j - 1, k - 1, n - 1, m - 1], :])
 
         # TODO: Ensure all indices are correct.
         F = np.linalg.det(
             np.array(
                 [
-                    [p[0,1,3,4], p[0,2,3,5], p[1,2,4,5], p[0,1,3,5]+p[0,2,3,4], p[0,1,4,5]+p[1,2,3,4], p[0,2,4,5]+p[1,2,3,5]],
-                    [p[0,1,6,7], p[0,2,6,8], p[1,2,7,8], p[0,1,6,8]+p[0,2,6,7], p[0,1,7,8]+p[1,2,6,7], p[0,2,7,8]+p[1,2,6,8]],
-                    [p[3,4,6,7], p[3,5,6,8], p[4,5,7,8], p[3,4,6,8]+p[3,5,6,7], p[3,4,7,8]+p[4,5,6,7], p[3,5,7,8]+p[4,5,6,8]],
-                    [p[0,1,3,7]-p[0,1,4,6], p[0,2,3,8]-p[0,2,5,6], p[1,2,4,8]-p[1,2,5,7], p[0,1,3,8]-p[0,1,5,6]+p[0,2,3,7]-p[0,2,4,6], p[0,1,4,8]-p[0,1,5,7]+p[1,2,3,7]-p[1,2,4,6], p[0,2,4,8]-p[0,2,5,7]+p[1,2,3,8]-p[1,2,5,6]],
-                    [p[0,3,4,7]-p[1,3,4,6], p[0,3,5,8]-p[2,3,5,6], p[1,4,5,8]-p[2,4,5,7], p[0,3,4,8]-p[1,3,5,6]+p[0,3,5,7]-p[2,3,4,6], p[0,4,5,7]-p[1,4,5,6]+p[1,3,4,8]-p[2,3,4,7], p[0,4,5,8]-p[2,3,5,7]+p[1,3,5,8]-p[2,4,5,6]],
-                    [p[0,4,6,7]-p[1,3,6,7], p[0,5,6,8]-p[2,3,6,8], p[1,5,7,8]-p[2,4,7,8], p[0,4,6,8]-p[1,3,6,8]+p[0,5,6,7]-p[2,3,6,7], p[0,4,7,8]-p[1,3,7,8]+p[1,5,6,7]-p[2,4,6,7], p[0,5,7,8]-p[2,3,7,8]+p[1,5,6,8]-p[2,4,6,8]]
+                    [
+                        p[0, 1, 3, 4],
+                        p[0, 2, 3, 5],
+                        p[1, 2, 4, 5],
+                        p[0, 1, 3, 5] + p[0, 2, 3, 4],
+                        p[0, 1, 4, 5] + p[1, 2, 3, 4],
+                        p[0, 2, 4, 5] + p[1, 2, 3, 5],
+                    ],
+                    [
+                        p[0, 1, 6, 7],
+                        p[0, 2, 6, 8],
+                        p[1, 2, 7, 8],
+                        p[0, 1, 6, 8] + p[0, 2, 6, 7],
+                        p[0, 1, 7, 8] + p[1, 2, 6, 7],
+                        p[0, 2, 7, 8] + p[1, 2, 6, 8],
+                    ],
+                    [
+                        p[3, 4, 6, 7],
+                        p[3, 5, 6, 8],
+                        p[4, 5, 7, 8],
+                        p[3, 4, 6, 8] + p[3, 5, 6, 7],
+                        p[3, 4, 7, 8] + p[4, 5, 6, 7],
+                        p[3, 5, 7, 8] + p[4, 5, 6, 8],
+                    ],
+                    [
+                        p[0, 1, 3, 7] - p[0, 1, 4, 6],
+                        p[0, 2, 3, 8] - p[0, 2, 5, 6],
+                        p[1, 2, 4, 8] - p[1, 2, 5, 7],
+                        p[0, 1, 3, 8] - p[0, 1, 5, 6] + p[0, 2, 3, 7] - p[0, 2, 4, 6],
+                        p[0, 1, 4, 8] - p[0, 1, 5, 7] + p[1, 2, 3, 7] - p[1, 2, 4, 6],
+                        p[0, 2, 4, 8] - p[0, 2, 5, 7] + p[1, 2, 3, 8] - p[1, 2, 5, 6],
+                    ],
+                    [
+                        p[0, 3, 4, 7] - p[1, 3, 4, 6],
+                        p[0, 3, 5, 8] - p[2, 3, 5, 6],
+                        p[1, 4, 5, 8] - p[2, 4, 5, 7],
+                        p[0, 3, 4, 8] - p[1, 3, 5, 6] + p[0, 3, 5, 7] - p[2, 3, 4, 6],
+                        p[0, 4, 5, 7] - p[1, 4, 5, 6] + p[1, 3, 4, 8] - p[2, 3, 4, 7],
+                        p[0, 4, 5, 8] - p[2, 3, 5, 7] + p[1, 3, 5, 8] - p[2, 4, 5, 6],
+                    ],
+                    [
+                        p[0, 4, 6, 7] - p[1, 3, 6, 7],
+                        p[0, 5, 6, 8] - p[2, 3, 6, 8],
+                        p[1, 5, 7, 8] - p[2, 4, 7, 8],
+                        p[0, 4, 6, 8] - p[1, 3, 6, 8] + p[0, 5, 6, 7] - p[2, 3, 6, 7],
+                        p[0, 4, 7, 8] - p[1, 3, 7, 8] + p[1, 5, 6, 7] - p[2, 4, 6, 7],
+                        p[0, 5, 7, 8] - p[2, 3, 7, 8] + p[1, 5, 6, 8] - p[2, 4, 6, 8],
+                    ],
                 ]
             )
         )
 
-        return abs(F) < max(tol ** 2, eps ** (3 / 4))
-
+        condition = abs(F) < max(tol**2, eps ** (3 / 4))
+        print(f"Determined to be {'separable' if condition else 'entangled'} by checking the Chow form.")
+        print(
+            "L. Chen and D. Z. Djokovic. Separability problem for multipartite states of rank at most four. ",
+            "J. Phys. A: Math. Theor., 46:275304, 2013."
+        )
+        return condition
 
     # Check the proximity of X with the maximally mixed state.
     if in_separable_ball(state):
         # Determined to be separable by closeness to the maximally mixed state.
         # L. Gurvits and H. Barnum. Largest separable balls around the maximally mixed bipartite quantum state.
         # Phys. Rev. A, 66:062311, 2002.
+        print("Determined to be separable by closeness to the maximally mixed state.")
+        print(
+            "L. Gurvits and H. Barnum. Largest separable balls around the maximally mixed bipartite quantum state. ",
+            "Phys. Rev. A, 66:062311, 2002."
+        )
         return True
 
     # Check if X is a rank-1 perturbation of the identity, which is
@@ -245,6 +314,8 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         # Determined to be separable by being a small rank-1 perturbation of the maximally-mixed state.
         # G. Vidal and R. Tarrach. Robustness of entanglement.
         # Phys. Rev. A, 59:141-155, 1999.
+        print("Determined to be separable by being a small rank-1 perturbation of the maximally-mixed state.")
+        print("G. Vidal and R. Tarrach. Robustness of entanglement. Phys. Rev. A, 59:141-155, 1999.")
         return True
 
     # Check tensor rank equalling 2
@@ -264,16 +335,17 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
                 elif j > 0:
                     break
 
-                a = (1 - t) ** 2 / (1 - t + t ** 2)
-                b = t ** 2 / (1 - t + t ** 2)
-                c = 1 / (1 - t + t ** 2)
+                a = (1 - t) ** 2 / (1 - t + t**2)
+                b = t**2 / (1 - t + t**2)
+                c = 1 / (1 - t + t**2)
                 Phi = np.diag([a + 1, c, b, b, a + 1, c, c, b, a + 1]) - phi * phi.conj().T
 
-                if not is_positive_semidefinite(
-                    partial_channel(state, Phi, 2, dim)
-                ):
+                if not is_positive_semidefinite(partial_channel(state, Phi, 2, dim)):
                     print(f"Determined to be entangled via the positive map Phi[a,b,c] with a = {a}, b = {b}, c = {c}")
-                    print("K.-C. Ha and S.-H. Kye. Entanglement witnesses arising from exposed positive linear maps. Open Systems & Information Dynamics, 18:323-337, 2011.")
+                    print(
+                        "K.-C. Ha and S.-H. Kye. Entanglement witnesses arising from exposed positive linear maps. ",
+                        "Open Systems & Information Dynamics, 18:323-337, 2011."
+                    )
                     return False
 
     # Use the Breuer-Hall positive maps (in even dimensions only) based on
@@ -284,22 +356,24 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         if np.remainder(dim[p], 2) == 0:
             phi = max_entangled(dim[p], 0, 0)
             U = np.kron(
-                np.eye(dim[p]),
-                np.fliplr(
-                    np.diag(
-                        np.array([[np.ones((dim[p] / 2, 1))], [-np.ones(dim(p)/2,1)]])
-                    )
-                )
+                np.eye(dim[p]), np.fliplr(np.diag(np.array([[np.ones((dim[p] / 2, 1))], [-np.ones(dim(p) / 2, 1)]])))
             )
             Phi = np.diag(np.ones((dim[p] ** 2, 1))) - phi * phi.conj().T - U * swap_operator(dim[p]) * U.conj().T
 
-            if not is_positive_semidefinite(
-                    partial_channel(state, Phi, p+1, dim)
-                ):
-                    print("Determined to be entangled via the Breuer-Hall positive maps based on antisymmetric unitary matrices.")
-                    print("1. H.-P. Breuer. Optimal entanglement criterion for mixed quantum states. Phys. Rev. Lett., 97:080501, 2006.")
-                    print("2. W. Hall. Constructions of indecomposable positive maps based on a new criterion for indecomposability. E-print: arXiv:quant-ph/0607035, 2006.")
-                    return False
+            if not is_positive_semidefinite(partial_channel(state, Phi, p + 1, dim)):
+                print(
+                    "Determined to be entangled via the Breuer-Hall positive maps based on "
+                    "antisymmetric unitary matrices."
+                )
+                print(
+                    "1. H.-P. Breuer. Optimal entanglement criterion for mixed quantum states. ",
+                    "Phys. Rev. Lett., 97:080501, 2006."
+                )
+                print(
+                    "2. W. Hall. Constructions of indecomposable positive maps based on a new ",
+                    "criterion for indecomposability. E-print: arXiv:quant-ph/0607035, 2006."
+                )
+                return False
 
     # The search for symmetric extensions.
     if any(has_symmetric_extension(state, level) for _ in range(2, level)):

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -162,7 +162,8 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         # subsystem to be the *first* subsystem, so swap accordingly.
         state_t = swap(state, [1, 2], dim) if dim[0] > 2 else state
 
-        # Check if Lemma 1 of refs{13} applies to X. Also check the Hildebrand 2xn results.
+        # Check if Lemma 1 of "N. Johnston. Separability from spectrum for qubit-qudit states. Phys. Rev. A, 88:062330, 2013"
+        # applies to X. Also check the Hildebrand 2xn results.
         A = state_t[:max_dim, :max_dim]
         B = state_t[:max_dim, max_dim : 2 * max_dim]
         C = state_t[max_dim : 2 * max_dim, max_dim : 2 * max_dim]

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -329,15 +329,16 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
     if dim[0] == 3 and dim[1] == 3:
         phi = max_entangled(3, False, False)
         for t in np.arange(0, 1.0, 0.1):
+            t_ = t  # This is to evade ruff `PLW2901` error.
             for j in range(2):
-                if t > 0:  # this is a weird way of using both t and 1/t as indices for the maps Phi we generate
-                    t = 1 / t
+                if t_ > 0:  # this is a weird way of using both t and 1/t as indices for the maps Phi we generate
+                    t_ = 1 / t_
                 elif j > 0:
                     break
 
-                a = (1 - t) ** 2 / (1 - t + t**2)
-                b = t**2 / (1 - t + t**2)
-                c = 1 / (1 - t + t**2)
+                a = (1 - t_) ** 2 / (1 - t_ + t_**2)
+                b = t_**2 / (1 - t_ + t_**2)
+                c = 1 / (1 - t_ + t_**2)
                 Phi = np.diag([a + 1, c, b, b, a + 1, c, c, b, a + 1]) - phi * phi.conj().T
 
                 if not is_positive_semidefinite(partial_channel(state, Phi, 2, dim)):

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -352,8 +352,6 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
     # Use the Breuer-Hall positive maps (in even dimensions only) based on
     # antisymmetric unitary matrices.
     for p in range(2):
-        # See https://stackoverflow.com/questions/57085118/equivalent-matlab-function-mod-in-numpy-or-python
-        # But here not a problem. TODO: Remove this statement.
         if np.remainder(dim[p], 2) == 0:
             phi = max_entangled(dim[p], 0, 0)
             U = np.kron(

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -1,5 +1,7 @@
 """Check if state is separable."""
 
+from itertools import product
+
 import numpy as np
 from scipy.linalg import orth
 
@@ -13,8 +15,6 @@ from toqito.state_props import in_separable_ball, is_ppt
 from toqito.state_props.has_symmetric_extension import has_symmetric_extension
 from toqito.state_props.schmidt_rank import schmidt_rank
 from toqito.states.max_entangled import max_entangled
-
-from itertools import product
 
 
 def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: int = 2, tol: float = 1e-8) -> bool:

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -103,7 +103,7 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
     # Check the PPT criterion.
     is_ppt_state = is_ppt(state, 2, dim, tol)
     if not is_ppt_state:
-        # Determined to be entangled via the PPT criterion. See (Peres_1996_PPT).
+        # Determined to be entangled via the PPT criterion. See (Peres_1996_Separability).
         # Also, see Horodecki Theorem in (Gühne_2009_Horodecki).
         return False
 

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -93,7 +93,7 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         # Every positive semidefinite matrix is separable when one of the local dimensions is 1.
         print(
             "Determined to be separable since every positive semidefinite matrix is separable ",
-            "when one of the local dimensions is 1."
+            "when one of the local dimensions is 1.",
         )
         return True
 
@@ -123,7 +123,7 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         print("Determined to be separable via sufficiency of the PPT criterion in small dimensions.")
         print(
             "M. Horodecki, P. Horodecki, and R. Horodecki. Separability of mixed states: ",
-            "Necessary and sufficient conditions."
+            "Necessary and sufficient conditions.",
         )
         return is_ppt_state
 
@@ -149,7 +149,7 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         print("Determined to be entangled via the realignment criterion.")
         print(
             "K. Chen and L.-A. Wu. A matrix realignment method for recognizing entanglement. ",
-            "Quantum Inf. Comput., 3:193-202, 2003."
+            "Quantum Inf. Comput., 3:193-202, 2003.",
         )
         return False
 
@@ -164,7 +164,7 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         print("Determined to be entangled by using Theorem 1 of reference.")
         print(
             "C.-J. Zhang, Y.-S. Zhang, S. Zhang, and G.-C. Guo. Entanglement detection beyond ",
-            "the cross-norm or realignment criterion. Phys. Rev. A, 77:060301(R), 2008."
+            "the cross-norm or realignment criterion. Phys. Rev. A, 77:060301(R), 2008.",
         )
         return False
 
@@ -292,7 +292,7 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         print(f"Determined to be {'separable' if condition else 'entangled'} by checking the Chow form.")
         print(
             "L. Chen and D. Z. Djokovic. Separability problem for multipartite states of rank at most four. ",
-            "J. Phys. A: Math. Theor., 46:275304, 2013."
+            "J. Phys. A: Math. Theor., 46:275304, 2013.",
         )
         return condition
 
@@ -304,7 +304,7 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
         print("Determined to be separable by closeness to the maximally mixed state.")
         print(
             "L. Gurvits and H. Barnum. Largest separable balls around the maximally mixed bipartite quantum state. ",
-            "Phys. Rev. A, 66:062311, 2002."
+            "Phys. Rev. A, 66:062311, 2002.",
         )
         return True
 
@@ -344,7 +344,7 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
                     print(f"Determined to be entangled via the positive map Phi[a,b,c] with a = {a}, b = {b}, c = {c}")
                     print(
                         "K.-C. Ha and S.-H. Kye. Entanglement witnesses arising from exposed positive linear maps. ",
-                        "Open Systems & Information Dynamics, 18:323-337, 2011."
+                        "Open Systems & Information Dynamics, 18:323-337, 2011.",
                     )
                     return False
 
@@ -367,11 +367,11 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
                 )
                 print(
                     "1. H.-P. Breuer. Optimal entanglement criterion for mixed quantum states. ",
-                    "Phys. Rev. Lett., 97:080501, 2006."
+                    "Phys. Rev. Lett., 97:080501, 2006.",
                 )
                 print(
                     "2. W. Hall. Constructions of indecomposable positive maps based on a new ",
-                    "criterion for indecomposability. E-print: arXiv:quant-ph/0607035, 2006."
+                    "criterion for indecomposability. E-print: arXiv:quant-ph/0607035, 2006.",
                 )
                 return False
 

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -223,16 +223,16 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
     if state_rank == 4 and min_dim == 3 and max_dim == 3:
         # This method computes more determinants than are actually
         # necessary, but the speed loss isn't too great
-        p = np.zeros((9, 9, 9, 9))  # initialize.
+        p = np.zeros((6, 7, 8, 9))  # initialize.
         q = orth(state)
 
+        # This loop does not access all positions in `p`, and that's expected.
         for j in range(6, 0, -1):
             for k in range(7, j, -1):
                 for n in range(8, k, -1):
                     for m in range(9, n, -1):
                         p[j - 1, k - 1, n - 1, m - 1] = np.linalg.det(q[[j - 1, k - 1, n - 1, m - 1], :])
 
-        # TODO: Ensure all indices are correct.
         F = np.linalg.det(
             np.array(
                 [
@@ -377,6 +377,16 @@ def is_separable(state: np.ndarray, dim: None | int | list[int] = None, level: i
                 return False
 
     # The search for symmetric extensions.
-    if any(has_symmetric_extension(state, level) for _ in range(2, level)):
+    if any(has_symmetric_extension(state, level) for _ in range(1, level)):
+        print("Determined to be separable via the semidefinite program based on PPT symmetric extensions.")
+        print(
+            "M. Navascues, M. Owari, and M. B. Plenio. A complete criterion for separability detection."
+            "Phys. Rev. Lett., 103:160404, 2009."
+        )
         return True
+    print("Determined to be entangled by not having a PPT symmetric extension.")
+    print(
+        "A. C. Doherty, P. A. Parrilo, and F. M. Spedalieri. A complete family of"
+        "separability criteria. Phys. Rev. A, 69:022308, 2004."
+    )
     return False

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -130,7 +130,7 @@ def test_separable_schmidt_rank():
 
 
 def test_separable_based_on_eigenvalues():
-    """Determined to be separable by inspecting its eigenvalues. See Lemma 1 of https://arxiv.org/abs/1309.2006."""
+    """Determined to be separable by inspecting its eigenvalues. See Lemma 1 of :cite:`Johnston_2013_Spectrum`."""
     # TODO: Although this satisfies the eigenvalues condition (from the paper), this returns True from a line above
     # the eigenvalues condition. Need to change `rho`.
     # State taken from https://arxiv.org/pdf/1309.2006

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -1,6 +1,7 @@
 """Test is_separable."""
 
 import numpy as np
+import pytest
 
 from toqito.channels import partial_trace
 from toqito.matrix_props import is_density
@@ -92,41 +93,57 @@ def test_entangled_cross_norm_realignment_criterion():
     np.testing.assert_equal(is_separable(rho), False)
 
 
-def test_separable_based_on_eigenvalues():
-    # TODO: This is returning True from a line above the eigenvalues condition. Need to change rho, etc...
-    # State taken from https://arxiv.org/pdf/1309.2006
-    rho = np.array([
-        [1 / 11, 0, 0, 0],
-        [0, 3 / 11, 2 / 11, 0],
-        [0, 2 / 11, 3 / 11, 0],
-        [0, 0, 0, 4 / 11]
-    ])
-    np.testing.assert_equal(is_separable(rho), True)
-
-
-def test_separable_rank4_dim3_rho():
-    rho =  np.array(
+def test_separable_schmidt_rank():
+    rho = np.array(
         [
-            [4, 1, 1, 1, 0, 0, 0, 0, 0],
-            [1, 4, 1, 1, 0, 0, 0, 0, 0],
-            [1, 1, 4, 1, 0, 0, 0, 0, 0],
-            [1, 1, 1, 4, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0, 0]
+            [0.25, 0.15, 0.1, 0.15, 0.09, 0.06, 0.1, 0.06, 0.04],
+            [0.15, 0.2, 0.05, 0.09, 0.12, 0.03, 0.06, 0.08, 0.02],
+            [0.1, 0.05, 0.05, 0.06, 0.03, 0.03, 0.04, 0.02, 0.02],
+            [0.15, 0.09, 0.06, 0.2, 0.12, 0.08, 0.05, 0.03, 0.02],
+            [0.09, 0.12, 0.03, 0.12, 0.16, 0.04, 0.03, 0.04, 0.01],
+            [0.06, 0.03, 0.03, 0.08, 0.04, 0.04, 0.02, 0.01, 0.01],
+            [0.1, 0.06, 0.04, 0.05, 0.03, 0.02, 0.05, 0.03, 0.02],
+            [0.06, 0.08, 0.02, 0.03, 0.04, 0.01, 0.03, 0.04, 0.01],
+            [0.04, 0.02, 0.02, 0.02, 0.01, 0.01, 0.02, 0.01, 0.01],
         ]
     )
     np.testing.assert_equal(is_separable(rho), True)
 
 
-def test_2n_ppt_check_array():
-    state = np.array([
-        [0.5, 0, 0, 0.5],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0],
-        [0.5, 0, 0, 0.5]
-    ])
-    # TODO
+# TODO: BELOW TESTS NEED CHANGES...TESTS ABOVE ARE ALREADY TESTED AND MATCHED WITH MATLAB VERSION.
+# def test_separable_chow_form():
+#     rho = np.array(
+#         [
+#             [4, 1, 1, 1, 0, 0, 0, 0, 0],
+#             [1, 4, 1, 1, 0, 0, 0, 0, 0],
+#             [1, 1, 4, 1, 0, 0, 0, 0, 0],
+#             [1, 1, 1, 4, 0, 0, 0, 0, 0],
+#             [0, 0, 0, 0, 0, 0, 0, 0, 0],
+#             [0, 0, 0, 0, 0, 0, 0, 0, 0],
+#             [0, 0, 0, 0, 0, 0, 0, 0, 0],
+#             [0, 0, 0, 0, 0, 0, 0, 0, 0],
+#             [0, 0, 0, 0, 0, 0, 0, 0, 0],
+#         ]
+#     )
+#     np.testing.assert_equal(is_separable(rho), True)
 
+
+def test_separable_based_on_eigenvalues():
+    # TODO: Although this satisfies the eigenvalues condition (from the paper), this returns True from a line above the eigenvalues condition. Need to change `rho`.
+    # State taken from https://arxiv.org/pdf/1309.2006
+    rho = np.array([[1 / 11, 0, 0, 0], [0, 3 / 11, 2 / 11, 0], [0, 2 / 11, 3 / 11, 0], [0, 0, 0, 4 / 11]])
+    np.testing.assert_equal(is_separable(rho), True)
+
+
+def test_2n_ppt_check_array():
+    state = np.array(
+        [
+            [0.5, 0, 0, 0, 0, 0.5],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0.5, 0, 0, 0, 0, 0.5],
+        ]
+    )
+    # TODO

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -93,6 +93,42 @@ def test_entangled_cross_norm_realignment_criterion():
     np.testing.assert_equal(is_separable(rho), False)
 
 
+def test_separable_closeness_to_maximally_mixed_state():
+    """Determined to be separable by closeness to the maximally mixed state."""
+    rho = np.array(
+        [
+            [4, 1, 1, 1, 0, 0, 0, 0, 0],
+            [1, 4, 1, 1, 0, 0, 0, 0, 0],
+            [1, 1, 4, 1, 0, 0, 0, 0, 0],
+            [1, 1, 1, 4, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 4, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 4, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 4, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 4, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 4],
+        ]
+    )
+    np.testing.assert_equal(is_separable(rho), True)
+
+
+def test_separable_small_rank1_perturbation_of_maximally_mixed_state():
+    """Determined to be separable by being a small rank-1 perturbation of the maximally-mixed state."""
+    rho = np.array(
+        [
+            [4, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 4, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 4, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 4, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 4, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 4, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 4, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 4, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 4],
+        ]
+    )
+    np.testing.assert_equal(is_separable(rho), True)
+
+
 def test_separable_schmidt_rank():
     """Determined to be separable by having operator Schmidt rank at most 2."""
     rho = np.array(
@@ -111,30 +147,56 @@ def test_separable_schmidt_rank():
     np.testing.assert_equal(is_separable(rho), True)
 
 
-# TODO: BELOW TESTS NEED CHANGES...TESTS ABOVE ARE ALREADY TESTED AND MATCHED WITH MATLAB VERSION.
+def test_entangled_symmetric_extension():
+    """Determined to be entangled by not having a PPT symmetric extension."""
+    # This matrix is obtained by using the `rho` from `test_separable_schmidt_rank`
+    # and finding the nearest PSD matrix to it. See https://stackoverflow.com/a/18542094.
+    rho = np.array(
+        [
+            [1.0, 0.67, 0.91, 0.67, 0.45, 0.61, 0.88, 0.59, 0.79],
+            [0.67, 1.0, 0.5, 0.45, 0.67, 0.34, 0.59, 0.88, 0.44],
+            [0.91, 0.5, 1.0, 0.61, 0.34, 0.68, 0.81, 0.44, 0.88],
+            [0.67, 0.45, 0.61, 1.0, 0.67, 0.91, 0.5, 0.33, 0.45],
+            [0.45, 0.67, 0.34, 0.67, 1.0, 0.5, 0.33, 0.5, 0.25],
+            [0.61, 0.34, 0.68, 0.91, 0.5, 1.0, 0.45, 0.26, 0.5],
+            [0.88, 0.59, 0.81, 0.5, 0.33, 0.45, 1.0, 0.66, 0.91],
+            [0.59, 0.88, 0.44, 0.33, 0.5, 0.26, 0.66, 1.0, 0.48],
+            [0.79, 0.44, 0.88, 0.45, 0.25, 0.5, 0.91, 0.48, 1.0],
+        ]
+    )
+
+    np.testing.assert_equal(is_separable(rho), False)
+
+
 # def test_separable_chow_form():
-#     rho = np.array(
-#         [
-#             [4, 1, 1, 1, 0, 0, 0, 0, 0],
-#             [1, 4, 1, 1, 0, 0, 0, 0, 0],
-#             [1, 1, 4, 1, 0, 0, 0, 0, 0],
-#             [1, 1, 1, 4, 0, 0, 0, 0, 0],
-#             [0, 0, 0, 0, 0, 0, 0, 0, 0],
-#             [0, 0, 0, 0, 0, 0, 0, 0, 0],
-#             [0, 0, 0, 0, 0, 0, 0, 0, 0],
-#             [0, 0, 0, 0, 0, 0, 0, 0, 0],
-#             [0, 0, 0, 0, 0, 0, 0, 0, 0],
-#         ]
-#     )
+# rho = np.array(
+#     [
+#         [4, 1, 1, 1, 0, 0, 0, 0, 0],
+#         [1, 4, 1, 1, 0, 0, 0, 0, 0],
+#         [1, 1, 4, 1, 0, 0, 0, 0, 0],
+#         [1, 1, 1, 4, 0, 0, 0, 0, 0],
+#         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+#         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+#         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+#         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+#         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+#     ]
+# )
 #     np.testing.assert_equal(is_separable(rho), True)
 
 
 def test_separable_based_on_eigenvalues():
     """Determined to be separable by inspecting its eigenvalues. See Lemma 1 of :cite:`Johnston_2013_Spectrum`."""
     # TODO: Although this satisfies the eigenvalues condition (from the paper), this returns True from a line above
-    # the eigenvalues condition. Need to change `rho`.
-    # State taken from https://arxiv.org/pdf/1309.2006
-    rho = np.array([[1 / 11, 0, 0, 0], [0, 3 / 11, 2 / 11, 0], [0, 2 / 11, 3 / 11, 0], [0, 0, 0, 4 / 11]])
+    # the eigenvalues condition.
+    rho = np.array(
+        [
+            [4 / 22, 2 / 22, -2 / 22, 2 / 22],
+            [2 / 22, 7 / 22, -2 / 22, -1 / 22],
+            [-2 / 22, -2 / 22, 4 / 22, -2 / 22],
+            [2 / 22, -1 / 22, -2 / 22, 7 / 22],
+        ]
+    )
     np.testing.assert_equal(is_separable(rho), True)
 
 

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -108,6 +108,7 @@ def test_separable_closeness_to_maximally_mixed_state():
             [0, 0, 0, 0, 0, 0, 0, 0, 4],
         ]
     )
+    rho = rho / np.trace(rho)
     np.testing.assert_equal(is_separable(rho), True)
 
 
@@ -126,6 +127,7 @@ def test_separable_small_rank1_perturbation_of_maximally_mixed_state():
             [1, 1, 1, 1, 1, 1, 1, 1, 4],
         ]
     )
+    rho = rho / np.trace(rho)
     np.testing.assert_equal(is_separable(rho), True)
 
 
@@ -144,6 +146,7 @@ def test_separable_schmidt_rank():
             [0.04, 0.02, 0.02, 0.02, 0.01, 0.01, 0.02, 0.01, 0.01],
         ]
     )
+    rho = rho / np.trace(rho)
     np.testing.assert_equal(is_separable(rho), True)
 
 
@@ -164,7 +167,7 @@ def test_entangled_symmetric_extension():
             [0.79, 0.44, 0.88, 0.45, 0.25, 0.5, 0.91, 0.48, 1.0],
         ]
     )
-
+    rho = rho / np.trace(rho)
     np.testing.assert_equal(is_separable(rho), False)
 
 

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -90,3 +90,43 @@ def test_entangled_cross_norm_realignment_criterion():
         ]
     )
     np.testing.assert_equal(is_separable(rho), False)
+
+
+def test_separable_based_on_eigenvalues():
+    # TODO: This is returning True from a line above the eigenvalues condition. Need to change rho, etc...
+    # State taken from https://arxiv.org/pdf/1309.2006
+    rho = np.array([
+        [1 / 11, 0, 0, 0],
+        [0, 3 / 11, 2 / 11, 0],
+        [0, 2 / 11, 3 / 11, 0],
+        [0, 0, 0, 4 / 11]
+    ])
+    np.testing.assert_equal(is_separable(rho), True)
+
+
+def test_separable_rank4_dim3_rho():
+    rho =  np.array(
+        [
+            [4, 1, 1, 1, 0, 0, 0, 0, 0],
+            [1, 4, 1, 1, 0, 0, 0, 0, 0],
+            [1, 1, 4, 1, 0, 0, 0, 0, 0],
+            [1, 1, 1, 4, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0]
+        ]
+    )
+    np.testing.assert_equal(is_separable(rho), True)
+
+
+def test_2n_ppt_check_array():
+    state = np.array([
+        [0.5, 0, 0, 0.5],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0.5, 0, 0, 0.5]
+    ])
+    # TODO
+

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -168,27 +168,10 @@ def test_entangled_symmetric_extension():
     np.testing.assert_equal(is_separable(rho), False)
 
 
-# def test_separable_chow_form():
-# rho = np.array(
-#     [
-#         [4, 1, 1, 1, 0, 0, 0, 0, 0],
-#         [1, 4, 1, 1, 0, 0, 0, 0, 0],
-#         [1, 1, 4, 1, 0, 0, 0, 0, 0],
-#         [1, 1, 1, 4, 0, 0, 0, 0, 0],
-#         [0, 0, 0, 0, 0, 0, 0, 0, 0],
-#         [0, 0, 0, 0, 0, 0, 0, 0, 0],
-#         [0, 0, 0, 0, 0, 0, 0, 0, 0],
-#         [0, 0, 0, 0, 0, 0, 0, 0, 0],
-#         [0, 0, 0, 0, 0, 0, 0, 0, 0],
-#     ]
-# )
-#     np.testing.assert_equal(is_separable(rho), True)
-
-
 def test_separable_based_on_eigenvalues():
     """Determined to be separable by inspecting its eigenvalues. See Lemma 1 of :cite:`Johnston_2013_Spectrum`."""
-    # TODO: Although this satisfies the eigenvalues condition (from the paper), this returns True from a line above
-    # the eigenvalues condition.
+    # Although this matrix, taken from the above paper, satisfies the eigenvalues condition,
+    # this returns True from a line above the eigenvalues condition.
     rho = np.array(
         [
             [4 / 22, 2 / 22, -2 / 22, 2 / 22],
@@ -198,18 +181,3 @@ def test_separable_based_on_eigenvalues():
         ]
     )
     np.testing.assert_equal(is_separable(rho), True)
-
-
-def test_2n_ppt_check_array():
-    """TODO."""
-    state = np.array(
-        [
-            [0.5, 0, 0, 0, 0, 0.5],
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            [0.5, 0, 0, 0, 0, 0.5],
-        ]
-    )
-    # TODO

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -94,6 +94,7 @@ def test_entangled_cross_norm_realignment_criterion():
 
 
 def test_separable_schmidt_rank():
+    """Determined to be separable by having operator Schmidt rank at most 2."""
     rho = np.array(
         [
             [0.25, 0.15, 0.1, 0.15, 0.09, 0.06, 0.1, 0.06, 0.04],
@@ -129,13 +130,16 @@ def test_separable_schmidt_rank():
 
 
 def test_separable_based_on_eigenvalues():
-    # TODO: Although this satisfies the eigenvalues condition (from the paper), this returns True from a line above the eigenvalues condition. Need to change `rho`.
+    """Determined to be separable by inspecting its eigenvalues. See Lemma 1 of https://arxiv.org/abs/1309.2006."""
+    # TODO: Although this satisfies the eigenvalues condition (from the paper), this returns True from a line above
+    # the eigenvalues condition. Need to change `rho`.
     # State taken from https://arxiv.org/pdf/1309.2006
     rho = np.array([[1 / 11, 0, 0, 0], [0, 3 / 11, 2 / 11, 0], [0, 2 / 11, 3 / 11, 0], [0, 0, 0, 4 / 11]])
     np.testing.assert_equal(is_separable(rho), True)
 
 
 def test_2n_ppt_check_array():
+    """TODO."""
     state = np.array(
         [
             [0.5, 0, 0, 0, 0, 0.5],


### PR DESCRIPTION
## Description
This is for issue #518 

## Changes
Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below.

  -  [X] Added several conditions porting from the MATLAB implementation. I believe only 1-2 relative checks (found to be slower, as written in the MATLAB code comments) are omitted.
  - [X] Added print statements to discern the reason for a specific output (True/False) for transparency.
  - [X] Initiated tests for the conditions added here. As discussed in #518, designing the test cases is not trivial, but we will try to work on it based on our potential discussion here.
  - [X] I think there was a bug in the original source code in this line: `if (lam[0] - lam[2 * max_dim - 1]) ** 2 <= 4 * lam[2 * max_dim - 2] * lam[2 * max_dim] + tol**2:` since Python's indexing is different than MATLAB. That has been changed here.

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [X] Use `ruff` for errors related to code style and formatting.
  -  [X] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [ ] Use `doctest` to verify the examples in the function docstrings work as expected.
