### PR TITLE
Add unambiguous discrimination strategy to state distinguishability and state exclusion

### DIFF
--- a/docs/articles.bib
+++ b/docs/articles.bib
@@ -297,6 +297,19 @@ doi = {https://doi.org/10.1016/S0375-9601(96)80001-6},
 author = {Gisin, N.},
 }
 
+@article{Gupta_2024_Unambiguous,
+   title={Unambiguous discrimination of sequences of quantum states},
+   volume={109},
+   ISSN={2469-9934},
+   url={http://dx.doi.org/10.1103/PhysRevA.109.052222},
+   DOI={10.1103/physreva.109.052222},
+   number={5},
+   journal={Physical Review A},
+   publisher={American Physical Society (APS)},
+   author={Gupta, Tathagata and Murshid, Shayeef and Bandyopadhyay, Somshubhro},
+   year={2024},
+   month=may }
+
 @article{Gurvits_2002_Largest,
    title={Largest separable balls around the maximally mixed bipartite quantum state},
    volume={66},

--- a/toqito/matrix_ops/tests/test_vector_to_density_matrix.py
+++ b/toqito/matrix_ops/tests/test_vector_to_density_matrix.py
@@ -30,4 +30,4 @@ def test_vector_to_density_matrix(input_vector, expected_output, exception):
             vector_to_density_matrix(input_vector)
     else:
         computed_density_matrix = vector_to_density_matrix(input_vector)
-        assert abs(computed_density_matrix - expected_output).all() <= 1e-3
+        assert (np.abs(computed_density_matrix - expected_output) <= 1e-3).all()

--- a/toqito/state_opt/ppt_distinguishability.py
+++ b/toqito/state_opt/ppt_distinguishability.py
@@ -25,10 +25,10 @@ def ppt_distinguishability(
 
     One can specify the distinguishability method using the :code:`dist_method` argument.
 
-    For :code:`dist_method = "min-error"`, this is the default method that yields the probability of
+    For :code:`dist_method = "min_error"`, this is the default method that yields the probability of
     distinguishing quantum states via PPT measurements that minimize the probability of error.
 
-    For :code:`dist_method = "unambiguous"`, Alice and Bob never provide an incorrect answer,
+    For :code:`dist_method = "unambig"`, Alice and Bob never provide an incorrect answer,
     although it is possible that their answer is inconclusive.
 
     For more info, go to the tutorial in the documentation :ref:`ref-label-state-dist-ppt`.

--- a/toqito/state_opt/state_distinguishability.py
+++ b/toqito/state_opt/state_distinguishability.py
@@ -64,8 +64,8 @@ def state_distinguishability(
         \end{align*}
 
     where :math:`\mathbf{p}` is the vector whose :math:`i`-th coordinate contains the probability
-    that the state is prepared in state :\math:`\left|\psi_i\right\rangle`, :math:`\Gamma` is
-    the Gram matrix of :math:`\left|\psi_1\right,\cdots,\left|\psi_n\right\rangle` and :math:`F_i` is
+    that the state is prepared in state :math:`\left|\psi_i\right\rangle`, :math:`\Gamma` is
+    the Gram matrix of :math:`\left|\psi_1\right\rangle,\cdots,\left|\psi_n\right\rangle` and :math:`F_i` is
     :math:`-|i\rangle\langle i|`.
 
     .. warning::
@@ -130,8 +130,8 @@ def state_distinguishability(
     :param probs: Respective list of probabilities each state is selected. If no
                   probabilities are provided, a uniform probability distribution is assumed.
     :param strategy: Whether to perform unambiguous or minimal error discrimination task. Possible
-                     values are "min_error" and "unambiguous".
-    :param solver: Optimization option for `picos` solver. Default option is `solver_option="cvxopt"`.
+                     values are "min_error" and "unambiguous". Default option is `strategy="min_error"`.
+    :param solver: Optimization option for `picos` solver. Default option is `solver="cvxopt"`.
     :param primal_dual: Option for the optimization problem. Default option is `"dual"`.
     :param kwargs: Additional arguments to pass to picos' solve method.
     :return: The optimal probability with which Bob can guess the state he was

--- a/toqito/state_opt/state_distinguishability.py
+++ b/toqito/state_opt/state_distinguishability.py
@@ -215,7 +215,7 @@ def _unambiguous_primal(
 ) -> tuple[float, tuple[picos.RealVariable]]:
     """Solve the primal problem for unambiguous quantum state distinguishability SDP.
 
-    Implemented according to Equation (5) of arXiv:2402.06365.
+    Implemented according to Equation (5) of :cite:`Gupta_2024_Unambiguous`:.
     """
     n = len(vectors)
     problem = picos.Problem()
@@ -239,7 +239,7 @@ def _unambiguous_dual(
 ) -> tuple[float, tuple[picos.HermitianVariable]]:
     """Solve the dual problem for unambiguous quantum state distinguishability SDP.
 
-    Implemented according to Equation (5) of arXiv:2402.06365.
+    Implemented according to Equation (5) of :cite:`Gupta_2024_Unambiguous`.
     """
     n = len(vectors)
     problem = picos.Problem()

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -238,7 +238,7 @@ def _unambiguous_primal(
 ) -> tuple[float, list[picos.HermitianVariable]]:
     """Solve the primal problem for unambiguous quantum state distinguishability SDP.
 
-    Implemented according to Equation (33) of arXiv:1306.4683.
+    Implemented according to Equation (33) of :cite:`Bandyopadhyay_2014_Conclusive`.
     """
     n = len(vectors)
     problem = picos.Problem()
@@ -268,7 +268,7 @@ def _unambiguous_dual(
 ) -> tuple[float, tuple[picos.HermitianVariable, picos.RealVariable]]:
     """Solve the dual problem for unambiguous quantum state distinguishability SDP.
 
-    Implemented according to Equation (35) of arXiv:1306.4683.
+    Implemented according to Equation (35) of :cite:`Bandyopadhyay_2014_Conclusive`.
     """
     n = len(vectors)
     problem = picos.Problem()

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -50,10 +50,10 @@ def state_exclusion(
             \begin{equation}
                 \begin{aligned}
                     \text{maximize:} \quad & \text{Tr}(Y) \\
-                    \text{subject to:} \quad & Y \leq M_1, \\
-                                             & Y \leq M_2, \\
+                    \text{subject to:} \quad & Y \preceq p_1\rho_1, \\
+                                             & Y \preceq p_2\rho_2, \\
                                              & \vdots \\
-                                             & Y \leq M_n, \\
+                                             & Y \preceq p_n\rho_n, \\
                                              & Y \in\text{Herm}(\mathcal{X}).
                 \end{aligned}
             \end{equation}
@@ -69,16 +69,16 @@ def state_exclusion(
             \text{minimize:} \quad & \text{Tr}\left(
                 \left(\sum_{i=1}^n p_i\rho_i\right)\left(\mathbb{I}-\sum_{i=1}^nM_i\right)
                 \right) \\
-            \text{subject to:} \quad & \sum_{i=1}^nM_i \geq \mathbb{I},\\
-                                     & M_1, \ldots, M_n \geq 0, \\
+            \text{subject to:} \quad & \sum_{i=1}^nM_i \preceq \mathbb{I},\\
+                                     & M_1, \ldots, M_n \succeq 0, \\
                                      & \langle M_1, \rho_1 \rangle, \ldots, \langle M_n, \rho_n \rangle =0
         \end{align*}
 
     .. math::
         \begin{align*}
             \text{maximize:} \quad & 1 - \text{Tr}(N) \\
-            \text{subject to:} \quad & a_1p_1\rho_1, \ldots, a_np_n\rho_n \geq \sum_{i=1}^np_i\rho_i - N,\\
-                                     & N \geq 0,\\
+            \text{subject to:} \quad & a_1p_1\rho_1, \ldots, a_np_n\rho_n \succeq \sum_{i=1}^np_i\rho_i - N,\\
+                                     & N \succeq 0,\\
                                      & a_1, \ldots, a_n \in\mathbb{R}
         \end{align*}
 

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -83,10 +83,9 @@ def state_exclusion(
         \end{align*}
 
 
-    .. warning::
-        Note that it only makes sense to exclude unambiguously when the pure states are linearly
-        independent. Calling this function on a set of states that doesn't verify this property will
-        return 0.
+    .. note::
+        It is known that it is always possible to perfectly exclude pure states that are linearly dependent.
+        Thus, calling this function on a set of states with this property will return 0.
 
     The conclusive state exclusion SDP is written explicitly in :cite:`Bandyopadhyay_2014_Conclusive`. The problem
     of conclusive state exclusion was also thought about under a different guise in :cite:`Pusey_2012_On`.

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -49,12 +49,12 @@ def state_exclusion(
         .. math::
             \begin{equation}
                 \begin{aligned}
-                    \text{maximize:} \quad & \text{Tr}(Y)
+                    \text{maximize:} \quad & \text{Tr}(Y) \\
                     \text{subject to:} \quad & Y \leq M_1, \\
                                              & Y \leq M_2, \\
                                              & \vdots \\
                                              & Y \leq M_n, \\
-                                             & Y \text{Herm}(\mathcal{X}).
+                                             & Y \in\text{Herm}(\mathcal{X}).
                 \end{aligned}
             \end{equation}
 

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -3,17 +3,19 @@
 import numpy as np
 import picos
 
-from toqito.matrix_ops import calculate_vector_matrix_dimension, vector_to_density_matrix
+from toqito.matrix_ops import calculate_vector_matrix_dimension, vector_to_density_matrix, vectors_to_gram_matrix
 from toqito.matrix_props import has_same_dimension
 
 
 def state_exclusion(
     vectors: list[np.ndarray],
     probs: list[float] = None,
+    strategy: str = "min_error",
     solver: str = "cvxopt",
     primal_dual: str = "dual",
-) -> tuple[float, list[picos.HermitianVariable]]:
-    r"""Compute probability of single state conclusive state exclusion.
+    **kwargs,
+) -> tuple[float, list[picos.HermitianVariable] | tuple[picos.HermitianVariable, picos.RealVariable]]:
+    r"""Compute probability of error of single state conclusive state exclusion.
 
     The *quantum state exclusion* problem involves a collection of :math:`n` quantum states
 
@@ -28,10 +30,12 @@ def state_exclusion(
     Alice chooses :math:`i` with probability :math:`p_i` and creates the state :math:`\rho_i`.
 
     Bob wants to guess which state he was *not* given from the collection of states. State exclusion implies that
-    ability to discard (with certainty) at least one out of the "n" possible quantum states by applying a measurement.
+    ability to discard at least one out of the "n" possible quantum states by applying a measurement.
 
-    This function implements the following semidefinite program that provides the optimal probability with which Bob can
-    conduct quantum state exclusion.
+    For :code:`strategy = "min_error"`, this is the default method that yields the minimal probability of error for Bob.
+
+    In that case, this function implements the following semidefinite program that provides the optimal probability
+    with which Bob can conduct quantum state exclusion.
 
         .. math::
             \begin{equation}
@@ -54,6 +58,35 @@ def state_exclusion(
                 \end{aligned}
             \end{equation}
 
+    For :code:`strategy = "unambiguous"`, Bob never provides an incorrect answer, although it is
+    possible that his answer is inconclusive. This function then yields the probability of an inconclusive outcome.
+
+    In that case, this function implements the following semidefinite program that provides the
+    optimal probability with which Bob can conduct unambiguous quantum state distinguishability.
+
+    .. math::
+        \begin{align*}
+            \text{minimize:} \quad & \text{Tr}\left(
+                \left(\sum_{i=1}^n p_i\rho_i\right)\left(\mathbb{I}-\sum_{i=1}^nM_i\right)
+                \right) \\
+            \text{subject to:} \quad & \sum_{i=1}^nM_i \geq \mathbb{I},\\
+                                     & M_1, \ldots, M_n \geq 0, \\
+                                     & \langle M_1, \rho_1 \rangle, \ldots, \langle M_n, \rho_n \rangle =0
+        \end{align*}
+
+    .. math::
+        \begin{align*}
+            \text{maximize:} \quad & 1 - \text{Tr}(N) \\
+            \text{subject to:} \quad & a_1p_1\rho_1, \ldots, a_np_n\rho_n \geq \sum_{i=1}^np_i\rho_i - N,\\
+                                     & N \geq 0,\\
+                                     & a_1, \ldots, a_n \in\mathbb{R}
+        \end{align*}
+
+
+    .. warning::
+        Note that it only makes sense to exclude unambiguously when the pure states are linearly
+        independent. Calling this function on a set of states that doesn't verify this property will
+        return 0.
 
     The conclusive state exclusion SDP is written explicitly in :cite:`Bandyopadhyay_2014_Conclusive`. The problem
     of conclusive state exclusion was also thought about under a different guise in :cite:`Pusey_2012_On`.
@@ -84,6 +117,15 @@ def state_exclusion(
     >>> '%.2f' % state_exclusion(vectors, probs)[0]
     '0.00'
 
+    Unambiguous state exclusion for unbiased states.
+
+    >>> from toqito.state_opt import state_exclusion
+    >>> import numpy as np
+    >>> states = [np.array([[1.], [0.]]), np.array([[1.],[1.]]) / np.sqrt(2)]
+    >>> res, _ = state_exclusion(states, primal_dual="primal", strategy="unambiguous", abs_ipm_opt_tol=1e-7)
+    >>> '%.2f' % res
+    '0.71'
+
     .. note::
         You do not need to use `'%.2f' %` when you use this function.
 
@@ -91,6 +133,12 @@ def state_exclusion(
         expected output upto two decimal points only. The accuracy of the solvers can calculate the
         `float` output to a certain amount of precision such that the value deviates after a few digits
         of accuracy.
+
+    .. note::
+        If you encounter a `ZeroDivisionError` when using cvxopt as a solver (which is the default), you might
+        want to try to set the `abs_ipm_opt_tol` option to a lower value (the default being `1e-8`).
+
+        https://gitlab.com/picos-api/picos/-/issues/341
 
     References
     ==========
@@ -101,8 +149,11 @@ def state_exclusion(
     :param vectors: A list of states provided as vectors.
     :param probs: Respective list of probabilities each state is selected. If no
                   probabilities are provided, a uniform probability distribution is assumed.
+    :param strategy: Whether to perform minimal error or unambiguous discrimination task. Possible values are
+                     "min_error" and "unambiguous".
     :param solver: Optimization option for `picos` solver. Default option is `solver_option="cvxopt"`.
     :param primal_dual: Option for the optimization problem.
+    :param kwargs: Additional arguments to pass to picos' solve method.
     :return: The optimal probability with which Bob can guess the state he was
              not given from `states` along with the optimal set of measurements.
 
@@ -115,9 +166,15 @@ def state_exclusion(
     probs = [1 / n] * n if probs is None else probs
     dim = calculate_vector_matrix_dimension(vectors[0])
 
+    if strategy == "min_error":
+        if primal_dual == "primal":
+            return _min_error_primal(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
+        return _min_error_dual(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
+
     if primal_dual == "primal":
-        return _min_error_primal(vectors=vectors, dim=dim, probs=probs, solver=solver)
-    return _min_error_dual(vectors=vectors, dim=dim, probs=probs, solver=solver)
+        return _unambiguous_primal(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
+
+    return _unambiguous_dual(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
 
 
 def _min_error_primal(
@@ -125,6 +182,7 @@ def _min_error_primal(
     dim: int,
     probs: list[float] = None,
     solver: str = "cvxopt",
+    **kwargs,
 ) -> tuple[float, list[picos.HermitianVariable]]:
     """Find the primal problem for minimum-error quantum state exclusion SDP."""
     n = len(vectors)
@@ -136,13 +194,21 @@ def _min_error_primal(
     problem.add_constraint(picos.sum(measurements) == picos.I(dim))
 
     dms = [vector_to_density_matrix(vector) for vector in vectors]
-    problem.set_objective("min", np.real(picos.sum([(probs[i] * dms[i] | measurements[i]) for i in range(n)])))
-    solution = problem.solve(solver=solver)
+    # # Numerical inaccuracies can make it so the trace of the density matrices aren't unital, which messes up with
+    # # cvxopt
+    # dms = [state / np.trace(state) for state in dms]
+    objective = picos.sum([(picos.trace(probs[i] * dms[i] * measurements[i])) for i in range(n)])
+    problem.set_objective("min", objective)
+    solution = problem.solve(solver=solver, **kwargs)
     return solution.value, measurements
 
 
 def _min_error_dual(
-    vectors: list[np.ndarray], dim: int, probs: list[float] = None, solver: str = "cvxopt"
+    vectors: list[np.ndarray],
+    dim: int,
+    probs: list[float] = None,
+    solver: str = "cvxopt",
+    **kwargs,
 ) -> tuple[float, list[picos.HermitianVariable]]:
     """Find the dual problem for minimum-error quantum state exclusion SDP."""
     n = len(vectors)
@@ -156,8 +222,70 @@ def _min_error_dual(
 
     # Objective function:
     problem.set_objective("max", picos.trace(y_var))
-    solution = problem.solve(solver=solver)
+    solution = problem.solve(solver=solver, **kwargs)
 
     measurements = [problem.get_constraint(k).dual for k in range(n)]
 
     return solution.value, measurements
+
+def _unambiguous_primal(
+    vectors: list[np.ndarray],
+    dim: int,
+    probs: list[float] = None,
+    solver: str = "cvxopt",
+    **kwargs,
+) -> tuple[float, list[picos.HermitianVariable]]:
+    """Solve the primal problem for unambiguous quantum state distinguishability SDP.
+
+    Implemented according to Equation (33) of arXiv:1306.4683.
+    """
+    n = len(vectors)
+    problem = picos.Problem()
+    measurements = [picos.HermitianVariable(f"M[{i}]", (dim, dim)) for i in range(n)]
+    inconclusive_measurement = picos.I(dim) - picos.sum(measurements)
+
+    problem.add_list_of_constraints([meas >> 0 for meas in measurements])
+    problem.add_constraint(inconclusive_measurement >> 0)
+
+    unnormalized_dms = [p * vector_to_density_matrix(vector) for (p, vector) in zip(probs, vectors)]
+    sums_of_unnormalized_dms = picos.sum(unnormalized_dms)
+
+    problem.add_list_of_constraints(m | rho == 0 for (m, rho) in zip(measurements, unnormalized_dms))
+
+    problem.set_objective("min", picos.trace(sums_of_unnormalized_dms * inconclusive_measurement))
+    solution = problem.solve(solver=solver, **kwargs)
+
+    return solution.value, measurements + [inconclusive_measurement]
+
+
+def _unambiguous_dual(
+    vectors: list[np.ndarray],
+    dim: int,
+    probs: list[float] = None,
+    solver: str = "cvxopt",
+    **kwargs,
+) -> tuple[float, tuple[picos.HermitianVariable, picos.RealVariable]]:
+    """Solve the dual problem for unambiguous quantum state distinguishability SDP.
+
+    Implemented according to Equation (35) of arXiv:1306.4683.
+    """
+    n = len(vectors)
+    problem = picos.Problem()
+    lagrangian_variable_big_n = picos.HermitianVariable("N", (dim, dim))
+    lagrangian_variables_a = picos.RealVariable("a", n)
+
+    problem.add_constraint(lagrangian_variable_big_n >> 0)
+
+    dms = [vector_to_density_matrix(vector) for (p, vector) in zip(probs, vectors)]
+    unnormalized_dms = [proba * rho for (proba, rho) in zip(probs, dms)]
+    sum_of_unnormalized_dms = picos.sum(unnormalized_dms)
+
+    problem.add_list_of_constraints(
+        (lagrangian_variable_big_n + lagrangian_variables_a[i] * unnormalized_dms[i] >> sum_of_unnormalized_dms)
+        for i in range(n)
+    )
+
+    problem.set_objective("max", 1 - picos.trace(lagrangian_variable_big_n))
+    solution = problem.solve(solver=solver, primals=None, **kwargs)
+
+    return solution.value, (lagrangian_variable_big_n, lagrangian_variables_a)

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -135,10 +135,11 @@ def state_exclusion(
         of accuracy.
 
     .. note::
-        If you encounter a `ZeroDivisionError` when using cvxopt as a solver (which is the default), you might
-        want to try to set the `abs_ipm_opt_tol` option to a lower value (the default being `1e-8`).
+        If you encounter a `ZeroDivisionError` or an `ArithmeticError` when using cvxopt as a solver (which is the
+        default), you might want to set the `abs_ipm_opt_tol` option to a lower value (the default being `1e-8`) or
+        to set the `cvxopt_kktsolver` option to `ldl`.
 
-        https://gitlab.com/picos-api/picos/-/issues/341
+        See https://gitlab.com/picos-api/picos/-/issues/341
 
     References
     ==========

--- a/toqito/state_opt/tests/test_state_distinguishability.py
+++ b/toqito/state_opt/tests/test_state_distinguishability.py
@@ -61,7 +61,7 @@ def test_state_distinguishability_min_error(vectors, probs, solver, primal_dual,
 @pytest.mark.parametrize("probs", probs_unambiguous)
 def test_state_distinguishability_unambiguous(vectors, probs, solver, primal_dual, expected_result):
     """Test function works as expected for a valid input for the unambiguous strategy."""
-    val = state_distinguishability(
+    val, _ = state_distinguishability(
         vectors=vectors,
         probs=probs,
         solver=solver,

--- a/toqito/state_opt/tests/test_state_distinguishability.py
+++ b/toqito/state_opt/tests/test_state_distinguishability.py
@@ -1,33 +1,73 @@
 """Test state_distinguishability."""
 
+import numpy as np
 import pytest
 
 from toqito.matrices import standard_basis
 from toqito.matrix_ops import vector_to_density_matrix
 from toqito.state_opt import state_distinguishability
-from toqito.states import bell
+from toqito.states import bb84, bell
 
 e_0, e_1 = standard_basis(2)
 
+states_min_error = [
+    # Bell states (should be perfectly distinguishable)
+    ([bell(0), bell(1), bell(2), bell(3)], 1),
+    # Bell states as density matrices
+    ([vector_to_density_matrix(bell(i)) for i in range(4)], 1),
+    # BB84 states
+    (bb84()[0] + bb84()[1], .5),
+]
 
-@pytest.mark.parametrize(
-    "vectors, probs, solver, primal_dual, expected_result",
-    [
-        # Bell states (default uniform probs with primal).
-        ([bell(0), bell(1), bell(2), bell(3)], None, "cvxopt", "primal", 1),
-        # Bell states (default uniform probs with dual).
-        ([bell(0), bell(1), bell(2), bell(3)], None, "cvxopt", "dual", 1),
-        # Bell states uniform probs with primal.
-        ([bell(0), bell(1), bell(2), bell(3)], [1 / 4, 1 / 4, 1 / 4, 1 / 4], "cvxopt", "primal", 1),
-        # Bell states uniform probs with dual.
-        ([bell(0), bell(1), bell(2), bell(3)], [1 / 4, 1 / 4, 1 / 4, 1 / 4], "cvxopt", "dual", 1),
-        # Density matrix Bell states (default uniform probs with dual).
-        ([vector_to_density_matrix(bell(0)), vector_to_density_matrix(bell(1))], None, "cvxopt", "dual", 1),
-    ],
-)
-def test_state_distinguishability(vectors, probs, solver, primal_dual, expected_result):
-    """Test function works as expected for a valid input."""
+states_unambiguous = [
+    # Bell states (should be perfectly distinguishable)
+    ([bell(0), bell(1)], 1),
+    # |0> and |+> states (should be unambiguously distinguishable with probability 1 - 1 / sqrt(2))
+    ([np.array([[1.], [0.]]), np.array([[1.],[1.]]) / np.sqrt(2)], 0.29289321881345254),
+]
+
+probs_min_error = [
+    None,
+    [1 / 4, 1 / 4, 1 / 4, 1 / 4]
+]
+
+probs_unambiguous = [
+    None,
+    [1 / 2, 1 / 2]
+]
+
+solvers = [
+    "cvxopt"
+]
+primal_duals = [
+    "primal",
+    "dual"
+]
+
+
+@pytest.mark.parametrize("vectors, expected_result", states_min_error)
+@pytest.mark.parametrize("solver", solvers)
+@pytest.mark.parametrize("primal_dual", primal_duals)
+@pytest.mark.parametrize("probs", probs_min_error)
+def test_state_distinguishability_min_error(vectors, probs, solver, primal_dual, expected_result):
+    """Test function works as expected for a valid input for the min_error strategy."""
     val, _ = state_distinguishability(vectors=vectors, probs=probs, solver=solver, primal_dual=primal_dual)
+    assert abs(val - expected_result) <= 1e-8
+
+
+@pytest.mark.parametrize("vectors, expected_result", states_unambiguous)
+@pytest.mark.parametrize("solver", solvers)
+@pytest.mark.parametrize("primal_dual", primal_duals)
+@pytest.mark.parametrize("probs", probs_unambiguous)
+def test_state_distinguishability_unambiguous(vectors, probs, solver, primal_dual, expected_result):
+    """Test function works as expected for a valid input for the unambiguous strategy."""
+    val = state_distinguishability(
+        vectors=vectors,
+        probs=probs,
+        solver=solver,
+        primal_dual=primal_dual,
+        strategy="unambiguous"
+    )
     assert abs(val - expected_result) <= 1e-8
 
 
@@ -38,7 +78,20 @@ def test_state_distinguishability(vectors, probs, solver, primal_dual, expected_
         ([bell(0), bell(1), bell(2), e_0], None, "cvxopt", "dual"),
     ],
 )
-def test_state_distinguishability_invalid_vectors(vectors, probs, solver, primal_dual):
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        "min_error",
+        "unambiguous",
+    ]
+)
+def test_state_distinguishability_invalid_vectors(vectors, probs, solver, primal_dual, strategy):
     """Test function works as expected for an invalid input."""
     with pytest.raises(ValueError, match="Vectors for state distinguishability must all have the same dimension."):
-        state_distinguishability(vectors=vectors, probs=probs, solver=solver, primal_dual=primal_dual)
+        state_distinguishability(
+            vectors=vectors,
+            probs=probs,
+            solver=solver,
+            primal_dual=primal_dual,
+            strategy=strategy
+        )

--- a/toqito/state_opt/tests/test_state_exclusion.py
+++ b/toqito/state_opt/tests/test_state_exclusion.py
@@ -17,8 +17,18 @@ states_min_error = [
     ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], None, 0, {"cvxopt_kktsolver": "ldl"}),
     ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], [1 / 2, 1 / 2], 0, {"cvxopt_kktsolver": "ldl"}),
     # For |0> and |+>, this probability is 1/2 - 1/(2*sqrt(2))
-    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], None, 0.14644660940672627, {"cvxopt_kktsolver": "ldl"}),
-    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], [1 / 2, 1 / 2], 0.14644660940672627, {"cvxopt_kktsolver": "ldl"}),
+    (
+        [np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)],
+        None,
+        0.14644660940672627,
+        {"cvxopt_kktsolver": "ldl"}
+    ),
+    (
+        [np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)],
+        [1 / 2, 1 / 2],
+        0.14644660940672627,
+        {"cvxopt_kktsolver": "ldl"}
+    ),
 ]
 
 states_unambiguous = [
@@ -28,8 +38,18 @@ states_unambiguous = [
     ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], None, 0, {}),
     ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], [1 / 2, 1 / 2], 0, {}),
     # For |0> and |+>, this probability is 1/sqrt(2)
-    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], None, 0.707106781186547, {"abs_ipm_opt_tol": 1e-6}),
-    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], [1 / 2, 1 / 2], 0.707106781186547, {"abs_ipm_opt_tol": 1e-6}),
+    (
+        [np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)],
+        None,
+        0.707106781186547,
+        {"abs_ipm_opt_tol": 1e-6}
+    ),
+    (
+        [np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)],
+        [1 / 2, 1 / 2],
+        0.707106781186547,
+        {"abs_ipm_opt_tol": 1e-6}
+    ),
 ]
 
 solvers = [

--- a/toqito/state_opt/tests/test_state_exclusion.py
+++ b/toqito/state_opt/tests/test_state_exclusion.py
@@ -12,24 +12,24 @@ e_0, e_1 = standard_basis(2)
 
 states_min_error = [
     # Bell states are perfectly distinguishable, so the probability of error should be nil
-    ([bell(0), bell(1), bell(2), bell(3)], None, 0),
-    ([bell(0), bell(1), bell(2), bell(3)], [1 / 4, 1 / 4, 1 / 4, 1 / 4], 0),
-    ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], None, 0),
-    ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], [1 / 2, 1 / 2], 0),
+    ([bell(0), bell(1), bell(2), bell(3)], None, 0, {}),
+    ([bell(0), bell(1), bell(2), bell(3)], [1 / 4, 1 / 4, 1 / 4, 1 / 4], 0, {}),
+    ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], None, 0, {"cvxopt_kktsolver": "ldl"}),
+    ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], [1 / 2, 1 / 2], 0, {"cvxopt_kktsolver": "ldl"}),
     # For |0> and |+>, this probability is 1/2 - 1/(2*sqrt(2))
-    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], None, 0.14644660940672627),
-    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], [1 / 2, 1 / 2], 0.14644660940672627),
+    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], None, 0.14644660940672627, {"cvxopt_kktsolver": "ldl"}),
+    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], [1 / 2, 1 / 2], 0.14644660940672627, {"cvxopt_kktsolver": "ldl"}),
 ]
 
 states_unambiguous = [
     # Bell states are perfectly distinguishable, so the probability of error should be nil
-    ([bell(0), bell(1), bell(2), bell(3)], None, 0),
-    ([bell(0), bell(1), bell(2), bell(3)], [1 / 4, 1 / 4, 1 / 4, 1 / 4], 0),
-    ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], None, 0),
-    ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], [1 / 2, 1 / 2], 0),
+    ([bell(0), bell(1), bell(2), bell(3)], None, 0, {}),
+    ([bell(0), bell(1), bell(2), bell(3)], [1 / 4, 1 / 4, 1 / 4, 1 / 4], 0, {}),
+    ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], None, 0, {}),
+    ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], [1 / 2, 1 / 2], 0, {}),
     # For |0> and |+>, this probability is 1/sqrt(2)
-    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], None, 0.707106781186547),
-    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], [1 / 2, 1 / 2], 0.707106781186547),
+    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], None, 0.707106781186547, {"abs_ipm_opt_tol": 1e-6}),
+    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], [1 / 2, 1 / 2], 0.707106781186547, {"abs_ipm_opt_tol": 1e-6}),
 ]
 
 solvers = [
@@ -42,26 +42,27 @@ primal_duals = [
 ]
 
 
-@pytest.mark.parametrize("vectors, probs, expected_result", states_min_error)
+@pytest.mark.parametrize("vectors, probs, expected_result, kwargs", states_min_error)
 @pytest.mark.parametrize("solver", solvers)
 @pytest.mark.parametrize("primal_dual", primal_duals)
-def test_state_exclusion_min_error(vectors, probs, solver, primal_dual, expected_result):
+def test_state_exclusion_min_error(vectors, probs, solver, primal_dual, expected_result, kwargs):
     """Test function works as expected for a valid input."""
-    val, _ = state_exclusion(vectors=vectors, probs=probs, solver=solver, primal_dual=primal_dual)
+    val, _ = state_exclusion(vectors=vectors, probs=probs, solver=solver, primal_dual=primal_dual, **kwargs)
     assert abs(val - expected_result) <= 1e-8
 
 
-@pytest.mark.parametrize("vectors, probs, expected_result", states_unambiguous)
+@pytest.mark.parametrize("vectors, probs, expected_result, kwargs", states_unambiguous)
 @pytest.mark.parametrize("solver", solvers)
 @pytest.mark.parametrize("primal_dual", primal_duals)
-def test_state_exclusion_unambiguous(vectors, probs, solver, primal_dual, expected_result):
+def test_state_exclusion_unambiguous(vectors, probs, solver, primal_dual, expected_result, kwargs):
     """Test function works as expected for a valid input."""
     val, _ = state_exclusion(
         vectors=vectors,
         probs=probs,
         solver=solver,
         primal_dual=primal_dual,
-        strategy="unambiguous"
+        strategy="unambiguous",
+        **kwargs
     )
     # Accuracy is quite low bcause of primals=None
     assert abs(val - expected_result) <= 1e-3

--- a/toqito/state_opt/tests/test_state_exclusion.py
+++ b/toqito/state_opt/tests/test_state_exclusion.py
@@ -1,5 +1,6 @@
 """Test state_exclusion."""
 
+import numpy as np
 import pytest
 
 from toqito.matrices import standard_basis
@@ -9,26 +10,61 @@ from toqito.states import bell
 
 e_0, e_1 = standard_basis(2)
 
+states_min_error = [
+    # Bell states are perfectly distinguishable, so the probability of error should be nil
+    ([bell(0), bell(1), bell(2), bell(3)], None, 0),
+    ([bell(0), bell(1), bell(2), bell(3)], [1 / 4, 1 / 4, 1 / 4, 1 / 4], 0),
+    ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], None, 0),
+    ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], [1 / 2, 1 / 2], 0),
+    # For |0> and |+>, this probability is 1/2 - 1/(2*sqrt(2))
+    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], None, 0.14644660940672627),
+    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], [1 / 2, 1 / 2], 0.14644660940672627),
+]
 
-@pytest.mark.parametrize(
-    "vectors, probs, solver, primal_dual, expected_result",
-    [
-        # Bell states (default uniform probs with primal).
-        ([bell(0), bell(1), bell(2), bell(3)], None, "cvxopt", "primal", 0),
-        # Bell states (default uniform probs with dual).
-        ([bell(0), bell(1), bell(2), bell(3)], None, "cvxopt", "dual", 0),
-        # Bell states uniform probs with primal.
-        ([bell(0), bell(1), bell(2), bell(3)], [1 / 4, 1 / 4, 1 / 4, 1 / 4], "cvxopt", "primal", 0),
-        # Bell states uniform probs with dual.
-        ([bell(0), bell(1), bell(2), bell(3)], [1 / 4, 1 / 4, 1 / 4, 1 / 4], "cvxopt", "dual", 0),
-        # Density matrix Bell states (default uniform probs with dual).
-        ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], None, "cvxopt", "dual", 0),
-    ],
-)
-def test_state_exclusion(vectors, probs, solver, primal_dual, expected_result):
+states_unambiguous = [
+    # Bell states are perfectly distinguishable, so the probability of error should be nil
+    ([bell(0), bell(1), bell(2), bell(3)], None, 0),
+    ([bell(0), bell(1), bell(2), bell(3)], [1 / 4, 1 / 4, 1 / 4, 1 / 4], 0),
+    ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], None, 0),
+    ([pure_to_mixed(bell(0)), pure_to_mixed(bell(1))], [1 / 2, 1 / 2], 0),
+    # For |0> and |+>, this probability is 1/sqrt(2)
+    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], None, 0.707106781186547),
+    ([np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)], [1 / 2, 1 / 2], 0.707106781186547),
+]
+
+solvers = [
+    "cvxopt"
+]
+
+primal_duals = [
+    "primal",
+    "dual"
+]
+
+
+@pytest.mark.parametrize("vectors, probs, expected_result", states_min_error)
+@pytest.mark.parametrize("solver", solvers)
+@pytest.mark.parametrize("primal_dual", primal_duals)
+def test_state_exclusion_min_error(vectors, probs, solver, primal_dual, expected_result):
     """Test function works as expected for a valid input."""
     val, _ = state_exclusion(vectors=vectors, probs=probs, solver=solver, primal_dual=primal_dual)
     assert abs(val - expected_result) <= 1e-8
+
+
+@pytest.mark.parametrize("vectors, probs, expected_result", states_unambiguous)
+@pytest.mark.parametrize("solver", solvers)
+@pytest.mark.parametrize("primal_dual", primal_duals)
+def test_state_exclusion_unambiguous(vectors, probs, solver, primal_dual, expected_result):
+    """Test function works as expected for a valid input."""
+    val, _ = state_exclusion(
+        vectors=vectors,
+        probs=probs,
+        solver=solver,
+        primal_dual=primal_dual,
+        strategy="unambiguous"
+    )
+    # Accuracy is quite low bcause of primals=None
+    assert abs(val - expected_result) <= 1e-3
 
 
 @pytest.mark.parametrize(
@@ -38,7 +74,14 @@ def test_state_exclusion(vectors, probs, solver, primal_dual, expected_result):
         ([bell(0), bell(1), bell(2), e_0], None, "cvxopt", "dual"),
     ],
 )
-def test_state_exclusion_invalid_vectors(vectors, probs, solver, primal_dual):
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        "min_error",
+        "unambiguous",
+    ]
+)
+def test_state_exclusion_invalid_vectors(vectors, probs, solver, primal_dual, strategy):
     """Test function works as expected for an invalid input."""
     with pytest.raises(ValueError, match="Vectors for state distinguishability must all have the same dimension."):
-        state_exclusion(vectors=vectors, probs=probs, solver=solver, primal_dual=primal_dual)
+        state_exclusion(vectors=vectors, probs=probs, solver=solver, primal_dual=primal_dual, strategy=strategy)

--- a/toqito/state_opt/tests/test_state_exclusion.py
+++ b/toqito/state_opt/tests/test_state_exclusion.py
@@ -42,13 +42,17 @@ states_unambiguous = [
         [np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)],
         None,
         0.707106781186547,
-        {"abs_ipm_opt_tol": 1e-6}
+        {
+            "abs_ipm_opt_tol": 1e-5,
+        }
     ),
     (
         [np.array([[1.], [0.]]), np.array([[1.], [1.]]) / np.sqrt(2)],
         [1 / 2, 1 / 2],
         0.707106781186547,
-        {"abs_ipm_opt_tol": 1e-6}
+        {
+            "abs_ipm_opt_tol": 1e-5,
+        }
     ),
 ]
 


### PR DESCRIPTION
## Description
Enable the ability for the user to unambiguously exclude or discriminate amongst of quantum states in the state_distinguishability.py and state_exclusion.py files, respectively. Fixes #519 

## Changes
Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below.

  - [x] More tests have been added to the tests suite 
  - [x] The user now has the possibility to unambiguously distinguish/exclude states via the implementation of the corresponding SDPs
  - [x] The user now has the possibility to pass arbitrary options to picos' solver. This fixes current, unreported bugs in `state_exclusion.py`

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
