### PR TITLE
Type checking for `channel_metrics`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,6 @@ extend-exclude = '''
 (/*.py # exclude all py files
 )
 '''
+
+[tool.mypy]
+disable_error_code = ["import-untyped"]

--- a/toqito/channel_metrics/completely_bounded_spectral_norm.py
+++ b/toqito/channel_metrics/completely_bounded_spectral_norm.py
@@ -32,4 +32,5 @@ def completely_bounded_spectral_norm(phi: np.ndarray) -> float:
     :return: The completely bounded spectral norm of the channel
 
     """
-    return completely_bounded_trace_norm(dual_channel(phi))
+    dual_as_array = np.asarray(dual_channel(phi))
+    return completely_bounded_trace_norm.completely_bounded_trace_norm(dual_as_array)

--- a/toqito/channel_metrics/completely_bounded_spectral_norm.py
+++ b/toqito/channel_metrics/completely_bounded_spectral_norm.py
@@ -33,4 +33,4 @@ def completely_bounded_spectral_norm(phi: np.ndarray) -> float:
 
     """
     dual_as_array = np.asarray(dual_channel(phi))
-    return completely_bounded_trace_norm.completely_bounded_trace_norm(dual_as_array)
+    return completely_bounded_trace_norm(dual_as_array)

--- a/toqito/channel_metrics/completely_bounded_trace_norm.py
+++ b/toqito/channel_metrics/completely_bounded_trace_norm.py
@@ -64,7 +64,7 @@ def completely_bounded_trace_norm(phi: np.ndarray) -> float:
     a_var = cp.bmat([[y0, -phi], [-phi.conj().T, y1]])
     constraints += [a_var >> 0]
     objective = cp.Minimize(
-        cp.norm(cp.partial_trace(y0, dims=(dim, dim), axis=1)) + cp.norm(cp.partial_trace(y1, dims=(dim, dim), axis=1))
+        cp.norm(cp.partial_trace(y0, dims=(dim, dim), axis=1)) + cp.norm(cp.partial_trace(y1, dims=(dim, dim), axis=1))  # type: ignore
     )
 
     problem = cp.Problem(objective, constraints)

--- a/toqito/channel_metrics/diamond_norm.py
+++ b/toqito/channel_metrics/diamond_norm.py
@@ -99,7 +99,7 @@ def diamond_norm(choi_1: np.ndarray, choi_2: np.ndarray) -> float:
 
     constraints += [(w_var - cvxpy.kron(np.eye(dim), rho)) << 0]
 
-    j_var = cvxpy.Parameter([dim_squared, dim_squared], complex=True)
+    j_var = cvxpy.Parameter((dim_squared, dim_squared), complex=True)
     objective = cvxpy.Maximize(cvxpy.real(cvxpy.trace(j_var.H @ w_var)))
 
     problem = cvxpy.Problem(objective, constraints)

--- a/toqito/channel_metrics/fidelity_of_separability.py
+++ b/toqito/channel_metrics/fidelity_of_separability.py
@@ -179,7 +179,7 @@ def fidelity_of_separability(
     problem.add_constraint((picos.I(dim_r) @ sym_choi) * choi * (picos.I(dim_r) @ sym_choi) == choi)
 
     # PPT condition on Choi state
-    sys = [] # type: List[int]
+    sys = []  # type: List[int]
     for i in range(1, 1 + k):
         sys = sys + [i]
         problem.add_constraint(picos.partial_transpose(choi, sys, choi_dims) >> 0)

--- a/toqito/channel_metrics/fidelity_of_separability.py
+++ b/toqito/channel_metrics/fidelity_of_separability.py
@@ -11,11 +11,12 @@ from toqito.perms import permute_systems, symmetric_projection
 from toqito.state_props import is_pure
 
 from toqito.matrix_props import is_density  # isort: skip
+from typing import List
 
 
 def fidelity_of_separability(
     psi: np.ndarray,
-    psi_dims: list[int],
+    psi_dims: List[int],
     k: int = 1,
     verbosity_option: int = 0,
     solver_option: str = "cvxopt",
@@ -178,7 +179,7 @@ def fidelity_of_separability(
     problem.add_constraint((picos.I(dim_r) @ sym_choi) * choi * (picos.I(dim_r) @ sym_choi) == choi)
 
     # PPT condition on Choi state
-    sys = []
+    sys = [] # type: List[int]
     for i in range(1, 1 + k):
         sys = sys + [i]
         problem.add_constraint(picos.partial_transpose(choi, sys, choi_dims) >> 0)

--- a/toqito/channel_ops/dual_channel.py
+++ b/toqito/channel_ops/dual_channel.py
@@ -1,5 +1,7 @@
 """Compute the dual of a map."""
 
+from typing import List
+
 import numpy as np
 
 from toqito.helper import channel_dim
@@ -7,8 +9,8 @@ from toqito.perms import swap
 
 
 def dual_channel(
-    phi_op: np.ndarray | list[np.ndarray] | list[list[np.ndarray]], dims: list[int] = None
-) -> np.ndarray | list[list[np.ndarray]]:
+    phi_op: np.ndarray | List[np.ndarray] | List[List[np.ndarray]], dims: List[int] = None
+) -> np.ndarray | List[List[np.ndarray]]:
     r"""Compute the dual of a map (quantum channel).
 
     (Section: Representations and Characterizations of Channels of :cite:`Watrous_2018_TQI`).


### PR DESCRIPTION
## Description
Related to #299 

We use `--explicit-package-bases` here to disable mypy errors due to 2 files of the same name existing in different modules. 

## Changes

Right now `~/toqito$ mypy toqito/channel_metrics --explicit-package-bases` is failing due to the following. These are mostly due to incompatibilities with type annotations in cvxpy compared to how we use them. 

```
toqito/channel_metrics/diamond_norm.py:102: error: Argument 1 to "Parameter" has incompatible type "list[int]"; expected "int | tuple[int, ...]"  [arg-type]
toqito/channel_metrics/completely_bounded_trace_norm.py:67: error: Argument "dims" to "partial_trace" has incompatible type "tuple[int, int]"; expected "tuple[int]"  [arg-type]
toqito/channel_metrics/completely_bounded_spectral_norm.py:35: error: Module not callable  [operator]

```
Will need to refactor portions of:

- `diamon_norm.py`: 

https://github.com/vprusso/toqito/blob/1122a6e6aeb4fe8c41dbafded6fccbbcb7a40453/toqito/channel_metrics/diamond_norm.py#L102

Here, `[dim_squared, dim_Squared]` is of type `List[int]` whereas `cxpy.Parameter` expects `shape: int | tuple[int, ...]`
https://www.cvxpy.org/api_reference/cvxpy.expressions.html#parameter

- `completely_bounded_trace_norm.py`

Same as the previous item, we use an incompatible type compared to what's expected by cvpy type annotation. It expects `tuple[int]` but we use `tuple[int. int]`. 

https://github.com/vprusso/toqito/blob/1122a6e6aeb4fe8c41dbafded6fccbbcb7a40453/toqito/channel_metrics/completely_bounded_trace_norm.py#L67

https://www.cvxpy.org/api_reference/cvxpy.atoms.affine.html#partial-trace
 
- `completely_bounded_spectral_norm.py`

For some reason, `completely_bounded_trace_norm` or `dual_channel` shows up as a module not callable. 

https://github.com/vprusso/toqito/blob/1122a6e6aeb4fe8c41dbafded6fccbbcb7a40453/toqito/channel_metrics/completely_bounded_spectral_norm.py#L35

If I specify the full path for `completely_bounded_trace_norm` as `completely_bounded_trace_norm.completely_bounded_trace_norm`, mypy fails with the following error:

```
toqito/channel_metrics/completely_bounded_spectral_norm.py:35: error: Argument 1 to "completely_bounded_trace_norm" has incompatible type "ndarray[Any, Any] | list[list[ndarray[Any, Any]]]"; expected "ndarray[Any, Any]"  [arg-type]
```
## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [ ] Use `ruff` for errors related to code style and formatting.
  -  [ ] Verify all previous and newly added unit tests pass in `pytest`.
  -  [ ] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [ ] Use `linkcheck` to check for broken links in the documentation
  -  [ ] Use `doctest` to verify the examples in the function docstrings work as expected.
