### PR TITLE
Added is_anti_hermitian.py

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1165,6 +1165,13 @@ numpages = {11}
   
 }
 
+@misc{WikiAntiHerm,
+  author  = "Wikipedia",
+  title   = "Skew-Hermitian matrix",
+  howpublished = {https://en.wikipedia.org/wiki/Skew-Hermitian_matrix}
+
+}
+
 
 @misc{WikiHilbSchOp,
   author  = "Wikipedia",

--- a/toqito/matrix_props/__init__.py
+++ b/toqito/matrix_props/__init__.py
@@ -3,6 +3,7 @@
 from toqito.matrix_props.has_same_dimension import has_same_dimension
 from toqito.matrix_props.is_square import is_square
 from toqito.matrix_props.kp_norm import kp_norm
+from toqito.matrix_props.is_anti_hermitian import is_anti_hermitian
 from toqito.matrix_props.is_hermitian import is_hermitian
 from toqito.matrix_props.is_positive_semidefinite import is_positive_semidefinite
 from toqito.matrix_props.is_density import is_density

--- a/toqito/matrix_props/is_anti_hermitian.py
+++ b/toqito/matrix_props/is_anti_hermitian.py
@@ -1,0 +1,67 @@
+"""Is matrix a Hermitian matrix."""
+
+import numpy as np
+
+from toqito.matrix_props.is_hermitian import is_hermitian
+
+
+def is_anti_hermitian(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
+    r"""Check if matrix is anti-Hermitian (a.k.a. skew-Hermitian) :cite:`WikiAntiHerm`.
+
+    An anti-Hermitian matrix is a complex square matrix that is equal to the negative of its own
+    conjugate transpose.
+
+    Examples
+    ==========
+
+    Consider the following matrix:
+
+    .. math::
+        A = \begin{pmatrix}
+                2j & -1 + 2j & 4j \\
+                1 + 2j & 3j & -1 \\
+                4j & 1 & 1j
+            \end{pmatrix}
+
+    our function indicates that this is indeed a Hermitian matrix as it holds that
+
+    .. math::
+        A = -A^*.
+
+    >>> from toqito.matrix_props import is_anti_hermitian
+    >>> import numpy as np
+    >>> mat = np.array([[2j, -1 + 2j, 4j], [1 + 2j, 3j, -1], [4j, 1, 1j]])
+    >>> is_anti_hermitian(mat)
+    True
+
+    Alternatively, the following example matrix :math:`B` defined as
+
+    .. math::
+        B = \begin{pmatrix}
+                1 & 2 & 3 \\
+                4 & 5 & 6 \\
+                7 & 8 & 9
+            \end{pmatrix}
+
+    is not anti-Hermitian.
+
+    >>> from toqito.matrix_props import is_anti_hermitian
+    >>> import numpy as np
+    >>> mat = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    >>> is_anti_hermitian(mat)
+    False
+
+    References
+    ==========
+    .. bibliography::
+        :filter: docname in docnames
+
+
+
+    :param mat: Matrix to check.
+    :param rtol: The relative tolerance parameter (default 1e-05).
+    :param atol: The absolute tolerance parameter (default 1e-08).
+    :return: Return True if matrix is anti-Hermitian, and False otherwise.
+
+    """
+    return is_hermitian(mat * 1j, rtol, atol)

--- a/toqito/matrix_props/is_anti_hermitian.py
+++ b/toqito/matrix_props/is_anti_hermitian.py
@@ -1,4 +1,4 @@
-"""Is matrix a Hermitian matrix."""
+"""Is matrix an anti-Hermitian matrix."""
 
 import numpy as np
 

--- a/toqito/matrix_props/is_anti_hermitian.py
+++ b/toqito/matrix_props/is_anti_hermitian.py
@@ -23,7 +23,7 @@ def is_anti_hermitian(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08)
                 4j & 1 & 1j
             \end{pmatrix}
 
-    our function indicates that this is indeed a Hermitian matrix as it holds that
+    our function indicates that this is indeed an anti-Hermitian matrix as it holds that
 
     .. math::
         A = -A^*.

--- a/toqito/matrix_props/tests/test_is_anti_hermitian.py
+++ b/toqito/matrix_props/tests/test_is_anti_hermitian.py
@@ -1,4 +1,4 @@
-"""Test is_hermitian."""
+"""Test is_anti_hermitian."""
 
 import numpy as np
 import pytest

--- a/toqito/matrix_props/tests/test_is_anti_hermitian.py
+++ b/toqito/matrix_props/tests/test_is_anti_hermitian.py
@@ -1,0 +1,23 @@
+"""Test is_hermitian."""
+
+import numpy as np
+
+from toqito.matrix_props import is_anti_hermitian
+
+
+def test_is_hermitian():
+    """Test if matrix is Hermitian."""
+    mat = np.array([[2j, -1 + 2j, 4j], [1 + 2j, 3j, -1], [4j, 1, 1j]])
+    np.testing.assert_equal(is_anti_hermitian(mat), True)
+
+
+def test_is_non_hermitian():
+    """Test non-Hermitian matrix."""
+    mat = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    np.testing.assert_equal(is_anti_hermitian(mat), False)
+
+
+def test_is_hermitian_not_square():
+    """Input must be a square matrix."""
+    mat = np.array([[-1, 1, 1], [1, 2, 3]])
+    np.testing.assert_equal(is_anti_hermitian(mat), False)

--- a/toqito/matrix_props/tests/test_is_anti_hermitian.py
+++ b/toqito/matrix_props/tests/test_is_anti_hermitian.py
@@ -14,7 +14,7 @@ data = [
     (np.array([[-1, 1, 1], [1, 2, 3]]), False),
 ]
 
-@pytest.mark.parametrize("mat,expected", data)
-def test_is_anti_hermitian(mat, expected):
+@pytest.mark.parametrize("mat,expected_bool", data)
+def test_is_anti_hermitian(mat, expected_bool):
     """Test if matrix is anti-Hermitian."""
-    np.testing.assert_equal(is_anti_hermitian(mat), expected)
+    np.testing.assert_equal(is_anti_hermitian(mat), expected_bool)

--- a/toqito/matrix_props/tests/test_is_anti_hermitian.py
+++ b/toqito/matrix_props/tests/test_is_anti_hermitian.py
@@ -1,23 +1,20 @@
 """Test is_hermitian."""
 
 import numpy as np
+import pytest
 
 from toqito.matrix_props import is_anti_hermitian
 
+data = [
+    # Test with anti-Hermitian matrix
+    (np.array([[2j, -1 + 2j, 4j], [1 + 2j, 3j, -1], [4j, 1, 1j]]), True),
+    # Test with non-anti-Hermitian matrix
+    (np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), False),
+    # Test with non-square matrix
+    (np.array([[-1, 1, 1], [1, 2, 3]]), False),
+]
 
-def test_is_hermitian():
-    """Test if matrix is Hermitian."""
-    mat = np.array([[2j, -1 + 2j, 4j], [1 + 2j, 3j, -1], [4j, 1, 1j]])
-    np.testing.assert_equal(is_anti_hermitian(mat), True)
-
-
-def test_is_non_hermitian():
-    """Test non-Hermitian matrix."""
-    mat = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    np.testing.assert_equal(is_anti_hermitian(mat), False)
-
-
-def test_is_hermitian_not_square():
-    """Input must be a square matrix."""
-    mat = np.array([[-1, 1, 1], [1, 2, 3]])
-    np.testing.assert_equal(is_anti_hermitian(mat), False)
+@pytest.mark.parametrize("mat,expected", data)
+def test_is_anti_hermitian(mat, expected):
+    """Test if matrix is anti-Hermitian."""
+    np.testing.assert_equal(is_anti_hermitian(mat), expected)

--- a/toqito/matrix_props/tests/test_is_hermitian.py
+++ b/toqito/matrix_props/tests/test_is_hermitian.py
@@ -1,23 +1,20 @@
 """Test is_hermitian."""
 
 import numpy as np
+import pytest
 
 from toqito.matrix_props import is_hermitian
 
+data = [
+    # Test with Hermitian matrix
+    (np.array([[2, 2 + 1j, 4], [2 - 1j, 3, 1j], [4, -1j, 1]]), True),
+    # Test with non-Hermitian matrix
+    (np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), False),
+    # Test with non-square matrix
+    (np.array([[-1, 1, 1], [1, 2, 3]]), False),
+]
 
-def test_is_hermitian():
+@pytest.mark.parametrize("mat,expected", data)
+def test_is_hermitian(mat, expected):
     """Test if matrix is Hermitian."""
-    mat = np.array([[2, 2 + 1j, 4], [2 - 1j, 3, 1j], [4, -1j, 1]])
-    np.testing.assert_equal(is_hermitian(mat), True)
-
-
-def test_is_non_hermitian():
-    """Test non-Hermitian matrix."""
-    mat = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    np.testing.assert_equal(is_hermitian(mat), False)
-
-
-def test_is_hermitian_not_square():
-    """Input must be a square matrix."""
-    mat = np.array([[-1, 1, 1], [1, 2, 3]])
-    np.testing.assert_equal(is_hermitian(mat), False)
+    np.testing.assert_equal(is_hermitian(mat), expected)

--- a/toqito/matrix_props/tests/test_is_hermitian.py
+++ b/toqito/matrix_props/tests/test_is_hermitian.py
@@ -14,7 +14,7 @@ data = [
     (np.array([[-1, 1, 1], [1, 2, 3]]), False),
 ]
 
-@pytest.mark.parametrize("mat,expected", data)
-def test_is_hermitian(mat, expected):
+@pytest.mark.parametrize("mat,expected_bool", data)
+def test_is_hermitian(mat, expected_bool):
     """Test if matrix is Hermitian."""
-    np.testing.assert_equal(is_hermitian(mat), expected)
+    np.testing.assert_equal(is_hermitian(mat), expected_bool)


### PR DESCRIPTION
## Description
Adds the `is_anti_hermitian` function to `matrix_props`. Fixes #766.

## Changes
Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below.

  -  [x] Adds the `is_anti_hermitian` function to `matrix_props`. The function internally uses `is_hermitian` to limit code duplication.

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
