### PR TITLE
Ignore APS links in linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,13 @@ extensions = [
 bibtex_bibfiles = ["refs.bib"]
 bibtex_default_style = "unsrt"
 suppress_warnings = ["bibtex.duplicate_label", "bibtex.duplicate_citation"]
+# Links matching with the following regular expressions will be ignored
+linkcheck_ignore = [
+    r"https://arxiv\.org/.*",
+    r"https://doi\.org/.*",
+    r"https://link\.aps\.org/doi/.*",
+    r"http://dx\.doi\.org/.*"
+]
 # we need to skip these warnigns because all the references appear twice, in a function docstring
 # and on the references page.
 master_doc = "index"


### PR DESCRIPTION
## Description
Multiple PRs show the `linkcheck` workflow failing due to a `403` error. This PR temporarily ignores all the broken links until I figure out a solution to it. 

The diff in this PR copies the changes to `conf.py` in https://github.com/unitaryfund/mitiq/pull/2332

## Changes
Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below.

  -  [ ] Change 1

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [ ] Use `ruff` for errors related to code style and formatting.
  -  [ ] Verify all previous and newly added unit tests pass in `pytest`.
  -  [ ] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [ ] Use `linkcheck` to check for broken links in the documentation
  -  [ ] Use `doctest` to verify the examples in the function docstrings work as expected.
