### PR TITLE
Non-local games check pass

### DIFF
--- a/docs/tutorials.nonlocal_games.rst
+++ b/docs/tutorials.nonlocal_games.rst
@@ -346,7 +346,8 @@ use :code:`toqito` to determine the lower bound on the quantum value.
     >>> import numpy as np
     >>> from toqito.nonlocal_games.nonlocal_game import NonlocalGame
     >>> chsh = NonlocalGame(prob_mat, pred_mat)
-    >>> np.around(chsh.quantum_value_lower_bound(), decimals=2)
+    >>> results = [np.around(chsh.quantum_value_lower_bound(), decimals=2) for _ in range(5)]
+    >>> max(results)
     np.float64(0.85)
 
 In this case, we can see that the quantum value of the CHSH game is in fact

--- a/docs/tutorials.nonlocal_games.rst
+++ b/docs/tutorials.nonlocal_games.rst
@@ -346,7 +346,8 @@ use :code:`toqito` to determine the lower bound on the quantum value.
     >>> import numpy as np
     >>> from toqito.nonlocal_games.nonlocal_game import NonlocalGame
     >>> chsh = NonlocalGame(prob_mat, pred_mat)
-    >>> results = [np.around(chsh.quantum_value_lower_bound(), decimals=2) for _ in range(5)]
+    >>> # Multiple runs to avoid trap in suboptimal quantum value.
+    >>> results = [np.around(chsh.quantum_value_lower_bound(), decimals=2) for _ in range(5)] 
     >>> max(results)
     np.float64(0.85)
 


### PR DESCRIPTION
## Description
Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue.
This PR is created to pass the check in the non-local games example. Since the optimal value for the chsh quantum probability is getting stuck in a suboptimal range, an approach to overcome this is running the check multiple times so as to maximize the chances to reach the optimal solution.
This has been discussed in detail in the discussion[here](https://github.com/vprusso/toqito/pull/835#issuecomment-2407326088).
#Resolves #613
## Changes
Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below.

  -  [x] The function `np.around(chsh.quantum_value_lower_bound(),  decimals=2)` has been run multiple times (5).

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
