### PR TITLE
Fix non-local games example

### DIFF
--- a/docs/tutorials.nonlocal_games.rst
+++ b/docs/tutorials.nonlocal_games.rst
@@ -487,7 +487,9 @@ In :code:`toqito`, we can encode this as a BCS game as follows
     >>> np.around(chsh_bcs.classical_value(), decimals=2)
     np.float64(0.75)
     >>> # Quantum value of CHSH is cos^2(pi/8) \approx 0.853...
-    >>> np.around(chsh_bcs.quantum_value_lower_bound(), decimals=2)
+    >>> # Multiple runs to avoid trap in suboptimal quantum value.
+    >>> results = [np.around(chsh_bcs.quantum_value_lower_bound(), decimals=2) for _ in range(5)] 
+    >>> max(results)
     np.float64(0.85)
 
 


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->
This PR resolves the flacky non-local games docstring example. The fix is the same as the earlier fix in #613.
#Resolves #873.

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [x] Added multiple runs in the non-local games example to prevent getting suboptimal solution.
 
## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
