### PR TITLE
Parallelize classical value in nonlocal games

### DIFF
--- a/toqito/nonlocal_games/nonlocal_game.py
+++ b/toqito/nonlocal_games/nonlocal_game.py
@@ -179,14 +179,16 @@ class NonlocalGame:
 
         num_iterations = num_alice_outputs**num_bob_inputs
 
+        # we parallelize for large problems only
         if num_iterations > 1000:
-            with multiprocessing.Pool() as pool:
+            with multiprocessing.Pool() as pool:  # Creating a pool of processes for parallelization
                 tgvals = pool.starmap(
                     NonlocalGame.process_iteration,
                     [(i, num_bob_outputs, num_bob_inputs, pred_mat_copy, num_alice_outputs, num_alice_inputs)
                     for i in range(num_iterations)]
                 )
                 p_win = max(tgvals)
+        # Using single core implementation for small problems
         else:
             for i in range(num_iterations):
                 tgval = NonlocalGame.process_iteration(i, num_bob_outputs, num_bob_inputs, pred_mat_copy,

--- a/toqito/nonlocal_games/nonlocal_game.py
+++ b/toqito/nonlocal_games/nonlocal_game.py
@@ -195,56 +195,6 @@ class NonlocalGame:
 
         return p_win
 
-
-    def classical_value(self) -> float:
-        """Compute the classical value of the nonlocal game.
-
-        This function has been adapted from the QETLAB package.
-
-        :return: A value between [0, 1] representing the classical value.
-        """
-        (
-            num_alice_outputs,
-            num_bob_outputs,
-            num_alice_inputs,
-            num_bob_inputs,
-        ) = self.pred_mat.shape
-
-        # Create a copy of pred_mat to avoid in-place modification
-        pred_mat_copy = np.copy(self.pred_mat)
-
-        for x_alice_in in range(num_alice_inputs):
-            for y_bob_in in range(num_bob_inputs):
-                pred_mat_copy[:, :, x_alice_in, y_bob_in] = (
-                    self.prob_mat[x_alice_in, y_bob_in] * pred_mat_copy[:, :, x_alice_in, y_bob_in]
-                )
-        p_win = float("-inf")
-        if num_alice_outputs**num_alice_inputs < num_bob_outputs**num_bob_inputs:
-            pred_mat_copy = np.transpose(pred_mat_copy, (1, 0, 3, 2))
-            (
-                num_alice_outputs,
-                num_bob_outputs,
-                num_alice_inputs,
-                num_bob_inputs,
-            ) = pred_mat_copy.shape
-        pred_mat_copy = np.transpose(pred_mat_copy, (0, 2, 1, 3))
-
-        for i in range(num_alice_outputs**num_bob_inputs):
-            number = i
-            base = num_bob_outputs
-            digits = num_bob_inputs
-            b_ind = np.zeros(digits)
-            for j in range(digits):
-                b_ind[digits - j - 1] = np.mod(number, base)
-                number = np.floor(number / base)
-            pred_alice = np.zeros((num_alice_outputs, num_alice_inputs))
-
-            for y_bob_in in range(num_bob_inputs):
-                pred_alice = pred_alice + pred_mat_copy[:, :, int(b_ind[y_bob_in]), y_bob_in]
-            tgval = np.sum(np.amax(pred_alice, axis=0))
-            p_win = max(p_win, tgval)
-        return p_win
-
     def quantum_value_lower_bound(
         self,
         dim: int = 2,

--- a/toqito/nonlocal_games/nonlocal_game.py
+++ b/toqito/nonlocal_games/nonlocal_game.py
@@ -165,7 +165,7 @@ class NonlocalGame:
                 pred_mat_copy[:, :, x_alice_in, y_bob_in] = (
                     self.prob_mat[x_alice_in, y_bob_in] * pred_mat_copy[:, :, x_alice_in, y_bob_in]
                 )
-
+        p_win = float("-inf")
         if num_alice_outputs**num_alice_inputs < num_bob_outputs**num_bob_inputs:
             pred_mat_copy = np.transpose(pred_mat_copy, (1, 0, 3, 2))
             (
@@ -176,7 +176,6 @@ class NonlocalGame:
             ) = pred_mat_copy.shape
         pred_mat_copy = np.transpose(pred_mat_copy, (0, 2, 1, 3))
 
-        p_win = float("-inf")
         num_iterations = num_alice_outputs**num_bob_inputs
 
         if num_iterations > 1000:

--- a/toqito/nonlocal_games/nonlocal_game.py
+++ b/toqito/nonlocal_games/nonlocal_game.py
@@ -132,9 +132,9 @@ class NonlocalGame:
         digits = num_bob_inputs
         b_ind = np.zeros(digits)
 
-        for j in range(digits):
-            b_ind[digits - j - 1] = np.mod(number, base)
-            number = np.floor(number / base)
+        for j in range(digits - 1, -1, -1):
+            number, remainder = divmod(number, base)
+            b_ind[j] = remainder
 
         pred_alice = np.zeros((num_alice_outputs, num_alice_inputs))
 

--- a/toqito/nonlocal_games/nonlocal_game.py
+++ b/toqito/nonlocal_games/nonlocal_game.py
@@ -121,7 +121,8 @@ class NonlocalGame:
 
         return cls(prob_mat, pred_mat, reps)
 
-    def process_iteration(i, num_bob_outputs, num_bob_inputs, pred_mat_copy, num_alice_outputs, num_alice_inputs):
+    def process_iteration(i:int, num_bob_outputs:int, num_bob_inputs:int, pred_mat_copy:np.ndarray,
+                          num_alice_outputs:int, num_alice_inputs:int)-> float:
         """Help the classical_value function as a helper method.
 
         :return: A value between [0, 1] representing the tgval.


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->
Adding parallelism using `multiprocessing` python library. Added a new function `process_iteration` that provides reusability of code. the parallelization is done when `num_alice_outputs**num_bob_inputs` is more than 1000.
#Resolves #12

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [x] Added a helper method to invoke multiprocessing when needed.
## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
