### PR TITLE
Fixed chessboard references

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -103,6 +103,21 @@
   url={https://link.aps.org/doi/10.1103/PhysRevLett.97.080501}
 }
 
+@article{Bruß_2000_Construction,
+  title = {Construction of quantum states with bound entanglement},
+  author = {Bru\ss{}, Dagmar and Peres, Asher},
+  journal = {Phys. Rev. A},
+  volume = {61},
+  issue = {3},
+  pages = {030301},
+  numpages = {2},
+  year = {2000},
+  month = {Feb},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevA.61.030301},
+  url = {https://link.aps.org/doi/10.1103/PhysRevA.61.030301}
+}
+
 % Last name begins with C
 @article{Cabello_2002_NParticle,
   title={$N$-Particle $N$-Level Singlet States: Some Properties and Applications},

--- a/toqito/states/chessboard.py
+++ b/toqito/states/chessboard.py
@@ -8,9 +8,9 @@ import numpy as np
 
 
 def chessboard(mat_params: list[float], s_param: float = None, t_param: float = None) -> np.ndarray:
-    r"""Produce a chessboard state :cite:`Dur_2000_ThreeQubits`.
+    r"""Produce a chessboard state :cite:`Bruß_2000_Construction`.
 
-    Generates the chessboard state defined in :cite:`Dur_2000_ThreeQubits`. Note that, for certain choices of
+    Generates the chessboard state defined in :cite:`Bruß_2000_Construction`. Note that, for certain choices of
     :code:`s_param` and :code:`t_param`, this state will not have positive partial transpose, and
     thus may not be bound entangled.
 
@@ -46,7 +46,7 @@ def chessboard(mat_params: list[float], s_param: float = None, t_param: float = 
       :filter: docname in docnames
 
 
-    :param mat_params: Parameters of the chessboard state as defined in :cite:`Dur_2000_ThreeQubits`.
+    :param mat_params: Parameters of the chessboard state as defined in :cite:`Bruß_2000_Construction`.
     :param s_param: Default is :code:`np.conj(mat_params[2]) / np.conj(mat_params[5])`.
     :param t_param: Default is :code:`t_param = mat_params[0] * mat_params[3] / mat_params[4]`.
     :return: A chessboard state.


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->
This PR fixes the references for the states/chessboard.py as discussed in the mentioned issue.
#Closes #843
## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [x] Added "Bruß_2000_Construction" reference in refs.bib
  -  [x] Modified reference in chessboard.py
  
## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
