### PR TITLE
Added pre-commit Hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version (keep in sync with the version in pyproject.toml)
+  rev: v0.8.2
+  hooks:
+    # Run the linter.
+    - id: ruff
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -111,9 +111,12 @@ might be incompatible with the changes made by :code:`black`. This is discussed 
 `this link <https://docs.astral.sh/ruff/formatter/black/>`_.
 
 Setting Up Pre-Commit Hooks
-Pre-commit hooks ensure that code meets our formatting and linting standards before it is committed to the repository. Install the hooks with the following command:
+Pre-commit hooks ensure that code meets our formatting and linting standards before it is committed to the repository. Install the hooks with the following command.
+
 .. code-block:: bash
-  poetry run pre-commit install
+   
+   poetry run pre-commit install
+
 This integrates ruff checks into your workflow, ensuring consistent code quality across the project.
 
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -110,8 +110,13 @@ Do not use an autoformatter like :code:`black` as the configuration settings for
 might be incompatible with the changes made by :code:`black`. This is discussed in detail at
 `this link <https://docs.astral.sh/ruff/formatter/black/>`_.
 
+Setting Up Pre-Commit Hooks
+Pre-commit hooks ensure that code meets our formatting and linting standards before it is committed to the repository. Install the hooks with the following command:
 .. code-block:: bash
   poetry run pre-commit install
+This integrates ruff checks into your workflow, ensuring consistent code quality across the project.
+
+
 ------------------------
 References in Docstrings
 ------------------------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -110,6 +110,8 @@ Do not use an autoformatter like :code:`black` as the configuration settings for
 might be incompatible with the changes made by :code:`black`. This is discussed in detail at
 `this link <https://docs.astral.sh/ruff/formatter/black/>`_.
 
+.. code-block:: bash
+  poetry run pre-commit install
 ------------------------
 References in Docstrings
 ------------------------


### PR DESCRIPTION
## Description

Fixes #912 
<!-- Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->
This PR introduces a pre-commit hook configuration for the repository to improve code quality and enforce consistent coding practices.

## Changes
<!-- Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->
  -  [x] Added a `.pre-commit-config.yaml` file to configure pre-commit hooks.
  -  [x] Modified `docs/contributing.rst` to include guidelines for using pre-commit hooks.

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR.

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR.
  -  [x] Use `linkcheck` to check for broken links in the documentation.
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
