### PR TITLE
Feature: Kraus operator to natural represention

### DIFF
--- a/toqito/channel_ops/__init__.py
+++ b/toqito/channel_ops/__init__.py
@@ -6,3 +6,4 @@ from toqito.channel_ops.choi_to_kraus import choi_to_kraus
 from toqito.channel_ops.kraus_to_choi import kraus_to_choi
 from toqito.channel_ops.dual_channel import dual_channel
 from toqito.channel_ops.complementary_channel import complementary_channel
+from toqito.channel_ops.natural_representation import natural_representation

--- a/toqito/channel_ops/natural_representation.py
+++ b/toqito/channel_ops/natural_representation.py
@@ -27,12 +27,6 @@ def natural_representation(kraus_ops: List[np.ndarray]) -> np.ndarray:
      [0.5 0.  0.  0.5]]
 
     """
-    if not isinstance(kraus_ops, list):
-        raise ValueError("Kraus operators must be provided as a list.")
-
-    if not all(isinstance(k, np.ndarray) for k in kraus_ops):
-        raise ValueError("All Kraus operators must be NumPy arrays.")
-
     if len(kraus_ops) == 0:
         raise ValueError("At least one Kraus operator must be provided.")
 

--- a/toqito/channel_ops/natural_representation.py
+++ b/toqito/channel_ops/natural_representation.py
@@ -14,7 +14,8 @@ def natural_representation(kraus_ops: List[np.ndarray]) -> np.ndarray:
     :math:`\Phi = \sum_i K_i \otimes K_i^*`
     where :math:`K_i^*` is the complex conjugate of :math:`K_i`.
 
-    Examples:
+    Examples
+    ==========
     >>> import numpy as np
     >>> # Kraus operators for a depolarizing channel
     >>> k0 = np.sqrt(1/2) * np.array([[1, 0], [0, 1]])

--- a/toqito/channel_ops/natural_representation.py
+++ b/toqito/channel_ops/natural_representation.py
@@ -17,7 +17,7 @@ def natural_representation(kraus_ops: List[np.ndarray]) -> np.ndarray:
     Examples
     ==========
     >>> import numpy as np
-    >>> # Kraus operators for a depolarizing channel
+    >>> from toqito.channel_ops import natural_representation
     >>> k0 = np.sqrt(1/2) * np.array([[1, 0], [0, 1]])
     >>> k1 = np.sqrt(1/2) * np.array([[0, 1], [1, 0]])
     >>> print(natural_representation([k0, k1]))
@@ -27,6 +27,12 @@ def natural_representation(kraus_ops: List[np.ndarray]) -> np.ndarray:
      [0.5 0.  0.  0.5]]
 
     """
+    if not isinstance(kraus_ops, list):
+        raise ValueError("Kraus operators must be provided as a list.")
+
+    if not all(isinstance(k, np.ndarray) for k in kraus_ops):
+        raise ValuesError("All Kraus operators must be NumPy arrays.")
+
     if len(kraus_ops) == 0:
         raise ValueError("At least one Kraus operator must be provided.")
 

--- a/toqito/channel_ops/natural_representation.py
+++ b/toqito/channel_ops/natural_representation.py
@@ -27,15 +27,6 @@ def natural_representation(kraus_ops: List[np.ndarray]) -> np.ndarray:
      [0.5 0.  0.  0.5]]
 
     """
-    if not isinstance(kraus_ops, list):
-        raise ValueError("Kraus operators must be provided as a list.")
-
-    if not all(isinstance(k, np.ndarray) for k in kraus_ops):
-        raise ValuesError("All Kraus operators must be NumPy arrays.")
-
-    if len(kraus_ops) == 0:
-        raise ValueError("At least one Kraus operator must be provided.")
-
     dim = kraus_ops[0].shape
     if not all(k.shape == dim for k in kraus_ops):
         raise ValueError("All Kraus operators must have the same dimensions.")

--- a/toqito/channel_ops/natural_representation.py
+++ b/toqito/channel_ops/natural_representation.py
@@ -1,0 +1,46 @@
+"""Kraus operators to natural representation."""
+
+import numpy as np
+
+from toqito.matrix_ops import tensor
+
+
+def natural_representation(kraus_ops):
+    """Convert a set of Kraus operators to the natural representation of a quantum channel.
+
+    The natural representation of a quantum channel is given by:
+    Φ = ∑_i K_i ⊗ K_i*
+    where K_i* is the complex conjugate of K_i.
+
+    :args: kraus_ops (list[np.ndarray]): List of Kraus operators.
+    :return: np.ndarray: The natural representation of the quantum channel.
+
+    Examples:
+    >>> import numpy as np
+    >>> # Kraus operators for a depolarizing channel
+    >>> k0 = np.sqrt(1/2) * np.array([[1, 0], [0, 1]])
+    >>> k1 = np.sqrt(1/2) * np.array([[0, 1], [1, 0]])
+    >>> nat_rep = natural_representation([k0, k1])
+    >>> print(nat_rep)
+    >>> print(nat_rep)
+    [[0.5 0.  0.  0.5]
+     [0.  0.5 0.5 0. ]
+     [0.  0.5 0.5 0. ]
+     [0.5 0.  0.  0.5]]
+
+    """
+    if not isinstance(kraus_ops, list):
+        raise ValueError("Kraus operators must be provided as a list.")
+
+    if not all(isinstance(k, np.ndarray) for k in kraus_ops):
+        raise ValueError("All Kraus operators must be NumPy arrays.")
+
+    if len(kraus_ops) == 0:
+        raise ValueError("At least one Kraus operator must be provided.")
+
+    dim = kraus_ops[0].shape
+    if not all(k.shape == dim for k in kraus_ops):
+        raise ValueError("All Kraus operators must have the same dimensions.")
+
+    # Compute the natural representation
+    return np.sum([tensor(k, np.conjugate(k)) for k in kraus_ops], axis=0)

--- a/toqito/channel_ops/natural_representation.py
+++ b/toqito/channel_ops/natural_representation.py
@@ -1,13 +1,11 @@
 """Kraus operators to natural representation."""
 
-from typing import List
-
 import numpy as np
 
 from toqito.matrix_ops import tensor
 
 
-def natural_representation(kraus_ops: List[np.ndarray]) -> np.ndarray:
+def natural_representation(kraus_ops: list[np.ndarray]) -> np.ndarray:
     r"""Convert a set of Kraus operators to the natural representation of a quantum channel.
 
     The natural representation of a quantum channel is given by:
@@ -31,5 +29,5 @@ def natural_representation(kraus_ops: List[np.ndarray]) -> np.ndarray:
     if not all(k.shape == dim for k in kraus_ops):
         raise ValueError("All Kraus operators must have the same dimensions.")
 
-    # Compute the natural representation
+    # Compute the natural representation.
     return np.sum([tensor(k, np.conjugate(k)) for k in kraus_ops], axis=0)

--- a/toqito/channel_ops/natural_representation.py
+++ b/toqito/channel_ops/natural_representation.py
@@ -1,28 +1,25 @@
 """Kraus operators to natural representation."""
 
+from typing import List
+
 import numpy as np
 
 from toqito.matrix_ops import tensor
 
 
-def natural_representation(kraus_ops):
-    """Convert a set of Kraus operators to the natural representation of a quantum channel.
+def natural_representation(kraus_ops: List[np.ndarray]) -> np.ndarray:
+    r"""Convert a set of Kraus operators to the natural representation of a quantum channel.
 
     The natural representation of a quantum channel is given by:
-    Φ = ∑_i K_i ⊗ K_i*
-    where K_i* is the complex conjugate of K_i.
-
-    :args: kraus_ops (list[np.ndarray]): List of Kraus operators.
-    :return: np.ndarray: The natural representation of the quantum channel.
+    :math:`\Phi = \sum_i K_i \otimes K_i^*`
+    where :math:`K_i^*` is the complex conjugate of :math:`K_i`.
 
     Examples:
     >>> import numpy as np
     >>> # Kraus operators for a depolarizing channel
     >>> k0 = np.sqrt(1/2) * np.array([[1, 0], [0, 1]])
     >>> k1 = np.sqrt(1/2) * np.array([[0, 1], [1, 0]])
-    >>> nat_rep = natural_representation([k0, k1])
-    >>> print(nat_rep)
-    >>> print(nat_rep)
+    >>> print(natural_representation([k0, k1]))
     [[0.5 0.  0.  0.5]
      [0.  0.5 0.5 0. ]
      [0.  0.5 0.5 0. ]

--- a/toqito/channel_ops/tests/test_natural_representataion.py
+++ b/toqito/channel_ops/tests/test_natural_representataion.py
@@ -4,17 +4,19 @@ import numpy as np
 import pytest
 
 from toqito.channel_ops.natural_representation import natural_representation
+from toqito.matrices import pauli
 from toqito.matrix_ops import tensor
 
 I2 = np.eye(2)
-X = np.array([[0, 1], [1, 0]])
-Y = np.array([[0, -1j], [1j, 0]])
-Z = np.array([[1, 0], [0, -1]])
+X = pauli("X")
+Y = pauli("Y")
+Z = pauli("Z")
 
 identity_channel = [I2]
 bit_flip_channel = [np.sqrt(0.7) * I2, np.sqrt(0.3) * X]
 amp_damp_channel = [np.array([[1, 0], [0, np.sqrt(0.6)]]), np.array([[0, np.sqrt(0.4)], [0, 0]])]
-depol_channel = [np.sqrt(0.7) * I2, np.sqrt(0.1) * X, np.sqrt(0.1) * Y, np.sqrt(0.1) * Z]
+p = 0.1
+depol_channel = [np.sqrt(1 - 3 * p / 4) * I2, np.sqrt(p / 4) * X, np.sqrt(p / 4) * Y, np.sqrt(p / 4) * Z]
 
 
 @pytest.mark.parametrize(

--- a/toqito/channel_ops/tests/test_natural_representataion.py
+++ b/toqito/channel_ops/tests/test_natural_representataion.py
@@ -3,11 +3,13 @@
 import numpy as np
 import pytest
 
+from toqito.channel_ops import choi_to_kraus
 from toqito.channel_ops.natural_representation import natural_representation
+from toqito.channels import depolarizing
 from toqito.matrices import pauli
 from toqito.matrix_ops import tensor
 
-I2 = np.eye(2)
+I2 = pauli("I")
 X = pauli("X")
 Y = pauli("Y")
 Z = pauli("Z")
@@ -15,8 +17,8 @@ Z = pauli("Z")
 identity_channel = [I2]
 bit_flip_channel = [np.sqrt(0.7) * I2, np.sqrt(0.3) * X]
 amp_damp_channel = [np.array([[1, 0], [0, np.sqrt(0.6)]]), np.array([[0, np.sqrt(0.4)], [0, 0]])]
-p = 0.1
-depol_channel = [np.sqrt(1 - 3 * p / 4) * I2, np.sqrt(p / 4) * X, np.sqrt(p / 4) * Y, np.sqrt(p / 4) * Z]
+depol_choi = depolarizing(2, 0.1)
+depol_channel = choi_to_kraus(depol_choi)
 
 
 @pytest.mark.parametrize(

--- a/toqito/channel_ops/tests/test_natural_representataion.py
+++ b/toqito/channel_ops/tests/test_natural_representataion.py
@@ -1,0 +1,88 @@
+"""Tests for natural_representation function."""
+
+import numpy as np
+import pytest
+
+from toqito.channel_ops.natural_representation import natural_representation
+from toqito.matrix_ops import tensor
+
+I2 = np.eye(2)
+X = np.array([[0, 1], [1, 0]])
+Y = np.array([[0, -1j], [1j, 0]])
+Z = np.array([[1, 0], [0, -1]])
+
+identity_channel = [I2]
+bit_flip_channel = [np.sqrt(0.7) * I2, np.sqrt(0.3) * X]
+amp_damp_channel = [np.array([[1, 0], [0, np.sqrt(0.6)]]), np.array([[0, np.sqrt(0.4)], [0, 0]])]
+depol_channel = [np.sqrt(0.7) * I2, np.sqrt(0.1) * X, np.sqrt(0.1) * Y, np.sqrt(0.1) * Z]
+
+
+@pytest.mark.parametrize(
+    "kraus_ops, expected",
+    [
+        # Identity channel : single Kraus operator
+        (identity_channel, tensor(I2, np.conjugate(I2))),
+        # Bit flip channel : two Kraus operators
+        (bit_flip_channel, 0.7 * tensor(I2, np.conjugate(I2)) + 0.3 * tensor(X, np.conjugate(X))),
+        # Amplitude damping channel : two Kraus operators
+        (
+            amp_damp_channel,
+            tensor(amp_damp_channel[0], np.conjugate(amp_damp_channel[0]))
+            + tensor(amp_damp_channel[1], np.conjugate(amp_damp_channel[1])),
+        ),
+        # Depolarizing channel : four Kraus operators
+        (depol_channel, np.sum([tensor(k, np.conjugate(k)) for k in depol_channel], axis=0)),
+        # Single qubit channel with different dimensions
+        (
+            [np.array([[1, 0, 0], [0, 1, 0]])],
+            tensor(np.array([[1, 0, 0], [0, 1, 0]]), np.conjugate(np.array([[1, 0, 0], [0, 1, 0]]))),
+        ),
+    ],
+)
+def test_natural_representation_valid_inputs(kraus_ops, expected):
+    """Test natural_representation function with valid inputs."""
+    actual = natural_representation(kraus_ops)
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_natural_representation_empty_list():
+    """Test natural_representation with empty list."""
+    with pytest.raises(ValueError, match="At least one Kraus operator must be provided."):
+        natural_representation([])
+
+
+def test_natural_representation_invalid_type():
+    """Test natural_representation with invalid input type."""
+    with pytest.raises(ValueError, match="Kraus operators must be provided as a list."):
+        natural_representation(I2)
+
+
+def test_natural_representation_invalid_item_type():
+    """Test natural_representation with invalid item type in list."""
+    with pytest.raises(ValueError, match="All Kraus operators must be NumPy arrays."):
+        natural_representation([I2, "not_an_array"])
+
+
+def test_natural_representation_different_dimensions():
+    """Test natural_representation with Kraus operators of different dimensions."""
+    k1 = np.array([[1, 0], [0, 1]])
+    k2 = np.array([[1, 0, 0], [0, 1, 0]])
+    with pytest.raises(ValueError, match="All Kraus operators must have the same dimensions."):
+        natural_representation([k1, k2])
+
+
+def test_natural_representation_trace_preserving():
+    """Test that the natural representation produces a trace-preserving map."""
+    nat_rep = natural_representation(depol_channel)
+    d = depol_channel[0].shape[0]
+    nat_rep_reshaped = nat_rep.reshape(d**2, d**2)
+    vec_identity = np.eye(d).reshape(d**2)
+    result = nat_rep_reshaped @ vec_identity
+    np.testing.assert_allclose(result, vec_identity, atol=1e-10)
+
+
+def test_natural_representation_completeness():
+    """Test completeness relation for Kraus operators via natural representation."""
+    k0, k1 = amp_damp_channel
+    completeness_check = np.conjugate(k0.T) @ k0 + np.conjugate(k1.T) @ k1
+    np.testing.assert_allclose(completeness_check, np.eye(2), atol=1e-10)

--- a/toqito/channel_ops/tests/test_natural_representataion.py
+++ b/toqito/channel_ops/tests/test_natural_representataion.py
@@ -49,24 +49,6 @@ def test_natural_representation_valid_inputs(kraus_ops, expected):
     np.testing.assert_allclose(actual, expected)
 
 
-def test_natural_representation_empty_list():
-    """Test natural_representation with empty list."""
-    with pytest.raises(ValueError, match="At least one Kraus operator must be provided."):
-        natural_representation([])
-
-
-def test_natural_representation_invalid_type():
-    """Test natural_representation with invalid input type."""
-    with pytest.raises(ValueError, match="Kraus operators must be provided as a list."):
-        natural_representation(I2)
-
-
-def test_natural_representation_invalid_item_type():
-    """Test natural_representation with invalid item type in list."""
-    with pytest.raises(ValueError, match="All Kraus operators must be NumPy arrays."):
-        natural_representation([I2, "not_an_array"])
-
-
 def test_natural_representation_different_dimensions():
     """Test natural_representation with Kraus operators of different dimensions."""
     k1 = np.array([[1, 0], [0, 1]])


### PR DESCRIPTION
## Description
Closes #885 

## Changes 

  -  [ ] Implemented `natural_representation` function to convert Kraus operators into their natural representation. 
  -  [ ] Added unit tests to validate correctness, including cases for identity, bit-flip, amplitude damping, and depolarizing 
  -  [ ] Ensured input validation for empty lists, incorrect types, and mismatched dimensions.  

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [ ] Use `ruff` for errors related to code style and formatting.
  -  [ ] Verify all previous and newly added unit tests pass in `pytest`.
  -  [ ] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [ ] Use `linkcheck` to check for broken links in the documentation
  -  [ ] Use `doctest` to verify the examples in the function docstrings work as expected.
