### PR TITLE
Add is_pseudo_unitary

### DIFF
--- a/toqito/matrix_props/__init__.py
+++ b/toqito/matrix_props/__init__.py
@@ -31,3 +31,4 @@ from toqito.matrix_props.is_positive import is_positive
 from toqito.matrix_props.positive_semidefinite_rank import positive_semidefinite_rank
 from toqito.matrix_props.is_stochastic import is_stochastic
 from toqito.matrix_props.spark import spark
+from toqito.matrix_props.is_pseudo_unitary import is_pseudo_unitary

--- a/toqito/matrix_props/is_pseudo_unitary.py
+++ b/toqito/matrix_props/is_pseudo_unitary.py
@@ -42,7 +42,7 @@ def is_pseudo_unitary(mat: np.ndarray, p: int, q: int, rtol: float = 1e-05, atol
     >>> from toqito.matrix_props import is_pseudo_unitary
     >>> A = np.array([[np.cosh(1), np.sinh(1)], [np.sinh(1), np.cosh(1)]])
     >>> is_pseudo_unitary(A, p=1, q=1)
-    True
+    np.True_
 
     However, the following matrix :math:B
 
@@ -56,7 +56,7 @@ def is_pseudo_unitary(mat: np.ndarray, p: int, q: int, rtol: float = 1e-05, atol
 
     >>> B = np.array([[1, 0], [1, 1]])
     >>> is_pseudo_unitary(B, p=1, q=1)
-    False
+    np.False_
 
     References
     ==========

--- a/toqito/matrix_props/is_pseudo_unitary.py
+++ b/toqito/matrix_props/is_pseudo_unitary.py
@@ -1,0 +1,88 @@
+"""Checks if matrix is pseudo unitary."""
+
+import numpy as np
+
+from toqito.matrix_props import is_square
+
+
+def is_pseudo_unitary(mat: np.ndarray, p: int, q: int, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
+    r"""Check if a matrix is pseudo-unitary.
+
+    A matrix A of size (p+q)x(p+q) is pseudo-unitary with respect to a given signature matrix J if it satisfies
+
+    .. math::
+        A^* J A = J,
+
+    where:
+        - :math:A^* is the conjugate transpose (Hermitian transpose) of :math:A,
+        - :math:J is a diagonal matrix with first p diagonal matrix equal to 1 and next q diagonal entries equal to -1
+
+    Examples
+    ==========
+
+    Consider the following matrix:
+
+    .. math::
+        A = \frac{1}{\sqrt{2}} \begin{pmatrix}
+            cosh(1) & sinh(1) \\
+            sinh(1) & cosh(1)
+        \end{pmatrix}
+
+    with the signature matrix:
+
+    .. math::
+        J = \begin{pmatrix}
+            1 & 0 \\
+            0 & -1
+        \end{pmatrix}
+
+    Our function confirms that :math:A is pseudo-unitary:
+
+    >>> import numpy as np
+    >>> from toqito.matrix_props import is_pseudo_unitary
+    >>> A = np.array([[np.cosh(1), np.sinh(1)], [np.sinh(1), np.cosh(1)]])
+    >>> is_pseudo_unitary(A, p=1, q=1)
+    True
+
+    However, the following matrix :math:B
+
+    .. math::
+        B = \begin{pmatrix}
+            1 & 0 \\
+            1 & 1
+        \end{pmatrix}
+
+    is not pseudo-unitary with respect to the same signature matrix:
+
+    >>> B = np.array([[1, 0], [1, 1]])
+    >>> is_pseudo_unitary(B, p=1, q=1)
+    False
+
+    References
+    ==========
+
+    .. bibliography::
+        :filter: docname in docnames
+
+    :param mat: The matrix to check.
+    :param p: Number of positive entries in the signature matrix.
+    :param q: Number of negative entries in the signature matrix.
+    :param rtol: The relative tolerance parameter (default 1e-05).
+    :param atol: The absolute tolerance parameter (default 1e-08).
+    :raises ValueError: When p < 0 or q < 0.
+    :return: Return :code:True if the matrix is pseudo-unitary, and :code:False otherwise.
+
+    """
+    if p < 0 or q < 0:
+        raise ValueError("p and q must be non-negative")
+
+    if not is_square(mat):
+        return False
+
+    if p + q != mat.shape[0]:
+        return False
+
+    signature = np.diag(np.hstack((np.ones(p), -np.ones(q))))
+    ac_j_a_mat = mat.conj().T @ signature @ mat
+
+    return np.all(np.isclose(ac_j_a_mat, signature, rtol=rtol, atol=atol))

--- a/toqito/matrix_props/is_pseudo_unitary.py
+++ b/toqito/matrix_props/is_pseudo_unitary.py
@@ -42,7 +42,7 @@ def is_pseudo_unitary(mat: np.ndarray, p: int, q: int, rtol: float = 1e-05, atol
     >>> from toqito.matrix_props import is_pseudo_unitary
     >>> A = np.array([[np.cosh(1), np.sinh(1)], [np.sinh(1), np.cosh(1)]])
     >>> is_pseudo_unitary(A, p=1, q=1)
-    np.True_
+    True
 
     However, the following matrix :math:B
 
@@ -56,7 +56,7 @@ def is_pseudo_unitary(mat: np.ndarray, p: int, q: int, rtol: float = 1e-05, atol
 
     >>> B = np.array([[1, 0], [1, 1]])
     >>> is_pseudo_unitary(B, p=1, q=1)
-    np.False_
+    False
 
     References
     ==========
@@ -85,4 +85,4 @@ def is_pseudo_unitary(mat: np.ndarray, p: int, q: int, rtol: float = 1e-05, atol
     signature = np.diag(np.hstack((np.ones(p), -np.ones(q))))
     ac_j_a_mat = mat.conj().T @ signature @ mat
 
-    return np.all(np.isclose(ac_j_a_mat, signature, rtol=rtol, atol=atol))
+    return np.allclose(ac_j_a_mat, signature, rtol=rtol, atol=atol)

--- a/toqito/matrix_props/is_pseudo_unitary.py
+++ b/toqito/matrix_props/is_pseudo_unitary.py
@@ -23,7 +23,7 @@ def is_pseudo_unitary(mat: np.ndarray, p: int, q: int, rtol: float = 1e-05, atol
     Consider the following matrix:
 
     .. math::
-        A = \frac{1}{\sqrt{2}} \begin{pmatrix}
+        A = \begin{pmatrix}
             cosh(1) & sinh(1) \\
             sinh(1) & cosh(1)
         \end{pmatrix}

--- a/toqito/matrix_props/tests/test_is_pseudo_unitary.py
+++ b/toqito/matrix_props/tests/test_is_pseudo_unitary.py
@@ -25,7 +25,7 @@ def test_is_not_pseudo_unitary():
     np.testing.assert_equal(is_pseudo_unitary(mat, p=1, q=1), False)
 
 
-def test_is_not_pseudo_unitary_incorrect_signatur_dimensions():
+def test_is_not_pseudo_unitary_incorrect_signature_dimensions():
     """Test that non-unitary matrix returns False."""
     mat = np.array([[1, 0], [1, 1]])
     np.testing.assert_equal(is_pseudo_unitary(mat, p=4, q=5), False)
@@ -35,3 +35,10 @@ def test_is_pseudo_unitary_not_square():
     """Input must be a square matrix."""
     mat = np.array([[-1, 1, 1], [1, 2, 3]])
     np.testing.assert_equal(is_pseudo_unitary(mat, p=1, q=1), False)
+
+
+def test_is_pseudo_unitary_value_error():
+    """Input must have p >= 0 and q >= 0."""
+    mat = np.array([[1, 0], [0, 1]])
+    np.testing.assert_raises_regex(ValueError, "p and q must be non-negative", is_pseudo_unitary, mat, p=-1, q=1)
+    np.testing.assert_raises_regex(ValueError, "p and q must be non-negative", is_pseudo_unitary, mat, p=1, q=-1)

--- a/toqito/matrix_props/tests/test_is_pseudo_unitary.py
+++ b/toqito/matrix_props/tests/test_is_pseudo_unitary.py
@@ -1,40 +1,25 @@
 """Test is_pseudo_unitary."""
 
 import numpy as np
+import pytest
 
 from toqito.matrix_props import is_pseudo_unitary
 from toqito.rand import random_unitary
 
 
-def test_is_unitary_random():
-    """Test that random unitary matrix with signature diag([1, 1]) return True."""
-    mat = random_unitary(2)
-    np.testing.assert_equal(is_pseudo_unitary(mat, p=2, q=0), True)
-
-
-def test_is_pseudo_unitary_lorentz_boost():
-    """Test that Lorentz boost matrix with signature diag([1, -1]) returns True."""
-    theta = np.random.rand()
-    mat = np.array([[np.cosh(theta), np.sinh(theta)], [np.sinh(theta), np.cosh(theta)]])
-    np.testing.assert_equal(is_pseudo_unitary(mat, p=1, q=1), True)
-
-
-def test_is_not_pseudo_unitary():
-    """Test that non pseudo unitary matrix returns False."""
-    mat = np.array([[1, 0], [1, -1]])
-    np.testing.assert_equal(is_pseudo_unitary(mat, p=1, q=1), False)
-
-
-def test_is_not_pseudo_unitary_incorrect_signature_dimensions():
-    """Test that non-unitary matrix returns False."""
-    mat = np.array([[1, 0], [1, 1]])
-    np.testing.assert_equal(is_pseudo_unitary(mat, p=4, q=5), False)
-
-
-def test_is_pseudo_unitary_not_square():
-    """Input must be a square matrix."""
-    mat = np.array([[-1, 1, 1], [1, 2, 3]])
-    np.testing.assert_equal(is_pseudo_unitary(mat, p=1, q=1), False)
+@pytest.mark.parametrize(
+    "mat, p, q, expected",
+    [
+        (random_unitary(2), 2, 0, True),  # Unitary Matrix
+        (np.array([[np.cosh(0.5), np.sinh(0.5)], [np.sinh(0.5), np.cosh(0.5)]]), 1, 1, True),  # Lorentz Boost Matrix
+        (np.array([[1, 0], [1, -1]]), 1, 1, False),  # Non pseudo unitary matrix
+        (np.array([[1, 0], [1, 1]]), 4, 5, False),  # Inconsistent shapes of matrix and signature
+        (np.array([[-1, 1, 1], [1, 2, 3]]), 1, 1, False),  # Non square matrix
+    ],
+)
+def test_is_pseudo_unitary(mat, p, q, expected):
+    """Test that is_pseudo_unitary gives correct boolean value on valid inputs."""
+    np.testing.assert_equal(is_pseudo_unitary(mat, p, q), expected)
 
 
 def test_is_pseudo_unitary_value_error():

--- a/toqito/matrix_props/tests/test_is_pseudo_unitary.py
+++ b/toqito/matrix_props/tests/test_is_pseudo_unitary.py
@@ -1,0 +1,37 @@
+"""Test is_pseudo_unitary."""
+
+import numpy as np
+
+from toqito.matrix_props import is_pseudo_unitary
+from toqito.rand import random_unitary
+
+
+def test_is_unitary_random():
+    """Test that random unitary matrix with signature diag([1, 1]) return True."""
+    mat = random_unitary(2)
+    np.testing.assert_equal(is_pseudo_unitary(mat, p=2, q=0), True)
+
+
+def test_is_pseudo_unitary_lorentz_boost():
+    """Test that Lorentz boost matrix with signature diag([1, -1]) returns True."""
+    theta = np.random.rand()
+    mat = np.array([[np.cosh(theta), np.sinh(theta)], [np.sinh(theta), np.cosh(theta)]])
+    np.testing.assert_equal(is_pseudo_unitary(mat, p=1, q=1), True)
+
+
+def test_is_not_pseudo_unitary():
+    """Test that non pseudo unitary matrix returns False."""
+    mat = np.array([[1, 0], [1, -1]])
+    np.testing.assert_equal(is_pseudo_unitary(mat, p=1, q=1), False)
+
+
+def test_is_not_pseudo_unitary_incorrect_signatur_dimensions():
+    """Test that non-unitary matrix returns False."""
+    mat = np.array([[1, 0], [1, 1]])
+    np.testing.assert_equal(is_pseudo_unitary(mat, p=4, q=5), False)
+
+
+def test_is_pseudo_unitary_not_square():
+    """Input must be a square matrix."""
+    mat = np.array([[-1, 1, 1], [1, 2, 3]])
+    np.testing.assert_equal(is_pseudo_unitary(mat, p=1, q=1), False)


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->

Added feature to check if a matrix is pseudo unitary (in regards to [Issue 767](https://github.com/vprusso/toqito/issues/767)).

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  Added is_pseudo_unitary
  -  Added test_is_pseudo_unitary
  -  Updated matrix_props/__init_.py

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [X] Use `ruff` for errors related to code style and formatting.
  -  [X] Verify all previous and newly added unit tests pass in `pytest`.
  -  [X] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [X] Use `linkcheck` to check for broken links in the documentation
  -  [X] Use `doctest` to verify the examples in the function docstrings work as expected.
