### PR TITLE
Update badges in README to reflect Unitary Foundation name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
-[![build status](https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml/badge.svg?style=plastic)](https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml)
-[![doc status](https://readthedocs.org/projects/toqito/badge/?version=latest&style=plastic)](https://toqito.readthedocs.io/en/latest/)
-[![codecov](https://codecov.io/gh/vprusso/toqito/branch/master/graph/badge.svg?style=plastic)](https://codecov.io/gh/vprusso/toqito)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4743211.svg)](https://doi.org/10.5281/zenodo.4743211)
-[![Downloads](https://static.pepy.tech/personalized-badge/toqito?style=platic&period=total&units=none&left_color=black&right_color=brightgreen&left_text=Downloads)](https://pepy.tech/project/toqito)
-[![Unitary Fund](https://img.shields.io/badge/Supported%20By-UNITARY%20FUND-brightgreen.svg?style=plastic)](http://unitary.fund)
-
-
 <p align="center">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/vprusso/toqito/raw/cfb62c4a5ce04b782f64229e7acd2b1c97f09801/docs/figures/logo.svg" width="60%">
@@ -15,6 +7,14 @@
 
 
 # toqito: Theory of Quantum Information Toolkit
+
+[![build status](https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml/badge.svg?style=plastic)](https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml)
+[![doc status](https://readthedocs.org/projects/toqito/badge/?version=latest&style=plastic)](https://toqito.readthedocs.io/en/latest/)
+[![codecov](https://codecov.io/gh/vprusso/toqito/branch/master/graph/badge.svg?style=plastic)](https://codecov.io/gh/vprusso/toqito)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4743211.svg)](https://doi.org/10.5281/zenodo.4743211)
+[![Downloads](https://static.pepy.tech/personalized-badge/toqito?style=platic&period=total&units=none&left_color=black&right_color=brightgreen&left_text=Downloads)](https://pepy.tech/project/toqito)
+[![Unitary Foundation](https://img.shields.io/badge/Supported%20By-Unitary%20Foundation-FFFF00.svg?style=plastic)](https://unitary.foundation)
+
 
 The `toqito` package is an open-source Python library for studying various
 objects in quantum information, namely, states, channels, and measurements.


### PR DESCRIPTION
This Pull Request addresses issue [#998](https://github.com/vprusso/toqito/issues/998). I made the following changes in the README:

1. **Rename “Unitary Fund” to “Unitary Foundation”**  
   - Updated all text references to use the new name.

2. **Align Badge Style**  
   - Modified the badges following the example from [this reference README](https://github.com/unitaryfund/metriq-gym/blob/main/README.md).  
   - Adjusted badge format and links to match the desired style.

These changes focus on **documentation and styling**; they do not affect any core functionality of the project.

## Additional Notes

- Feedback or further suggestions are welcome.  
- Thank you for reviewing this Pull Request!
