### PR TITLE
Removed broken link to toqito homepage from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,6 @@ chsh.quantum_value()
 Full documentation along with specific examples and tutorials are provided here:
 [https://toqito.readthedocs.io/](https://toqito.readthedocs.io/). 
 
-More information can also be found on the following
-[toqito homepage](https://vprusso.github.io/toqito/).
-
 Chat with us in our `toqito` channel on [Discord](http://discord.unitary.fund/). 
 
 ## Testing


### PR DESCRIPTION
## Description
Removed a broken link from the README that pointed to a non-existent toqito homepage. Since no dedicated landing page exists, this line was removed entirely as suggested in the issue discussion.

Fixes Issue #1002 

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [ ] Removed the broken link from the README

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
