### PR TITLE
Update style plastic and include Unitary Foundation name in index.rst

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 # toqito: Theory of Quantum Information Toolkit
 
-[![build status](https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml/badge.svg?style=plastic)](https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml)
-[![doc status](https://readthedocs.org/projects/toqito/badge/?version=latest&style=plastic)](https://toqito.readthedocs.io/en/latest/)
-[![codecov](https://codecov.io/gh/vprusso/toqito/branch/master/graph/badge.svg?style=plastic)](https://codecov.io/gh/vprusso/toqito)
+[![build status](https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml/badge.svg)](https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml)
+[![doc status](https://readthedocs.org/projects/toqito/badge/?version=latest)](https://toqito.readthedocs.io/en/latest/)
+[![codecov](https://codecov.io/gh/vprusso/toqito/branch/master/graph/badge.svg)](https://codecov.io/gh/vprusso/toqito)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4743211.svg)](https://doi.org/10.5281/zenodo.4743211)
 [![Downloads](https://static.pepy.tech/personalized-badge/toqito?style=platic&period=total&units=none&left_color=black&right_color=brightgreen&left_text=Downloads)](https://pepy.tech/project/toqito)
-[![Unitary Foundation](https://img.shields.io/badge/Supported%20By-Unitary%20Foundation-FFFF00.svg?style=plastic)](https://unitary.foundation)
+[![Unitary Foundation](https://img.shields.io/badge/Supported%20By-Unitary%20Foundation-FFFF00.svg)](https://unitary.foundation)
 
 
 The `toqito` package is an open-source Python library for studying various

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,21 +13,19 @@ entanglement theory, nonlocal games, and other aspects of quantum information
 that are often associated with computer science.
 
 
-.. image:: https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml/badge.svg?style=plastic
+.. image:: https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml/badge.svg
    :alt: Build Status
    :target: https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml
-.. image:: https://readthedocs.org/projects/toqito/badge/?version=latest&style=plastic
-   :alt: Documentation
+.. image:: https://readthedocs.org/projects/toqito/badge/?version=latest
    :target: https://toqito.readthedocs.io/en/latest/
-.. image:: https://codecov.io/gh/vprusso/toqito/branch/master/graph/badge.svg?style=plastic
+.. image:: https://codecov.io/gh/vprusso/toqito/branch/master/graph/badge.svg
    :alt: Codecov
    :target: https://codecov.io/gh/vprusso/toqito
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4743211.svg?style=plastic
-   :alt: DOI
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4743211.svg
    :target: https://doi.org/10.5281/zenodo.4743211
-.. image:: https://img.shields.io/badge/Supported%20By-UNITARY%20FUND-brightgreen.svg?style=plastic
-   :alt: Unitary Fund
-   :target: http://unitary.fund
+.. image:: https://img.shields.io/badge/Supported%20By-Unitary%20Foundation-FFFF00.svg
+   :alt: Unitary Foundation
+   :target: https://unitary.foundation
 
 
 User Documentation


### PR DESCRIPTION
# Update Docs Page & Badge Style

## Description

This Pull Request addresses the additional feedback from [@vprusso](https://github.com/vprusso) regarding the documentation and badge style:

1. **Documentation Page Update**  
   - Updated the `docs/index.rst` file to ensure the name and badge references are consistent with the recent changes.

2. **Badge Style Change**  
   - Changed the badge style from **"plastic"** to match the style used in [the linked reference page](https://raw.githubusercontent.com/unitaryfund/metriq-gym/refs/heads/main/README.md). This ensures visual consistency across the project.

These updates build on the previous changes by refining documentation and improving the user-facing badges. As always, feedback or further suggestions are welcome.

## Additional Notes

- Please let me know if there are any other documentation sections that need updating.  
- Thank you for taking the time to review this PR!
