### PR TITLE
Add MyPy to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,11 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format 
+
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+    -   id: mypy
+        args: [--config-file=pyproject.toml]
+        pass_filenames: false
+        stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,3 +87,9 @@ ignore = ["D407", "D203", "D213", "D416", "PLR0912", "PLR0911", "PLR0915", "PLR2
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["I001"]
 # I001 - skip checking Import block is un-sorted or un-formatted
+
+[tool.mypy]
+files = ["toqito/measurements"]
+# files = ["toqito"] uncomment this line when all the modules in toqito are mypy compliant.
+ignore_missing_imports = true
+follow_imports = "skip"


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->

Fixes #1010 

Adds mypy to github workflow as a pre-commit hook(#1010 ). 
As of now, mypy only checks toqito/measurements module(which has been mypy complaint).  Later when one fixes type errors module wise/file wise, we can add those filenames/module names in pyproject.toml. 

This is inline with what Purva Thakre suggested over here, https://github.com/vprusso/toqito/issues/299#issuecomment-1831987820.
There are quite a few type errors (~400). I think one should raise PR's modulewise/functionwise as Purva suggested earlier. I've solved few type errors and I'll raise seperate PRs for them. Shall I create new issues as Purva suggested earlier? 

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [x] Add mypy hook to pre-commit-config.yaml
  -  [x] Update pyproject.toml config file accordingly.  

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [ ] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [ ] Use `linkcheck` to check for broken links in the documentation
  -  [ ] Use `doctest` to verify the examples in the function docstrings work as expected.
