### PR TITLE
Add is_abs_ppt

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ linkcheck_ignore = [
     r"https://arxiv\.org/.*",
     r"https://doi\.org/.*",
     r"https://link\.aps\.org/doi/.*",
-    r"http://dx\.doi\.org/.*"
+    r"http://dx\.doi\.org/.*",
 ]
 # we need to skip these warnigns because all the references appear twice, in a function docstring
 # and on the references page.

--- a/toqito/state_props/__init__.py
+++ b/toqito/state_props/__init__.py
@@ -23,3 +23,4 @@ from toqito.state_props.sk_vec_norm import sk_vector_norm
 from toqito.state_props.is_antidistinguishable import is_antidistinguishable
 from toqito.state_props.is_distinguishable import is_distinguishable
 from toqito.state_props.is_unextendible_product_basis import is_unextendible_product_basis
+from toqito.state_props.is_abs_ppt import is_abs_ppt

--- a/toqito/state_props/is_abs_ppt.py
+++ b/toqito/state_props/is_abs_ppt.py
@@ -17,21 +17,21 @@ def is_abs_ppt(rho: np.ndarray, dim: list[int] | None = None, max_constraints: i
 
     >>> import numpy as np
     >>> rho = np.array([[0.5, 0.0], [0.0, 0.5]])
-    >>> is_abs_ppt(rho, [2, 2])
+    >>> is_abs_ppt(rho, [2, 1])
     True
 
-    2) Bell state (entangled, not absolutely PPT):
+    Bell state (entangled, not absolutely PPT):
 
     >>> from toqito.states import bell
     >>> bell_state = bell(0) @ bell(0).conj().T
     >>> is_abs_ppt(bell_state, [2, 2])
     False
 
-    3) High-dimensional identity matrix (likely inconclusive):
+    High-dimensional identity matrix:
 
     >>> rho_7 = np.eye(49) / 49
     >>> is_abs_ppt(rho_7, [7, 7])
-    None  # or possibly True or False if partial constraints detect otherwise
+    True
 
     References
     ==========

--- a/toqito/state_props/is_abs_ppt.py
+++ b/toqito/state_props/is_abs_ppt.py
@@ -3,12 +3,118 @@
 import numpy as np
 
 from toqito.matrix_props.is_density import is_density
-from toqito.state_opt.symmetric_extension_hierarchy import symmetric_extension_hierarchy
+from toqito.matrix_props.is_positive_semidefinite import is_positive_semidefinite
 from toqito.state_props.in_separable_ball import in_separable_ball
-from toqito.state_props.is_ppt import is_ppt
 
 
-def is_abs_ppt(rho: np.ndarray, dim: list[int] | None = None, max_constraints: int = 2612) -> bool | None:
+def perm_inv(a):
+    """Inverse of a permutation array."""
+    b = [0] * len(a)
+    for i, v in enumerate(a):
+        b[v - 1] = i + 1
+    return b
+
+
+def check_ordered(X, i, j):
+    """Check if matrix X is column-wise ordered at position (i, j)."""
+    return not (i > 0 and X[i - 1][j] > X[i][j])
+
+
+def check_cross(p, X):
+    """Validate cross-ordering constraints on matrix X."""
+    for i in range(p):
+        for j in range(p):
+            for k in range(p):
+                for idx_l in range(p):
+                    for m in range(p):
+                        for n in range(p):
+                            if (
+                                X[min(i, j)][max(i, j)] > X[min(k, idx_l)][max(k, idx_l)]
+                                and X[min(idx_l, n)][max(idx_l, n)] > X[min(j, m)][max(j, m)]
+                                and X[min(i, n)][max(i, n)] < X[min(k, m)][max(k, m)]
+                            ):
+                                return False
+    return True
+
+
+def eigen_from_order(X, lam, dim):
+    """Construct eigenvalue constraint matrix based on index matrix X."""
+    p = min(dim)
+    prod_dim = np.prod(dim)
+    Y = np.triu(X, 1)
+    X_full = np.triu(X) + np.triu(X, 1).T
+    sparsity_pattern = Y > 0
+    sorted_indices = np.argsort(Y[sparsity_pattern].flatten())
+    Y[sparsity_pattern] = np.array(perm_inv(sorted_indices + 1))
+    Y = Y + Y.T + np.diag(prod_dim + 1 - np.diag(X_full))
+
+    L_mat = lam[prod_dim - X_full]
+    L_mat += 2 * np.diag(np.diag(L_mat))
+    L_mat -= lam[Y]
+    return L_mat
+
+
+def abs_ppt_constraints(lam, dim, escape_if_not_psd=False, lim=0):
+    """Construct absolutely PPT constraint matrices from the eigenvalues.
+
+    These matrices, if all positive semidefinite, indicate that the state is absolutely PPT.
+
+    :param lam: Sorted eigenvalues of the density matrix.
+    :param dim: Dimensions of the bipartite state.
+    :param escape_if_not_psd: Stop once a PSD violation is detected.
+    :param lim: Maximum number of matrices to generate.
+    :return: List of constraint matrices.
+    """
+    lam = np.sort(np.real(lam))[::-1]
+    p = min(dim)
+    total = p * (p + 1) // 2
+    constraints = []
+
+    if p == 1:
+        return []
+    elif p == 2:
+        L = np.array([[2 * lam[-1], lam[-2] - lam[0]], [lam[-2] - lam[0], 2 * lam[-3]]])
+        return [L]
+
+    X = np.full((p, p), total + 1, dtype=int)
+    num_pool = [1] * total
+    X[0][0] = 1
+    X[0][1] = 2
+    X[p - 1][p - 1] = total
+    X[p - 2][p - 1] = total - 1
+
+    def fill_matrix(i, j, low_lim):
+        nonlocal constraints
+        up_lim = min(j * (j + 1) // 2 + i * (p - j), total - 2)
+        for k in range(low_lim, up_lim + 1):
+            if num_pool[k - 1] == 1:
+                X[i][j] = k
+                num_pool[k - 1] = 0
+
+                if check_ordered(X, i, j):
+                    if i == p - 2 and j == p - 2:
+                        if check_cross(p, X):
+                            L = eigen_from_order(X, lam, dim)
+                            constraints.append(L)
+                            if (escape_if_not_psd and not is_positive_semidefinite(L)) or (
+                                lim > 0 and len(constraints) >= lim
+                            ):
+                                return True
+                    elif j == p - 1:
+                        if fill_matrix(i + 1, i + 1, 3):
+                            return True
+                    elif fill_matrix(i, j + 1, k + 1):
+                        return True
+
+                num_pool[k - 1] = 1
+        X[i][j] = total + 1
+        return False
+
+    fill_matrix(1, 2, 3)
+    return constraints
+
+
+def is_abs_ppt(rho: np.ndarray, dim: list[int] = None, max_constraints: int = 2612) -> bool | None:
     r"""Determine whether a quantum state is absolutely PPT.
 
     Examples
@@ -33,47 +139,73 @@ def is_abs_ppt(rho: np.ndarray, dim: list[int] | None = None, max_constraints: i
     >>> is_abs_ppt(rho_7, [7, 7])
     True
 
+    Qutrit-qutrit state (not absolutely PPT)
+
+    >>> lam = np.array([0.3, 0.2, 0.15, 0.1, 0.08, 0.06, 0.04, 0.04, 0.03])
+    >>> is_abs_ppt(lam, [3, 3])
+    False
+
+
     References
     ==========
     .. bibliography::
         :filter: docname in docnames
 
-    :param rho: Density matrix to be tested.
+    :param rho: A density matrix or eigenvalue vector.
     :param dim: A list of two integers representing bipartite dimensions. If `None`, assume equal split.
-    :param max_constraints: Maximum number of SDP constraints for symmetric extension checks.
-    :raises ValueError: If `rho` is invalid as a density matrix.
+    :param max_constraints: Number of constraints to generate for checking.
+    :raises ValueError: If `rho` is not a valid density matrix.
+    :raises ValueError: If `rho` is neither a valid matrix nor a 1D eigenvalue array.
+    :raises ValueError: If the product of `dim` does not match the length of `rho`.
     :return: `True` if absolutely PPT, `False` if not, or `None` if inconclusive.
 
     """
-    if not is_density(rho):
+    rho = np.array(rho, dtype=np.complex128)
+
+    if len(rho.shape) == 2 and rho.shape[0] != rho.shape[1]:
         raise ValueError("Input `rho` is not a valid density matrix.")
 
-    rho = (rho + rho.conj().T) / 2
-    d = rho.shape[0]
-    if dim is None:
-        s = int(np.sqrt(d))
-        if s * s != d:
-            raise ValueError("Unable to infer valid bipartite dimensions; please specify `dim` explicitly.")
-        dim = [s, s]
-    if len(dim) != 2 or dim[0] * dim[1] != d:
-        raise ValueError("`dim` must match the shape of `rho`.")
+    rho = (rho + rho.T.conj()) / 2
 
-    lam = np.linalg.eigvalsh(rho)
+    if len(rho.shape) == 2:
+        if not is_density(rho):
+            raise ValueError("Input `rho` is not a valid density matrix.")
+        lam = np.sort(np.real(np.linalg.eigvalsh(rho)))[::-1]
+    elif len(rho.shape) == 1:
+        lam = np.sort(np.real(rho))[::-1]
+    else:
+        raise ValueError("Input `rho` must be a square matrix or a list of eigenvalues.")
+
+    len_lam = len(lam)
+    if dim is None:
+        d = int(np.sqrt(len_lam))
+        dim = [d, d]
+
+    if len(dim) == 1:
+        dim = [dim[0], len_lam // dim[0]]
+
+    if np.prod(dim) != len_lam:
+        raise ValueError("Dimensions do not match the length of `rho`.")
+
     p = min(dim)
 
-    if in_separable_ball(np.sort(lam)[::-1]):
+    if in_separable_ball(lam):
         return True
-    if not is_ppt(rho, sys=2, dim=dim):
+
+    if np.sum(lam[: p - 1]) <= 2 * lam[-1] + np.sum(lam[-p + 1 : -1]):
+        return True
+
+    if p >= 7:
+        return None
+
+    constraints = abs_ppt_constraints(lam, dim, escape_if_not_psd=True, lim=max_constraints)
+    if not constraints:
         return False
 
-    lam_sorted = np.sort(lam)[::-1]
-    if np.sum(lam_sorted[: p - 1]) <= 2 * lam_sorted[-1] + np.sum(lam_sorted[-(p - 1) : -1]):
+    if not is_positive_semidefinite(constraints[-1]):
+        return False
+
+    if p <= 6:
         return True
 
-    try:
-        L = symmetric_extension_hierarchy([rho], level=1, dim=dim, max_constraints=max_constraints)
-        if np.any(np.linalg.eigvals(L[-1]) < 0):
-            return False
-        return True if p <= 6 else None
-    except Exception:
-        return None
+    return None

--- a/toqito/state_props/is_abs_ppt.py
+++ b/toqito/state_props/is_abs_ppt.py
@@ -1,0 +1,128 @@
+"""Check if a quantum state is absolutely PPT."""
+
+import numpy as np
+
+from toqito.matrix_props.is_positive_semidefinite import is_positive_semidefinite
+from toqito.state_opt.symmetric_extension_hierarchy import symmetric_extension_hierarchy
+from toqito.state_props.is_ppt import is_ppt
+from toqito.state_props.is_separable import is_separable
+
+
+def is_abs_ppt(rho: np.ndarray, dim: list[int] = None, max_constraints: int = 2612) -> int:
+    r"""Determine whether a quantum state is absolutely PPT.
+
+    A quantum state :math:`\rho` is absolutely PPT if it remains PPT under any unitary transformation.
+    This function evaluates the condition using:
+
+    - Quick separability checks (to immediately identify separable states)
+    - The PPT property (to test for the PPT condition)
+    - A Gershgorin-type condition (providing a bound based on the eigenvalues)
+    - A symmetric extension hierarchy (for deeper verification when needed)
+
+    .. math::
+        \rho \text{ is absolutely PPT} \iff \forall U,\, (U \rho U^\dagger)^{T_B} \succeq 0.
+
+    Examples
+    ========
+    Example 1: A separable mixed state (trivially PPT)
+
+    >>> import numpy as np
+    >>> from toqito.state_props import is_abs_ppt
+    >>> rho = np.array([[0.5, 0], [0, 0.5]])  # Maximally mixed state
+    >>> is_abs_ppt(rho, [2, 2])
+    1
+
+    Example 2: A Bell state (entangled, not absolutely PPT)
+
+    >>> from toqito.states import bell
+    >>> bell_state = bell(0) @ bell(0).conj().T
+    >>> is_abs_ppt(bell_state, [2, 2])
+    0
+
+    Example 3: A high-dimensional identity matrix (returns -1 for inconclusive cases)
+
+    >>> rho = np.eye(49) / 49
+    >>> is_abs_ppt(rho, [7, 7])
+    -1
+
+    References
+    ==========
+    - MATLAB QETLAB Implementation: Nathaniel Johnston,
+      "IsAbsPPT function" <http://www.qetlab.com/IsAbsPPT>
+
+    Parameters
+    ==========
+    rho : np.ndarray
+        The density matrix (or a vector of its eigenvalues) to be tested.
+    dim : list[int], optional
+        A list of two integers representing the dimensions of the bipartite subsystems.
+        If `None`, an equal split is assumed.
+    max_constraints : int, optional
+        The maximum number of SDP constraints to impose when using the symmetric extension hierarchy.
+
+    Returns
+    =======
+    int
+        - 1 if `rho` is absolutely PPT.
+        - 0 if `rho` is not absolutely PPT.
+        - -1 if the test is inconclusive (e.g., due to high dimension or computational constraints).
+
+    Raises
+    ======
+    ValueError
+        If `rho` is not square.
+    ValueError
+        If `rho` has zero trace.
+    ValueError
+        If `dim` does not match the shape of `rho`.
+
+    """
+    rho = np.array(rho, dtype=np.complex128)
+
+    if rho.shape[0] != rho.shape[1]:
+        raise ValueError("The input matrix `rho` must be square.")
+
+    if np.isclose(np.trace(rho), 0):
+        raise ValueError("The input matrix `rho` has zero trace, which is invalid for density matrices.")
+
+    rho = (rho + rho.T.conj()) / 2  # Force Hermitian symmetry
+
+    if dim is None:
+        total_dim = int(np.sqrt(rho.shape[0]))
+        dim = [total_dim, total_dim]
+
+    if len(dim) != 2 or np.prod(dim) != rho.shape[0]:
+        raise ValueError("Dimension mismatch: `dim` must be a 1x2 list that correctly partitions `rho`.")
+
+    eigvals = np.linalg.eigvalsh(rho)
+    p = int(min(dim))
+    print(f"[DEBUG] Computed p = {p}, type = {type(p)}")
+
+    if p >= 7:
+        print("[DEBUG] Large dimension detected (p >= 7). Returning -1.")
+        return -1
+
+    if not is_positive_semidefinite(rho):
+        if p >= 6:
+            print("[DEBUG] rho is not PSD but high-dimensional; returning -1 as inconclusive.")
+            return -1
+        print("[DEBUG] rho is not PSD. Returning 0.")
+        return 0
+
+    try:
+        if is_separable(rho):
+            return 1
+    except ValueError:
+        pass
+
+    if not is_ppt(rho, sys=2, dim=dim):
+        return 0
+
+    if np.sum(eigvals[: p - 1]) <= 2 * eigvals[-1] + np.sum(eigvals[-p + 1 : -1]):
+        return 1
+
+    L = symmetric_extension_hierarchy([rho], level=1, dim=dim)
+    if not is_positive_semidefinite(L[-1]):
+        return 0
+
+    return 1

--- a/toqito/state_props/is_abs_ppt.py
+++ b/toqito/state_props/is_abs_ppt.py
@@ -2,127 +2,78 @@
 
 import numpy as np
 
-from toqito.matrix_props.is_positive_semidefinite import is_positive_semidefinite
+from toqito.matrix_props.is_density import is_density
 from toqito.state_opt.symmetric_extension_hierarchy import symmetric_extension_hierarchy
+from toqito.state_props.in_separable_ball import in_separable_ball
 from toqito.state_props.is_ppt import is_ppt
-from toqito.state_props.is_separable import is_separable
 
 
-def is_abs_ppt(rho: np.ndarray, dim: list[int] = None, max_constraints: int = 2612) -> int:
+def is_abs_ppt(rho: np.ndarray, dim: list[int] | None = None, max_constraints: int = 2612) -> bool | None:
     r"""Determine whether a quantum state is absolutely PPT.
 
-    A quantum state :math:`\rho` is absolutely PPT if it remains PPT under any unitary transformation.
-    This function evaluates the condition using:
-
-    - Quick separability checks (to immediately identify separable states)
-    - The PPT property (to test for the PPT condition)
-    - A Gershgorin-type condition (providing a bound based on the eigenvalues)
-    - A symmetric extension hierarchy (for deeper verification when needed)
-
-    .. math::
-        \rho \text{ is absolutely PPT} \iff \forall U,\, (U \rho U^\dagger)^{T_B} \succeq 0.
-
     Examples
-    ========
-    Example 1: A separable mixed state (trivially PPT)
+    =========
+    A maximally mixed state on 2 x 2:
 
     >>> import numpy as np
-    >>> from toqito.state_props import is_abs_ppt
-    >>> rho = np.array([[0.5, 0], [0, 0.5]])  # Maximally mixed state
+    >>> rho = np.array([[0.5, 0.0], [0.0, 0.5]])
     >>> is_abs_ppt(rho, [2, 2])
-    1
+    True
 
-    Example 2: A Bell state (entangled, not absolutely PPT)
+    2) Bell state (entangled, not absolutely PPT):
 
     >>> from toqito.states import bell
     >>> bell_state = bell(0) @ bell(0).conj().T
     >>> is_abs_ppt(bell_state, [2, 2])
-    0
+    False
 
-    Example 3: A high-dimensional identity matrix (returns -1 for inconclusive cases)
+    3) High-dimensional identity matrix (likely inconclusive):
 
-    >>> rho = np.eye(49) / 49
-    >>> is_abs_ppt(rho, [7, 7])
-    -1
+    >>> rho_7 = np.eye(49) / 49
+    >>> is_abs_ppt(rho_7, [7, 7])
+    None  # or possibly True or False if partial constraints detect otherwise
 
     References
     ==========
-    - MATLAB QETLAB Implementation: Nathaniel Johnston,
-      "IsAbsPPT function" <http://www.qetlab.com/IsAbsPPT>
+    .. bibliography::
+        :filter: docname in docnames
 
-    Parameters
-    ==========
-    rho : np.ndarray
-        The density matrix (or a vector of its eigenvalues) to be tested.
-    dim : list[int], optional
-        A list of two integers representing the dimensions of the bipartite subsystems.
-        If `None`, an equal split is assumed.
-    max_constraints : int, optional
-        The maximum number of SDP constraints to impose when using the symmetric extension hierarchy.
-
-    Returns
-    =======
-    int
-        - 1 if `rho` is absolutely PPT.
-        - 0 if `rho` is not absolutely PPT.
-        - -1 if the test is inconclusive (e.g., due to high dimension or computational constraints).
-
-    Raises
-    ======
-    ValueError
-        If `rho` is not square.
-    ValueError
-        If `rho` has zero trace.
-    ValueError
-        If `dim` does not match the shape of `rho`.
+    :param rho: Density matrix to be tested.
+    :param dim: A list of two integers representing bipartite dimensions. If `None`, assume equal split.
+    :param max_constraints: Maximum number of SDP constraints for symmetric extension checks.
+    :raises ValueError: If `rho` is invalid as a density matrix.
+    :return: `True` if absolutely PPT, `False` if not, or `None` if inconclusive.
 
     """
-    rho = np.array(rho, dtype=np.complex128)
+    if not is_density(rho):
+        raise ValueError("Input `rho` is not a valid density matrix.")
 
-    if rho.shape[0] != rho.shape[1]:
-        raise ValueError("The input matrix `rho` must be square.")
-
-    if np.isclose(np.trace(rho), 0):
-        raise ValueError("The input matrix `rho` has zero trace, which is invalid for density matrices.")
-
-    rho = (rho + rho.T.conj()) / 2  # Force Hermitian symmetry
-
+    rho = (rho + rho.conj().T) / 2
+    d = rho.shape[0]
     if dim is None:
-        total_dim = int(np.sqrt(rho.shape[0]))
-        dim = [total_dim, total_dim]
+        s = int(np.sqrt(d))
+        if s * s != d:
+            raise ValueError("Unable to infer valid bipartite dimensions; please specify `dim` explicitly.")
+        dim = [s, s]
+    if len(dim) != 2 or dim[0] * dim[1] != d:
+        raise ValueError("`dim` must match the shape of `rho`.")
 
-    if len(dim) != 2 or np.prod(dim) != rho.shape[0]:
-        raise ValueError("Dimension mismatch: `dim` must be a 1x2 list that correctly partitions `rho`.")
+    lam = np.linalg.eigvalsh(rho)
+    p = min(dim)
 
-    eigvals = np.linalg.eigvalsh(rho)
-    p = int(min(dim))
-    print(f"[DEBUG] Computed p = {p}, type = {type(p)}")
+    if in_separable_ball(np.sort(lam)[::-1]):
+        return True
+    if not is_ppt(rho, sys=2, dim=dim):
+        return False
 
-    if p >= 7:
-        print("[DEBUG] Large dimension detected (p >= 7). Returning -1.")
-        return -1
-
-    if not is_positive_semidefinite(rho):
-        if p >= 6:
-            print("[DEBUG] rho is not PSD but high-dimensional; returning -1 as inconclusive.")
-            return -1
-        print("[DEBUG] rho is not PSD. Returning 0.")
-        return 0
+    lam_sorted = np.sort(lam)[::-1]
+    if np.sum(lam_sorted[: p - 1]) <= 2 * lam_sorted[-1] + np.sum(lam_sorted[-(p - 1) : -1]):
+        return True
 
     try:
-        if is_separable(rho):
-            return 1
-    except ValueError:
-        pass
-
-    if not is_ppt(rho, sys=2, dim=dim):
-        return 0
-
-    if np.sum(eigvals[: p - 1]) <= 2 * eigvals[-1] + np.sum(eigvals[-p + 1 : -1]):
-        return 1
-
-    L = symmetric_extension_hierarchy([rho], level=1, dim=dim)
-    if not is_positive_semidefinite(L[-1]):
-        return 0
-
-    return 1
+        L = symmetric_extension_hierarchy([rho], level=1, dim=dim, max_constraints=max_constraints)
+        if np.any(np.linalg.eigvals(L[-1]) < 0):
+            return False
+        return True if p <= 6 else None
+    except Exception:
+        return None

--- a/toqito/state_props/tests/test_is_abs_ppt.py
+++ b/toqito/state_props/tests/test_is_abs_ppt.py
@@ -8,8 +8,32 @@ from toqito.states import bell, max_mixed
 
 
 @pytest.mark.parametrize(
+    "rho, dim",
+    [
+        # Check for non-square input (invalid density matrix)
+        (np.random.rand(3, 4), [2, 2]),
+        # Zero-trace matrix (invalid)
+        (np.eye(4) - np.eye(4), [2, 2]),
+        # Dimension mismatch
+        (np.eye(4) / 4, [3, 2]),
+        # Slightly off-normalized trace
+        (1.001 * max_mixed(4), [2, 2]),
+        # Matrix with negative eigenvalue
+        ((np.array([[0.6, 0.8], [0.8, -0.2]]) + np.array([[0.6, 0.8], [0.8, -0.2]]).T.conj()) / 2, [1, 2]),
+        # Invalid in high dimension
+        (np.eye(36) / 36 - 0.03 * np.eye(36), [6, 6]),
+    ],
+)
+def test_is_abs_ppt_invalid_inputs(rho, dim):
+    """Test that invalid input raises appropriate errors."""
+    with np.testing.assert_raises(ValueError):
+        is_abs_ppt(rho, dim)
+
+
+@pytest.mark.parametrize(
     "rho, dim, expected_result",
     [
+        # General tests
         (max_mixed(4), [2, 2], True),
         (bell(0) @ bell(0).conj().T, [2, 2], False),
         (np.eye(9) / 9, [3, 3], True),
@@ -19,61 +43,27 @@ from toqito.states import bell, max_mixed
             [2, 2],
             True,
         ),
+        # QETLAB examples
+        (np.eye(25) / 25, [5, 5], True),
+        (np.array([0.22, 0.18, 0.14, 0.12, 0.10, 0.08, 0.06, 0.06, 0.04]), [3, 3], False),
+        (np.array([0.3, 0.2, 0.15, 0.1, 0.08, 0.06, 0.04, 0.04, 0.03]), [3, 3], False),
+        (np.eye(49) / 49, [7, 7], None),
     ],
 )
-def test_is_abs_ppt(rho, dim, expected_result):
-    """Check function with typical states in lower dimensions (p <= 6)."""
+def test_is_abs_ppt_known_values(rho, dim, expected_result):
+    """Test known examples and general functionality for is_abs_ppt."""
     if callable(rho):
         rho = rho()
-    assert is_abs_ppt(rho, dim) == expected_result
+    result = is_abs_ppt(rho, dim)
+    if expected_result is None:
+        assert result in [True, False, None]
+    else:
+        np.testing.assert_equal(result, expected_result)
 
 
 @pytest.mark.parametrize("dim_size", [7, 8, 9])
-def test_is_abs_ppt_sdp(dim_size):
-    """Check high-dimensional (p >= 7) cases that trigger an SDP-based check."""
+def test_is_abs_ppt_high_dimension_indeterminate(dim_size):
+    """Test larger dimensions that should return None or valid result."""
     rho = np.eye(dim_size**2) / (dim_size**2)
     result = is_abs_ppt(rho, [dim_size, dim_size])
-    assert result in [True, False, None], f"Unexpected result for p={dim_size}: {result}"
-
-
-def test_non_square_matrix_raises():
-    """A non-square matrix should raise ValueError about invalid density matrix."""
-    non_square = np.random.rand(3, 4)
-    with pytest.raises(ValueError, match="Input `rho` is not a valid density matrix."):
-        is_abs_ppt(non_square, [2, 2])
-
-
-def test_zero_trace_matrix_raises():
-    """A matrix with zero trace should raise ValueError about invalid density matrix."""
-    zero_trace = np.eye(4) - np.eye(4)
-    with pytest.raises(ValueError, match="Input `rho` is not a valid density matrix."):
-        is_abs_ppt(zero_trace, [2, 2])
-
-
-def test_dimension_mismatch_raises():
-    """Dimension mismatch should raise a ValueError indicating shape mismatch."""
-    rho = np.eye(4) / 4
-    with pytest.raises(ValueError, match="must match the shape of `rho`."):
-        is_abs_ppt(rho, [3, 2])
-
-
-def test_normalization_of_trace_off_by_small_amount():
-    """A matrix whose trace is not ~1 is invalid as a density matrix."""
-    rho = 1.001 * max_mixed(4)
-    with pytest.raises(ValueError, match="Input `rho` is not a valid density matrix."):
-        is_abs_ppt(rho, [2, 2])
-
-
-def test_invalid_density_due_to_negative_eigenvalue():
-    """A Hermitian matrix with negative eigenvalue is invalid as a density matrix."""
-    rho = np.array([[0.6, 0.8], [0.8, -0.2]])
-    rho = (rho + rho.T.conj()) / 2
-    with pytest.raises(ValueError, match="Input `rho` is not a valid density matrix."):
-        is_abs_ppt(rho, [1, 2])
-
-
-def test_inconclusive_result_for_non_psd_in_higher_dim():
-    """For p >= 6 and invalid density, the function raises ValueError."""
-    rho = np.eye(36) / 36 - 0.03 * np.eye(36)
-    with pytest.raises(ValueError, match="Input `rho` is not a valid density matrix."):
-        is_abs_ppt(rho, [6, 6])
+    assert result in [True, False, None]

--- a/toqito/state_props/tests/test_is_abs_ppt.py
+++ b/toqito/state_props/tests/test_is_abs_ppt.py
@@ -10,36 +10,70 @@ from toqito.states import bell, max_mixed
 @pytest.mark.parametrize(
     "rho, dim, expected_result",
     [
-        (max_mixed(4), [2, 2], 1),
-        (bell(0) @ bell(0).conj().T, [2, 2], 0),
-        (np.eye(9) / 9, [3, 3], 1),
-        (np.random.rand(36, 36), [6, 6], -1),
-        (np.array([[0.7, 0.3], [0.3, 0.3]]), [2, 1], 1),
-        (0.99 * max_mixed(4) + 0.01 * np.eye(4), [2, 2], 1),
-        (np.eye(49) / 49, [7, 7], -1),
+        (max_mixed(4), [2, 2], True),
+        (bell(0) @ bell(0).conj().T, [2, 2], False),
+        (np.eye(9) / 9, [3, 3], True),
+        (np.array([[0.7, 0.3], [0.3, 0.3]]), [2, 1], True),
+        (
+            lambda: (0.99 * max_mixed(4) + 0.01 * np.eye(4)) / np.trace(0.99 * max_mixed(4) + 0.01 * np.eye(4)),
+            [2, 2],
+            True,
+        ),
     ],
 )
 def test_is_abs_ppt(rho, dim, expected_result):
-    """Test function works as expected for practical computational cases."""
+    """Check function with typical states in lower dimensions (p <= 6)."""
+    if callable(rho):
+        rho = rho()
     assert is_abs_ppt(rho, dim) == expected_result
 
 
+@pytest.mark.parametrize("dim_size", [7, 8, 9])
+def test_is_abs_ppt_sdp(dim_size):
+    """Check high-dimensional (p >= 7) cases that trigger an SDP-based check."""
+    rho = np.eye(dim_size**2) / (dim_size**2)
+    result = is_abs_ppt(rho, [dim_size, dim_size])
+    assert result in [True, False, None], f"Unexpected result for p={dim_size}: {result}"
+
+
 def test_non_square_matrix_raises():
-    """Test that a non-square matrix raises a ValueError."""
+    """A non-square matrix should raise ValueError about invalid density matrix."""
     non_square = np.random.rand(3, 4)
-    with pytest.raises(ValueError, match="must be square"):
+    with pytest.raises(ValueError, match="Input `rho` is not a valid density matrix."):
         is_abs_ppt(non_square, [2, 2])
 
 
 def test_zero_trace_matrix_raises():
-    """Test that a matrix with zero trace raises a ValueError."""
+    """A matrix with zero trace should raise ValueError about invalid density matrix."""
     zero_trace = np.eye(4) - np.eye(4)
-    with pytest.raises(ValueError, match="zero trace"):
+    with pytest.raises(ValueError, match="Input `rho` is not a valid density matrix."):
         is_abs_ppt(zero_trace, [2, 2])
 
 
 def test_dimension_mismatch_raises():
-    """Test that a dimension mismatch raises a ValueError."""
+    """Dimension mismatch should raise a ValueError indicating shape mismatch."""
     rho = np.eye(4) / 4
-    with pytest.raises(ValueError, match="Dimension mismatch"):
+    with pytest.raises(ValueError, match="must match the shape of `rho`."):
         is_abs_ppt(rho, [3, 2])
+
+
+def test_normalization_of_trace_off_by_small_amount():
+    """A matrix whose trace is not ~1 is invalid as a density matrix."""
+    rho = 1.001 * max_mixed(4)
+    with pytest.raises(ValueError, match="Input `rho` is not a valid density matrix."):
+        is_abs_ppt(rho, [2, 2])
+
+
+def test_invalid_density_due_to_negative_eigenvalue():
+    """A Hermitian matrix with negative eigenvalue is invalid as a density matrix."""
+    rho = np.array([[0.6, 0.8], [0.8, -0.2]])
+    rho = (rho + rho.T.conj()) / 2
+    with pytest.raises(ValueError, match="Input `rho` is not a valid density matrix."):
+        is_abs_ppt(rho, [1, 2])
+
+
+def test_inconclusive_result_for_non_psd_in_higher_dim():
+    """For p >= 6 and invalid density, the function raises ValueError."""
+    rho = np.eye(36) / 36 - 0.03 * np.eye(36)
+    with pytest.raises(ValueError, match="Input `rho` is not a valid density matrix."):
+        is_abs_ppt(rho, [6, 6])

--- a/toqito/state_props/tests/test_is_abs_ppt.py
+++ b/toqito/state_props/tests/test_is_abs_ppt.py
@@ -1,0 +1,45 @@
+"""Test cases for the `is_abs_ppt` function."""
+
+import numpy as np
+import pytest
+
+from toqito.state_props.is_abs_ppt import is_abs_ppt
+from toqito.states import bell, max_mixed
+
+
+@pytest.mark.parametrize(
+    "rho, dim, expected_result",
+    [
+        (max_mixed(4), [2, 2], 1),
+        (bell(0) @ bell(0).conj().T, [2, 2], 0),
+        (np.eye(9) / 9, [3, 3], 1),
+        (np.random.rand(36, 36), [6, 6], -1),
+        (np.array([[0.7, 0.3], [0.3, 0.3]]), [2, 1], 1),
+        (0.99 * max_mixed(4) + 0.01 * np.eye(4), [2, 2], 1),
+        (np.eye(49) / 49, [7, 7], -1),
+    ],
+)
+def test_is_abs_ppt(rho, dim, expected_result):
+    """Test function works as expected for practical computational cases."""
+    assert is_abs_ppt(rho, dim) == expected_result
+
+
+def test_non_square_matrix_raises():
+    """Test that a non-square matrix raises a ValueError."""
+    non_square = np.random.rand(3, 4)
+    with pytest.raises(ValueError, match="must be square"):
+        is_abs_ppt(non_square, [2, 2])
+
+
+def test_zero_trace_matrix_raises():
+    """Test that a matrix with zero trace raises a ValueError."""
+    zero_trace = np.eye(4) - np.eye(4)
+    with pytest.raises(ValueError, match="zero trace"):
+        is_abs_ppt(zero_trace, [2, 2])
+
+
+def test_dimension_mismatch_raises():
+    """Test that a dimension mismatch raises a ValueError."""
+    rho = np.eye(4) / 4
+    with pytest.raises(ValueError, match="Dimension mismatch"):
+        is_abs_ppt(rho, [3, 2])


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->
This PR adds the is_abs_ppt function to check whether a quantum state is absolutely PPT (Positive Partial Transpose). It also includes unit tests to verify correctness.

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->
  -  Implemented is_abs_ppt function in toqito/state_props/is_abs_ppt.py.
  -  Added unit tests in toqito/state_props/tests/test_is_abs_ppt.py.
  -  Integrated function into toqito/state_props/__init__.py for module accessibility.
  -  Ensured compliance with ruff for code style and black for formatting.
  -  Referenced QETLAB's MATLAB implementation in the docstring.

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
