### PR TITLE
Removing explicit cvxopt dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2074,4 +2074,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "aac40aed0724e6362c33fef8ada363e29a8157a1871b6b3ec7597b1df9e3d701"
+content-hash = "84ea50d71cbfe64b24f670098a2c277925d2dc32250a07cb803af43cc13705a5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ keywords = ["quantum information", "quantum computing", "nonlocal games"]
 [tool.poetry.dependencies]
 python = ">=3.10,<4"
 cvxpy = "1.6.2"
-cvxopt = "1.3.2"
 more-itertools = "10.6.0"
 numpy = "2.2.3"
 scipy = "1.15.2"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ with open("README.md", "r") as fh:
 requirements = [
     "cvx",
     "cvxpy",
-    "cvxopt",
     "more-itertools",
     "numpy",
     "picos",

--- a/toqito/channel_metrics/channel_fidelity.py
+++ b/toqito/channel_metrics/channel_fidelity.py
@@ -97,4 +97,4 @@ def channel_fidelity(choi_1: np.ndarray, choi_2: np.ndarray) -> float:
 
     problem = cvxpy.Problem(objective, constraints)
 
-    return problem.solve(solver="CVXOPT")
+    return problem.solve(solver="SCS")


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->
Fixes #1040 

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [x] Removed explicit installation of cvxopt from `setup.py`, `pyproject.toml`
  -  [x] Added the usage of `solver = SCS` instead of `solver=CVXOPT` for a `problem` method defined in `cvxpy` in file `toqito/channel_metrics/channel_fidelity.py`

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
