### PR TITLE
fix: `random_unitary` doesn't sample from the Haar distribution

### DIFF
--- a/toqito/rand/random_density_matrix.py
+++ b/toqito/rand/random_density_matrix.py
@@ -34,8 +34,8 @@ def random_density_matrix(
     >>> from toqito.rand import random_density_matrix
     >>> complex_dm = random_density_matrix(2)
     >>> complex_dm # doctest: +SKIP
-    array([[0.83378447+0.j        , 0.25937396-0.12958422j],
-           [0.25937396+0.12958422j, 0.16621553+0.j        ]])
+    array([[ 0.53822849+0.j        , -0.26155866+0.02081311j],
+           [-0.26155866-0.02081311j,  0.46177151+0.j        ]])
 
     We can verify that this is in fact a valid density matrix using the :code:`is_denisty` function from :code:`toqito`
     as follows
@@ -49,8 +49,8 @@ def random_density_matrix(
     >>> from toqito.rand import random_density_matrix
     >>> real_dm = random_density_matrix(2, is_real=True)
     >>> real_dm # doctest: +SKIP
-    array([[0.3686455 , 0.48243625],
-           [0.48243625, 0.6313545 ]])
+    array([[0.47783773, 0.45763467],
+           [0.45763467, 0.52216227]])
 
 
     Again, verifying that this is a valid density matrix can be done as follows.
@@ -65,8 +65,8 @@ def random_density_matrix(
     >>> from toqito.rand import random_density_matrix
     >>> bures_mat = random_density_matrix(2, distance_metric="bures")
     >>> bures_mat # doctest: +SKIP
-    array([[0.73969055+0.j        , 0.09494426-0.15279342j],
-           [0.09494426+0.15279342j, 0.26030945+0.j        ]])
+    array([[ 0.41427711+0.j       , -0.15503543+0.2405496j],
+           [-0.15503543-0.2405496j,  0.58572289+0.j       ]])
 
 
     As before, we can verify that this matrix generated is a valid density matrix.

--- a/toqito/rand/random_orthonormal_basis.py
+++ b/toqito/rand/random_orthonormal_basis.py
@@ -16,16 +16,16 @@ def random_orthonormal_basis(dim: int, is_real: bool = False, seed: int | None =
 
     >>> from toqito.rand import random_orthonormal_basis
     >>> random_orthonormal_basis(4, is_real = True) # doctest: +SKIP
-    [array([0.52188745, 0.4983613 , 0.69049811, 0.04981832]),
-    array([-0.48670459,  0.58756912, -0.10226756,  0.63829658]),
-    array([ 0.23965404, -0.58538248,  0.187136  ,  0.75158061]),
-    array([ 0.658269  ,  0.25243989, -0.69118291,  0.158815  ])]
+    [array([ 0.18609797,  0.12416167,  0.28230062, -0.93287608]),
+    array([-0.48238484,  0.72089168,  0.4763625 ,  0.14387088]),
+    array([-0.66230111,  0.06548609, -0.6711639 , -0.32650855]),
+    array([ 0.54224502,  0.67868302, -0.49287336,  0.04935131])]
 
     It is also possible to add a seed for reproducibility.
 
     >>> from toqito.rand import random_orthonormal_basis
     >>> random_orthonormal_basis(2, is_real=True, seed=42)
-    [array([0.66954664, 0.74277002]), array([-0.74277002,  0.66954664])]
+    [array([0.37621414, 0.92653274]), array([-0.92653274,  0.37621414])]
 
 
     References

--- a/toqito/rand/random_unitary.py
+++ b/toqito/rand/random_unitary.py
@@ -102,7 +102,7 @@ def random_unitary(
         raise ValueError("Unitary matrix must be square.")
 
     # Construct the Ginibre ensemble.
-    gin = gen.random((dim[0], dim[1]))
+    gin = gen.standard_normal((dim[0], dim[1]))
 
     if not is_real:
         gin = gin + 1j * gen.standard_normal((dim[0], dim[1]))

--- a/toqito/rand/random_unitary.py
+++ b/toqito/rand/random_unitary.py
@@ -71,8 +71,8 @@ def random_unitary(
     >>> from toqito.matrix_props import is_unitary
     >>> seeded = random_unitary(2, seed=42)
     >>> seeded
-    array([[0.14398279-0.92188954j, -0.05864249+0.35489392j],
-           [0.35459797+0.06040626j,  0.91839541+0.16480666j]])
+    array([[ 0.14398279-0.92188954j, -0.05864249+0.35489392j],
+           [ 0.35459797+0.06040626j,  0.91839541+0.16480666j]])
 
     And once again, we can verify that this matrix generated is a valid unitary matrix.
 

--- a/toqito/rand/random_unitary.py
+++ b/toqito/rand/random_unitary.py
@@ -22,8 +22,8 @@ def random_unitary(
     >>> from toqito.rand import random_unitary
     >>> complex_dm = random_unitary(2)
     >>> complex_dm # doctest: +SKIP
-    array([[ 0.13764463+0.65538975j,  0.74246453+0.01626838j],
-           [ 0.45776527+0.58478132j, -0.6072508 +0.28236187j]])
+    array([[-0.59597046+0.06963662j,  0.68835876+0.40759314j],
+           [ 0.55431572+0.57680503j,  0.06860805+0.59608975j]])
 
 
     We can verify that this is in fact a valid unitary matrix using the :code:`is_unitary` function
@@ -38,8 +38,8 @@ def random_unitary(
     >>> from toqito.rand import random_unitary
     >>> real_dm = random_unitary(2, True)
     >>> real_dm # doctest: +SKIP
-    array([[ 0.87766506, -0.47927449],
-           [ 0.47927449,  0.87766506]])
+    array([[ 0.99999631, -0.00271622],
+           [-0.00271622, -0.99999631]])
 
 
     Again, verifying that this is a valid unitary matrix can be done as follows.
@@ -54,10 +54,10 @@ def random_unitary(
     >>> from toqito.rand import random_unitary
     >>> mat = random_unitary([4, 4], True)
     >>> mat # doctest: +SKIP
-    array([[ 0.49527332,  0.08749933, -0.16968586,  0.84749922],
-           [ 0.68834418, -0.26695275,  0.62674543, -0.24921614],
-           [ 0.38614979, -0.438767  , -0.7417619 , -0.32887862],
-           [ 0.36300822,  0.85355938, -0.16788735, -0.33387909]])
+    array([[ 0.08457995,  0.02911453, -0.98921738,  0.11596361],
+           [ 0.77315815, -0.49113837,  0.00461571, -0.40123343],
+           [-0.50492423, -0.85772782, -0.05947552,  0.0762704 ],
+           [-0.3743317 ,  0.14912557, -0.13375477, -0.90539881]])
 
 
     As before, we can verify that this matrix generated is a valid unitary matrix.
@@ -71,8 +71,8 @@ def random_unitary(
     >>> from toqito.matrix_props import is_unitary
     >>> seeded = random_unitary(2, seed=42)
     >>> seeded
-    array([[0.34074554-0.85897194j, 0.32146645+0.20668575j],
-           [0.37801036+0.05628362j, 0.30953006-0.87070745j]])
+    array([[0.14398279-0.92188954j, -0.05864249+0.35489392j],
+           [0.35459797+0.06040626j,  0.91839541+0.16480666j]])
 
     And once again, we can verify that this matrix generated is a valid unitary matrix.
 

--- a/toqito/rand/tests/test_random_density_matrix.py
+++ b/toqito/rand/tests/test_random_density_matrix.py
@@ -60,8 +60,8 @@ def test_random_density_matrix(dim, is_real, distance_metric):
             None,
             "haar",
             np.array([
-                [0.67842043+0.j, -0.04636114+0.29398703j],
-                [-0.04636114-0.29398703j, 0.32157957+0.j]
+                [0.37758384+0.j, 0.19597419+0.19965911j],
+                [0.19597419-0.19965911j, 0.62241616+0.j]
             ])
         ),
         # Generate random real density matrix.
@@ -71,8 +71,8 @@ def test_random_density_matrix(dim, is_real, distance_metric):
             None,
             "haar",
             np.array([
-                [0.85019307, 0.29087271],
-                [0.29087271, 0.14980693]
+                [0.45158815, 0.49355259],
+                [0.49355259, 0.54841185]
             ])
         ),
         # Random non-real density matrix according to Bures metric.
@@ -82,8 +82,9 @@ def test_random_density_matrix(dim, is_real, distance_metric):
             None,
             "bures",
             np.array([
-                [0.60005221+0.j, -0.00344727+0.16976473j],
-                [-0.00344727-0.16976473j, 0.39994779+0.j]
+                [ 0.31466466+0.j, -0.09170064+0.24517065j],
+                [-0.09170064-0.24517065j,  0.68533534+0.j]
+                
             ])
         ),
         # Generate random non-real density matrix all params.
@@ -93,8 +94,8 @@ def test_random_density_matrix(dim, is_real, distance_metric):
             2,
             "haar",
             np.array([
-                [0.85019307, 0.29087271],
-                [0.29087271, 0.14980693]
+                [0.45158815, 0.49355259],
+                [0.49355259, 0.54841185]
             ])
         ),
     ],
@@ -106,6 +107,6 @@ def test_seed(dim, is_real, k_param, distance_metric, expected):
         is_real,
         k_param=k_param,
         distance_metric=distance_metric,
-        seed=123
+        seed=124
     )
     assert_array_almost_equal(dm, expected)

--- a/toqito/rand/tests/test_random_density_matrix.py
+++ b/toqito/rand/tests/test_random_density_matrix.py
@@ -84,7 +84,7 @@ def test_random_density_matrix(dim, is_real, distance_metric):
             np.array([
                 [ 0.31466466+0.j, -0.09170064+0.24517065j],
                 [-0.09170064-0.24517065j,  0.68533534+0.j]
-                
+
             ])
         ),
         # Generate random non-real density matrix all params.

--- a/toqito/rand/tests/test_random_orthonormal_basis.py
+++ b/toqito/rand/tests/test_random_orthonormal_basis.py
@@ -26,8 +26,8 @@ def test_random_orth_basis_int_dim(input_dim, bool):
                 np.array([-0.172472+0.465563j, -0.637147-0.589532j]),
                 np.array([-0.857827+0.132805j, -0.117157+0.482462j])
             ]
-            
- 
+
+
         ),
 (
             2,

--- a/toqito/rand/tests/test_random_orthonormal_basis.py
+++ b/toqito/rand/tests/test_random_orthonormal_basis.py
@@ -23,21 +23,24 @@ def test_random_orth_basis_int_dim(input_dim, bool):
             2,
             False,
             [
-                np.array([0.51345691+0.6924564j, 0.16581665-0.47892689j]),
-                np.array([0.38709015+0.32715034j, -0.08796944+0.85755189j])
+                np.array([-0.172472+0.465563j, -0.637147-0.589532j]),
+                np.array([-0.857827+0.132805j, -0.117157+0.482462j])
             ]
+            
+ 
         ),
 (
             2,
             True,
             [
-                np.array([0.95160818, 0.30731397]),
-                np.array([-0.30731397, 0.95160818])
+                np.array([-0.26129, -0.96526]),
+                np.array([-0.96526,  0.26129])
             ]
+
         ),
     ]
 )
 def test_seed(dim, is_real, expected):
     """Test that the function returns the expected output when seeded."""
-    basis = random_orthonormal_basis(dim, is_real, seed=123)
+    basis = random_orthonormal_basis(dim, is_real, seed=124)
     assert_array_almost_equal(basis, expected)

--- a/toqito/rand/tests/test_random_unitary.py
+++ b/toqito/rand/tests/test_random_unitary.py
@@ -41,21 +41,21 @@ def test_non_square_dims(dim_n, dim_m, is_real):
             2,
             False,
             np.array([
-                [0.51345691+0.6924564j, 0.38709015+0.32715034j],
-                [0.16581665-0.47892689j, -0.08796944+0.85755189j]
+                [-0.17247218+0.46556261j, -0.85782721+0.13280541j],
+                [-0.63714743-0.58953198j, -0.1171568 +0.48246189j]
             ])
         ),
         (
             2,
             True,
             np.array([
-                [0.95160818, -0.30731397],
-                [0.30731397,  0.95160818]
+                [-0.26129, -0.96526],
+                [-0.96526,  0.26129]
             ])
         ),
     ]
 )
 def test_seed(dim, is_real, expected):
     """Test that the function returns the expected output when seeded."""
-    mat = random_unitary(dim=dim, is_real=is_real, seed=123)
+    mat = random_unitary(dim=dim, is_real=is_real, seed=124)
     assert_array_almost_equal(mat, expected)


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->
Fixes #1031 

This bug was noticed, and a probable solution was put forward by @tnemoz; thanks!

The bug was related to the `rand` module not producing the unitary/orthogonal matrix according to the Harr distribution.

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [x] Fixed the bug by changing `random distribution` with a 'standard distribution` causing the issue in `rand/random_unitary.py`
  -  [x] Updated the `test` files  `test_random_density_matrix.py`, `test_random_orthonormal_basis.py` and `test_random_unitary.py`

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
