### PR TITLE
fix:pyproject.toml lint for unused imports removal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,22 +50,23 @@ requires = ["setuptools","poetry>=0.12"]
 build-backend = "poetry.masonry.api"
 
 [tool.ruff]
-# exclude = ["__init__.py"]
+exclude = ["__init__.py"]
 line-length = 120
-target-version = "py311"
+target-version = "py312"
 
 [tool.ruff.lint]
-select = ["I", "E", "W", "D", "PL"]
+select = ["I", "E", "W", "D", "PL", "F"]
 # ruff configuration
 # E, W -- pycodestyle
 # D -- pydocstyle
 # I -- isort
 # PL -- pylint
+# F -- pyflakes
 
 # Rules considered over other incompatible ones
 exclude = ["docs/conf.py", "setup.py"]
 
-ignore = ["D407", "D203", "D213", "D416", "PLR0912", "PLR0911", "PLR0915", "PLR2004", "PLR0913"]
+ignore = ["D407", "D203", "D213", "D416", "PLR0912", "PLR0911", "PLR0915", "PLR2004", "PLR0913", "F811"]
 # Rules Ignored
 
 # D407 - Ignored because ==== under a section heading is considered as a missing underline.
@@ -85,5 +86,5 @@ ignore = ["D407", "D203", "D213", "D416", "PLR0912", "PLR0911", "PLR0915", "PLR2
 # PLR0913 Too many arguments in function definition
 
 [tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["I001"]
+"__init__.py" = ["I001", "F401"]
 # I001 - skip checking Import block is un-sorted or un-formatted

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,4 @@ ignore = ["D407", "D203", "D213", "D416", "PLR0912", "PLR0911", "PLR0915", "PLR2
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["I001", "F401"]
 # I001 - skip checking Import block is un-sorted or un-formatted
+# F401 - Checks for unused imports, applying fixes to __init__.py currently under review

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,8 @@ ignore = ["D407", "D203", "D213", "D416", "PLR0912", "PLR0911", "PLR0915", "PLR2
 # PLR0915 -- Checks for functions or methods with too many statements. The default number is 50. 
 # PLR2004 -- Checks if an equality or an inequality is compared to a variable or a num (prefers variable pre)
 # PLR0913 Too many arguments in function definition
+# F811 -- Checks for variable definitions that redefine (or "shadow") unused variables 
+# It was removing definitions with the same name creating conflicts in
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["I001", "F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ ignore = ["D407", "D203", "D213", "D416", "PLR0912", "PLR0911", "PLR0915", "PLR2
 # PLR2004 -- Checks if an equality or an inequality is compared to a variable or a num (prefers variable pre)
 # PLR0913 Too many arguments in function definition
 # F811 -- Checks for variable definitions that redefine (or "shadow") unused variables 
-# It was removing definitions with the same name creating conflicts in
+# It was removing definitions with the same name creating conflicts in test_is_stochastic.py
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["I001", "F401"]

--- a/toqito/matrix_props/is_positive_definite.py
+++ b/toqito/matrix_props/is_positive_definite.py
@@ -2,8 +2,6 @@
 
 import numpy as np
 
-from toqito.matrix_props import is_hermitian
-
 
 def is_positive_definite(mat: np.ndarray) -> bool:
     r"""Check if matrix is positive definite (PD) :cite:`WikiPosDef`.

--- a/toqito/matrix_props/tests/test_is_block_positive.py
+++ b/toqito/matrix_props/tests/test_is_block_positive.py
@@ -1,6 +1,5 @@
 """Test is_block_positive."""
 
-from unittest.mock import patch
 
 import numpy as np
 import pytest

--- a/toqito/matrix_props/tests/test_is_positive.py
+++ b/toqito/matrix_props/tests/test_is_positive.py
@@ -1,7 +1,6 @@
 """Tests for nonnegative matrix check function."""
 
 import numpy as np
-import pytest
 
 from toqito.matrix_props import is_positive
 

--- a/toqito/matrix_props/tests/test_is_stochastic.py
+++ b/toqito/matrix_props/tests/test_is_stochastic.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from toqito.matrices import cyclic_permutation_matrix, pauli
-from toqito.matrix_props import is_nonnegative, is_square, is_stochastic
+from toqito.matrix_props import is_stochastic
 
 
 @pytest.mark.parametrize("test_input", [(np.identity(3)), (cyclic_permutation_matrix(4)), (pauli("X"))])

--- a/toqito/state_opt/state_distinguishability.py
+++ b/toqito/state_opt/state_distinguishability.py
@@ -238,7 +238,7 @@ def _unambiguous_dual(
     problem = picos.Problem()
 
     gram = vectors_to_gram_matrix(vectors)
-    lagrangian_variable_big_z = picos.SymmetricVariable(f"Z", (n, n))
+    lagrangian_variable_big_z = picos.SymmetricVariable("Z", (n, n))
 
     problem.add_constraint(lagrangian_variable_big_z >> 0)
     problem.add_list_of_constraints(lagrangian_variable_big_z[i, i] >= probs[i] for i in range(n))

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -3,7 +3,7 @@
 import numpy as np
 import picos
 
-from toqito.matrix_ops import calculate_vector_matrix_dimension, to_density_matrix, vectors_to_gram_matrix
+from toqito.matrix_ops import calculate_vector_matrix_dimension, to_density_matrix
 from toqito.matrix_props import has_same_dimension
 
 


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->
Fixes #1045 

After facing some version control issues in the previous (almost the same) PR #1046, the following pr was created.

The issue was:
`ruff lint` was not removing unused imports due to not selecting "F401" for `tool.ruff.lint` in the `pyproject.toml` file

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [x] Fixed `pyproject.toml`
  -  [x] Removed unused imports from `matrix_props/is_positive_definite.py`
  -  [x] Removed unused imports from  `matrix_props/tests/test_is_block_positive.py`
  -  [x] Removed unused imports from  `matrix_props/tests/test_is_positive.py`
  -  [x] Removed unused imports from  `matrix_props/tests/test_is_stochastic.py`
  -  [x] Removed unused imports from  `state_opt/state_exclusion.py`
  
Further changes:  
  -  [x] Removed unused imports from `state_opt/state_distinguishability.py`
  -  [x] Changed `ruff target version` to `python=3.12`
  -  [x] ruff now exclude `__init__.py`
  -  [x] ignored `"F811"` 







## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
