### PR TITLE
Added a white bg to all the images

### DIFF
--- a/docs/figures/alice_and_bob.svg
+++ b/docs/figures/alice_and_bob.svg
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="114.183pt" height="29.143pt" viewBox="0 0 114.183 29.143" version="1.1">
+<rect width="100%" height="100%" fill="white" />
+
 <defs>
 <g>
 <symbol overflow="visible" id="glyph0-0">

--- a/docs/figures/extended_nonlocal_game.svg
+++ b/docs/figures/extended_nonlocal_game.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="270.786pt" height="171.258pt" viewBox="0 0 270.786 171.258" version="1.1">
+<rect width="100%" height="100%" fill="white" />
 <defs>
 <g>
 <symbol overflow="visible" id="glyph0-0">

--- a/docs/figures/nonlocal_game.svg
+++ b/docs/figures/nonlocal_game.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="212.675pt" height="142.529pt" viewBox="0 0 212.675 142.529" version="1.1">
+<rect width="100%" height="100%" fill="white" />
 <defs>
 <g>
 <symbol overflow="visible" id="glyph0-0">

--- a/docs/figures/nonlocal_game_quantum_strategy.svg
+++ b/docs/figures/nonlocal_game_quantum_strategy.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="270.786pt" height="154.25pt" viewBox="0 0 270.786 154.25" version="1.1">
+<rect width="100%" height="100%" fill="white" />
 <defs>
 <g>
 <symbol overflow="visible" id="glyph0-0">

--- a/docs/figures/quantum_state_distinguish.svg
+++ b/docs/figures/quantum_state_distinguish.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="411.82pt" height="227.569pt" viewBox="0 0 411.82 227.569" version="1.1">
+<rect width="100%" height="100%" fill="white" />
 <defs>
 <g>
 <symbol overflow="visible" id="glyph0-0">


### PR DESCRIPTION
## Description
It was difficult to see all the images correctly in the dark mode as the black components of it were not visible.
![image](https://github.com/user-attachments/assets/97a9f4e7-ffe8-4582-a6c9-bde360526f08)
![image](https://github.com/user-attachments/assets/6a53e0a4-c6c4-4185-8f09-58eaccbb44f1)


## Changes
The background of the images have been changed into a white color so that they're easily and correctly visible even in dark mode.
