### PR TITLE
Inverted the colors of the Images of documentation for better visibility when used in the dark mode.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,14 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinxcontrib.bibtex",
     "sphinx_copybutton",
+    "sphinx-image-inverter",
 ]
+
+#Sphinx image inverter has been defined here to 
+#Invert the colors when reading into dark mode
+sphinx_image_inverter = {
+    'inverter_all': True,  #All images are being inverted
+}
 
 bibtex_bibfiles = ["refs.bib"]
 bibtex_default_style = "unsrt"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@ sphinxcontrib-bibtex == 2.6.3
 sympy == 1.13.3
 sphinx-autoapi == 3.5.0
 sphinx-copybutton == 0.5.2
-
+sphinx-image-inverter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,21 @@ sphinx-copybutton = "0.5.2"
 [build-system]
 requires = ["setuptools","poetry>=0.12"]
 build-backend = "poetry.masonry.api"
+requires = ["sphinx", "sphinx-image-inverter"]
+build-backend = "setuptools.build_meta"
+
+[tool.sphinx]
+extensions = [
+    "sphinx_image_inverter"
+]
+
+[sphinx]
+extra_extensions = [
+    "sphinx_image_inverter"
+]
+
+[sphinx_image_inverter]
+inverter_all = true
 
 [tool.ruff]
 exclude = ["__init__.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,6 @@ extensions = [
     "sphinx_image_inverter"
 ]
 
-[sphinx]
-extra_extensions = [
-    "sphinx_image_inverter"
-]
-
 [sphinx_image_inverter]
 inverter_all = true
 


### PR DESCRIPTION
## Description
The purpose of this PR is in response to the issue #1064 Add a white background to the examples in the documentation.

## Changes
Sphinx-Image-converter was used in this repository to invert the colors of the images (from black to white whilst the other hue changes are mostly unnoticeable.) for better visibility in the dark mode.

Change 1: Added the Sphinx-Image-Inverter package into the pyproject.toml file.

Change 2: Added the Sphinx-Image-Inverter dependency into the docs/requirements.txt file.

Change 3: Enabled the Sphinx-Image-Inverter function in the docs/config.py file.