### PR TITLE
Update docstrings in matrix_ops/vec.py 

### DIFF
--- a/toqito/channel_props/__init__.py
+++ b/toqito/channel_props/__init__.py
@@ -8,3 +8,4 @@ from toqito.channel_props.choi_rank import choi_rank
 from toqito.channel_props.is_trace_preserving import is_trace_preserving
 from toqito.channel_props.is_quantum_channel import is_quantum_channel
 from toqito.channel_props.is_unitary import is_unitary
+from toqito.channel_props.is_extremal import is_extremal

--- a/toqito/channel_props/is_extremal.py
+++ b/toqito/channel_props/is_extremal.py
@@ -6,59 +6,59 @@ from numpy.linalg import matrix_rank
 from toqito.channel_ops.choi_to_kraus import choi_to_kraus
 
 
-def is_extremal(channel):
-    r"""Determine whether a quantum channel is extremal.
+def is_extremal(phi: np.ndarray | list[np.ndarray | list[np.ndarray]], tol: float = 1e-9) -> bool:
+    """Determine whether a quantum channel is extremal.
 
-    A channel with Kraus operators :math:`\{A_i\}_{i=1}^{r}` is **extremal** if and only if
-    the set :math:`\{A_i^\dagger A_j : i,j=1,\dots,r\}` is linearly independent.
+    A channel with Kraus operators {A_i} is extremal if and only if
+    the set {A_i^† A_j : i,j=1,...,r} is linearly independent.
 
-    For more details, see Section 2.2.4 of :cite:`Watrous_2018_TQI`.
+    The channel can be provided as either:
+      - A Choi matrix (np.ndarray), which is converted to a flat list of Kraus operators.
+      - A flat list of Kraus operators ([np.ndarray, ...]).
+      - A nested list of Kraus operators ([[np.ndarray, ...], ...]), in which case the
+        list is flattened.
 
-    :param channel: The quantum channel representation, which can be:
-        - A list of Kraus operators,
-        - A Choi matrix,
-        - A dictionary with ``'kraus'`` or ``'choi'`` key,
-        - An object with a callable ``kraus()`` method.
-    :type channel: list[numpy.ndarray] | numpy.ndarray | dict
-    :raises ValueError: If no Kraus operators can be extracted.
-    :return: ``True`` if the channel is extremal; ``False`` otherwise.
+    :param phi: The quantum channel, either a list (possibly nested) of Kraus operators or a Choi matrix.
+    :type phi: list[numpy.ndarray] | list[list[numpy.ndarray]] | numpy.ndarray
+    :raises ValueError: If the input is neither a valid list of Kraus operators nor a Choi matrix.
+    :return: True if the channel is extremal; False otherwise.
     :rtype: bool
     """
-    # Convert the input into a list of Kraus operators
-    if isinstance(channel, list):
-        kraus_ops = channel
-    elif isinstance(channel, np.ndarray):
-        kraus_ops = choi_to_kraus(channel)
-    elif isinstance(channel, dict):
-        if "kraus" in channel:
-            kraus_ops = channel["kraus"]
-        elif "choi" in channel:
-            kraus_ops = choi_to_kraus(channel["choi"])
+    # If input is a Choi matrix, convert to a (flat) list of Kraus operators.
+    if isinstance(phi, np.ndarray):
+        kraus_ops = choi_to_kraus(phi)
+    elif isinstance(phi, list):
+        # If the first element is a list, assume nested list of Kraus operators.
+        if len(phi) == 0:
+            raise ValueError("The channel must contain at least one Kraus operator.")
+        if isinstance(phi[0], list):
+            # Flatten the nested list
+            kraus_ops = [op for sublist in phi for op in sublist if isinstance(op, np.ndarray)]
+        elif all(isinstance(op, np.ndarray) for op in phi):
+            kraus_ops = phi
         else:
-            raise ValueError("Dictionary must have a 'kraus' or 'choi' key.")
-    elif hasattr(channel, "kraus") and callable(channel.kraus):
-        kraus_ops = channel.kraus()
+            raise ValueError("Channel must be a list (or nested list) of Kraus operators.")
     else:
-        raise ValueError("Unsupported channel format. Provide Kraus operators, a Choi matrix, or a dictionary.")
+        raise ValueError("Channel must be a list of Kraus operators or a Choi matrix.")
 
-    if not kraus_ops or len(kraus_ops) == 0:
+    # Check that we have at least one Kraus operator.
+    if not kraus_ops:
         raise ValueError("The channel must contain at least one Kraus operator.")
-
-    # If nested lists (non-completely positive maps), extract the first set of Kraus operators
-    if isinstance(kraus_ops[0], list):
-        kraus_ops = [op[0] for op in kraus_ops]
 
     r = len(kraus_ops)
 
-    # A single Kraus operator (e.g., unitary channel) is always extremal.
+    # A single Kraus operator (e.g., a unitary channel) is always extremal.
     if r == 1:
         return True
 
-    # Compute the set {A_i^† A_j}
-    flattened_products = [np.dot(A.conj().T, B).flatten() for A in kraus_ops for B in kraus_ops]
+    # Compute the set {A_i^† A_j} for every pair (i, j).
+    flattened_products = [
+        np.dot(A.conj().T, B).flatten() for A in kraus_ops for B in kraus_ops
+    ]
 
     # Form a matrix whose columns are these vectorized operators.
     M = np.column_stack(flattened_products)
 
-    # The channel is extremal if and only if the operators {A_i^† A_j} are linearly independent.
-    return matrix_rank(M) == r * r
+    # The channel is extremal if and only if the operators {A_i^† A_j} are linearly independent,
+    # i.e. the rank of M equals r^2.
+    return matrix_rank(M, tol=tol) == r * r

--- a/toqito/channel_props/is_extremal.py
+++ b/toqito/channel_props/is_extremal.py
@@ -7,22 +7,52 @@ from toqito.channel_ops.choi_to_kraus import choi_to_kraus
 
 
 def is_extremal(phi: np.ndarray | list[np.ndarray | list[np.ndarray]], tol: float = 1e-9) -> bool:
-    """Determine whether a quantum channel is extremal.
+    r"""Determine whether a quantum channel is extremal.
 
-    A channel with Kraus operators {A_i} is extremal if and only if
-    the set {A_i^† A_j : i,j=1,...,r} is linearly independent.
+    (Section 2.2.4: Extremal Channels from :cite:`Watrous_2018_TQI`).
 
-    The channel can be provided as either:
-      - A Choi matrix (np.ndarray), which is converted to a flat list of Kraus operators.
-      - A flat list of Kraus operators ([np.ndarray, ...]).
-      - A nested list of Kraus operators ([[np.ndarray, ...], ...]), in which case the
-        list is flattened.
+    Theorem 2.31 in :cite:`Watrous_2018_TQI` provides the characterization of extremal
+    quantum channels: A channel :math:`\Phi` is an extreme point of the convex set
+    of quantum channels if and only if the collection:
 
-    :param phi: The quantum channel, either a list (possibly nested) of Kraus operators or a Choi matrix.
+    .. math::
+        \{ A_i^\dagger A_j \}_{i,j=1}^{r}
+
+    is linearly independent.
+
+    The channel can be provided in one of the following representations:
+
+    - A Choi matrix, representing the quantum channel in the Choi representation. It will
+      be converted internally to a set of Kraus operators.
+    - A list of Kraus operators, representing the channel in Kraus form.
+    - A nested list of Kraus operators, which will be flattened automatically.
+
+    Examples
+    ==========
+
+    The following demonstrates an example of an extremal quantum channel from Example 2.33
+    in :cite:`Watrous_2018_TQI`.
+
+    >>> import numpy as np
+    >>> from toqito.channel_props import is_extremal
+    >>> kraus_ops = [
+    ...     (1 / np.sqrt(6)) * np.array([[2, 0], [0, 1], [0, 1], [0, 0]]),
+    ...     (1 / np.sqrt(6)) * np.array([[0, 0], [1, 0], [1, 0], [0, 2]])
+    ... ]
+    >>> is_extremal(kraus_ops)
+    True
+
+    References
+    ==========
+    .. bibliography::
+        :filter: docname in docnames
+
+    :param phi: The quantum channel, which may be given as a Choi matrix or a list of Kraus operators.
+    :param tol: Tolerance value for numerical precision in rank computation.
     :type phi: list[numpy.ndarray] | list[list[numpy.ndarray]] | numpy.ndarray
     :raises ValueError: If the input is neither a valid list of Kraus operators nor a Choi matrix.
     :return: True if the channel is extremal; False otherwise.
-    :rtype: bool
+
     """
     # If input is a Choi matrix, convert to a (flat) list of Kraus operators.
     if isinstance(phi, np.ndarray):
@@ -32,7 +62,7 @@ def is_extremal(phi: np.ndarray | list[np.ndarray | list[np.ndarray]], tol: floa
         if len(phi) == 0:
             raise ValueError("The channel must contain at least one Kraus operator.")
         if isinstance(phi[0], list):
-            # Flatten the nested list
+            # Flatten the nested list.
             kraus_ops = [op for sublist in phi for op in sublist if isinstance(op, np.ndarray)]
         elif all(isinstance(op, np.ndarray) for op in phi):
             kraus_ops = phi

--- a/toqito/channel_props/is_extremal.py
+++ b/toqito/channel_props/is_extremal.py
@@ -1,0 +1,96 @@
+"""Module for checking whether a quantum channel is extremal."""
+
+import numpy as np
+from numpy.linalg import matrix_rank
+
+from toqito.channel_ops.choi_to_kraus import choi_to_kraus
+
+
+def _convert_to_kraus(channel):
+    r"""Convert a quantum channel into its Kraus representation.
+
+    The input channel can be provided as:
+      - A list of Kraus operators (each a numpy.ndarray),
+      - A Choi matrix (numpy.ndarray),
+      - A dictionary with a 'kraus' or 'choi' key,
+      - An object with a callable kraus() method.
+
+    Parameters
+    ----------
+    channel : list, numpy.ndarray, or dict
+        The quantum channel representation.
+
+    Returns
+    -------
+    list
+        A list of numpy.ndarray objects representing the Kraus operators.
+
+    Raises
+    ------
+    ValueError
+        If the channel input type is not supported.
+
+    """
+    if isinstance(channel, list):
+        return channel
+    if isinstance(channel, np.ndarray):
+        return choi_to_kraus(channel)
+    if isinstance(channel, dict):
+        if "kraus" in channel:
+            return channel["kraus"]
+        if "choi" in channel:
+            return choi_to_kraus(channel["choi"])
+        raise ValueError("Dictionary channel representation must have either 'kraus' or 'choi' key.")
+    if hasattr(channel, "kraus") and callable(channel.kraus):
+        return channel.kraus()
+    raise ValueError(
+        "Unsupported channel input type. Please provide a list of Kraus operators, "
+        "a Choi matrix, or a dict with a 'kraus' or 'choi' key."
+    )
+
+
+def is_extremal(channel):
+    r"""Check whether a quantum channel is extremal.
+
+    According to Section 2.2.4 of Watrous's *Theory of Quantum Information*,
+    a channel with Kraus operators \(\{A_i\}_{i=1}^{r}\) is extremal if and only if
+    the set \(\{A_i^\dagger A_j \,:\, i,j=1,\dots,r\}\) is linearly independent.
+
+    Parameters
+    ----------
+    channel : list, numpy.ndarray, or dict
+        The quantum channel representation, which can be:
+        - A list of Kraus operators
+        - A Choi matrix
+        - A dictionary with 'kraus' or 'choi' key
+        - An object with a callable kraus() method
+
+    Returns
+    -------
+    bool
+        True if the channel is extremal; False otherwise.
+
+    Raises
+    ------
+    ValueError
+        If no Kraus operators can be extracted.
+
+    """
+    kraus_ops = _convert_to_kraus(channel)
+
+    if not kraus_ops or len(kraus_ops) == 0:
+        raise ValueError("The channel must contain at least one Kraus operator.")
+
+    if isinstance(kraus_ops[0], list):
+        kraus_ops = [op[0] for op in kraus_ops]
+
+    r = len(kraus_ops)
+
+    if r == 1:
+        return True
+
+    flattened_products = [np.dot(A.conj().T, B).flatten() for A in kraus_ops for B in kraus_ops]
+
+    M = np.column_stack(flattened_products)
+
+    return matrix_rank(M) == r * r

--- a/toqito/channel_props/is_extremal.py
+++ b/toqito/channel_props/is_extremal.py
@@ -1,4 +1,4 @@
-"""Module for checking whether a quantum channel is extremal."""
+"""Determines whether a quantum channel is extremal."""
 
 import numpy as np
 from numpy.linalg import matrix_rank
@@ -6,91 +6,59 @@ from numpy.linalg import matrix_rank
 from toqito.channel_ops.choi_to_kraus import choi_to_kraus
 
 
-def _convert_to_kraus(channel):
-    r"""Convert a quantum channel into its Kraus representation.
-
-    The input channel can be provided as:
-      - A list of Kraus operators (each a numpy.ndarray),
-      - A Choi matrix (numpy.ndarray),
-      - A dictionary with a 'kraus' or 'choi' key,
-      - An object with a callable kraus() method.
-
-    Parameters
-    ----------
-    channel : list, numpy.ndarray, or dict
-        The quantum channel representation.
-
-    Returns
-    -------
-    list
-        A list of numpy.ndarray objects representing the Kraus operators.
-
-    Raises
-    ------
-    ValueError
-        If the channel input type is not supported.
-
-    """
-    if isinstance(channel, list):
-        return channel
-    if isinstance(channel, np.ndarray):
-        return choi_to_kraus(channel)
-    if isinstance(channel, dict):
-        if "kraus" in channel:
-            return channel["kraus"]
-        if "choi" in channel:
-            return choi_to_kraus(channel["choi"])
-        raise ValueError("Dictionary channel representation must have either 'kraus' or 'choi' key.")
-    if hasattr(channel, "kraus") and callable(channel.kraus):
-        return channel.kraus()
-    raise ValueError(
-        "Unsupported channel input type. Please provide a list of Kraus operators, "
-        "a Choi matrix, or a dict with a 'kraus' or 'choi' key."
-    )
-
-
 def is_extremal(channel):
-    r"""Check whether a quantum channel is extremal.
+    r"""Determine whether a quantum channel is extremal.
 
-    According to Section 2.2.4 of Watrous's *Theory of Quantum Information*,
-    a channel with Kraus operators \(\{A_i\}_{i=1}^{r}\) is extremal if and only if
-    the set \(\{A_i^\dagger A_j \,:\, i,j=1,\dots,r\}\) is linearly independent.
+    A channel with Kraus operators :math:`\{A_i\}_{i=1}^{r}` is **extremal** if and only if
+    the set :math:`\{A_i^\dagger A_j : i,j=1,\dots,r\}` is linearly independent.
 
-    Parameters
-    ----------
-    channel : list, numpy.ndarray, or dict
-        The quantum channel representation, which can be:
-        - A list of Kraus operators
-        - A Choi matrix
-        - A dictionary with 'kraus' or 'choi' key
-        - An object with a callable kraus() method
+    For more details, see Section 2.2.4 of :cite:`Watrous_2018_TQI`.
 
-    Returns
-    -------
-    bool
-        True if the channel is extremal; False otherwise.
-
-    Raises
-    ------
-    ValueError
-        If no Kraus operators can be extracted.
-
+    :param channel: The quantum channel representation, which can be:
+        - A list of Kraus operators,
+        - A Choi matrix,
+        - A dictionary with ``'kraus'`` or ``'choi'`` key,
+        - An object with a callable ``kraus()`` method.
+    :type channel: list[numpy.ndarray] | numpy.ndarray | dict
+    :raises ValueError: If no Kraus operators can be extracted.
+    :return: ``True`` if the channel is extremal; ``False`` otherwise.
+    :rtype: bool
     """
-    kraus_ops = _convert_to_kraus(channel)
+    # Convert the input into a list of Kraus operators
+    if isinstance(channel, list):
+        kraus_ops = channel
+    elif isinstance(channel, np.ndarray):
+        kraus_ops = choi_to_kraus(channel)
+    elif isinstance(channel, dict):
+        if "kraus" in channel:
+            kraus_ops = channel["kraus"]
+        elif "choi" in channel:
+            kraus_ops = choi_to_kraus(channel["choi"])
+        else:
+            raise ValueError("Dictionary must have a 'kraus' or 'choi' key.")
+    elif hasattr(channel, "kraus") and callable(channel.kraus):
+        kraus_ops = channel.kraus()
+    else:
+        raise ValueError("Unsupported channel format. Provide Kraus operators, a Choi matrix, or a dictionary.")
 
     if not kraus_ops or len(kraus_ops) == 0:
         raise ValueError("The channel must contain at least one Kraus operator.")
 
+    # If nested lists (non-completely positive maps), extract the first set of Kraus operators
     if isinstance(kraus_ops[0], list):
         kraus_ops = [op[0] for op in kraus_ops]
 
     r = len(kraus_ops)
 
+    # A single Kraus operator (e.g., unitary channel) is always extremal.
     if r == 1:
         return True
 
+    # Compute the set {A_i^† A_j}
     flattened_products = [np.dot(A.conj().T, B).flatten() for A in kraus_ops for B in kraus_ops]
 
+    # Form a matrix whose columns are these vectorized operators.
     M = np.column_stack(flattened_products)
 
+    # The channel is extremal if and only if the operators {A_i^† A_j} are linearly independent.
     return matrix_rank(M) == r * r

--- a/toqito/channel_props/tests/test_is_extremal.py
+++ b/toqito/channel_props/tests/test_is_extremal.py
@@ -7,93 +7,58 @@ from toqito.channel_ops.kraus_to_choi import kraus_to_choi
 from toqito.channel_props.is_extremal import is_extremal
 
 
-# Test cases for unitary channels (which are extremal)
+# Consolidated test for all extremal cases.
 @pytest.mark.parametrize(
     "phi, expected",
     [
-        # Direct flat list of Kraus operators
+        # --- Unitary channels (extremal) ---
+        # Flat list representation.
         ([np.array([[0, 1], [1, 0]])], True),
-        # Nested list of Kraus operators
+
+        # Nested list representation.
         ([[np.array([[0, 1], [1, 0]])]], True),
-    ],
-)
-def test_extremal_unitary_channel(phi, expected):
-    """Verify that unitary channels are correctly identified as extremal."""
-    assert is_extremal(phi) == expected
 
-
-# Test cases for non-extremal channels
-@pytest.mark.parametrize(
-    "phi, expected",
-    [
+        # --- Non-extremal channels ---
+        # Flat list representation: two identical Kraus operators.
         (
-            # Flat list: two identical Kraus operators.
             [
                 np.sqrt(0.5) * np.array([[1, 0], [0, 1]]),
                 np.sqrt(0.5) * np.array([[1, 0], [0, 1]]),
             ],
             False,
         ),
+        # Nested list representation of the above.
         (
-            # Nested list version of the above.
             [
                 [np.sqrt(0.5) * np.array([[1, 0], [0, 1]])],
                 [np.sqrt(0.5) * np.array([[1, 0], [0, 1]])],
             ],
             False,
         ),
-    ],
-)
-def test_non_extremal_channel(phi, expected):
-    """Verify that non-extremal channels are correctly identified."""
-    assert is_extremal(phi) == expected
 
-
-# Test cases where the channel is provided as a Choi matrix
-@pytest.mark.parametrize(
-    "phi, expected",
-    [
+        # --- Choi matrix input ---
         (kraus_to_choi([np.array([[0, 1], [1, 0]])]), True),
-    ],
-)
-def test_choi_input(phi, expected):
-    """Verify that a channel provided as a Choi matrix is correctly processed."""
-    assert is_extremal(phi) == expected
 
-
-# Test example from Watrous's book (example 2.33)
-@pytest.mark.parametrize(
-    "phi, expected",
-    [
+        # --- Example from Watrous (Example 2.33) ---
+        # Flat list representation.
         (
-            # Flat list representation.
             [
                 (1 / np.sqrt(6)) * np.array([[2, 0], [0, 1], [0, 1], [0, 0]]),
                 (1 / np.sqrt(6)) * np.array([[0, 0], [1, 0], [1, 0], [0, 2]]),
             ],
             True,
         ),
+        # Nested list representation.
         (
-            # Nested list representation.
             [
                 [(1 / np.sqrt(6)) * np.array([[2, 0], [0, 1], [0, 1], [0, 0]])],
                 [(1 / np.sqrt(6)) * np.array([[0, 0], [1, 0], [1, 0], [0, 2]])],
             ],
             True,
         ),
-    ],
-)
-def test_example_from_watrous(phi, expected):
-    """Test the example 2.33 from Watrous's *Theory of Quantum Information*."""
-    assert is_extremal(phi) == expected
 
-
-# Test depolarizing channel, which is non-extremal for d > 2 (here d=2)
-@pytest.mark.parametrize(
-    "phi, expected",
-    [
+        # --- Depolarizing channel (non-extremal) ---
         (
-            # Flat list representation of depolarizing channel Kraus ops.
             [
                 np.sqrt(1 - 3 * 0.75 / 4) * np.eye(2),
                 np.sqrt(0.75 / 4) * np.array([[0, 1], [1, 0]]),
@@ -104,29 +69,30 @@ def test_example_from_watrous(phi, expected):
         ),
     ],
 )
-def test_depolarizing_channel(phi, expected):
-    """Test that the depolarizing channel is correctly identified as non-extremal."""
+def test_is_extremal(phi, expected):
+    """Test various cases for the `is_extremal` function."""
     assert is_extremal(phi) == expected
 
 
-# <- Tests for ValueError conditions ->
+# <- Consolidated tests for ValueErrors. ->
 
-def test_empty_kraus_operators():
-    """Ensure an error is raised when the input is an empty list."""
-    with pytest.raises(ValueError, match="The channel must contain at least one Kraus operator."):
-        is_extremal([])
+@pytest.mark.parametrize(
+    "phi, error_message",
+    [
+        # Empty list.
+        ([], "The channel must contain at least one Kraus operator."),
 
-def test_empty_nested_list():
-    """Ensure an error is raised when a nested list contains no Kraus operators."""
-    with pytest.raises(ValueError, match="The channel must contain at least one Kraus operator."):
-        is_extremal([[]])
+        # Empty nested list.
+        ([[]], "The channel must contain at least one Kraus operator."),
 
-def test_invalid_list_contents():
-    """Ensure an error is raised when the input list contains invalid elements."""
-    with pytest.raises(ValueError, match="Channel must be a list \\(or nested list\\) of Kraus operators."):
-        is_extremal([1, np.array([[0, 1], [1, 0]])])
+        # Invalid list contents.
+        ([1, np.array([[0, 1], [1, 0]])], "Channel must be a list \\(or nested list\\) of Kraus operators."),
 
-def test_unsupported_input_type():
-    """Ensure an error is raised when the input type is not supported."""
-    with pytest.raises(ValueError, match="Channel must be a list of Kraus operators or a Choi matrix."):
-        is_extremal(42)  # Passing an integer
+        # Unsupported input type.
+        (42, "Channel must be a list of Kraus operators or a Choi matrix."),
+    ],
+)
+def test_is_extremal_value_errors(phi, error_message):
+    """Ensure ValueErrors are raised correctly for invalid inputs."""
+    with pytest.raises(ValueError, match=error_message):
+        is_extremal(phi)

--- a/toqito/channel_props/tests/test_is_extremal.py
+++ b/toqito/channel_props/tests/test_is_extremal.py
@@ -1,61 +1,142 @@
-"""Tests for the is_extremal function in the toqito library."""
-
-import unittest
+"""Tests for the `is_extremal` function in the Toqito library."""
 
 import numpy as np
+import pytest
 
 from toqito.channel_ops.kraus_to_choi import kraus_to_choi
 from toqito.channel_props.is_extremal import is_extremal
 
 
-class TestIsExtremal(unittest.TestCase):
-    """Test suite for checking extremality of quantum channels."""
-
-    def test_extremal_unitary_channel(self):
-        """Test that a unitary channel is correctly identified as extremal."""
-        U = np.array([[0, 1], [1, 0]])
-        kraus_ops = [U]
-        self.assertTrue(is_extremal(kraus_ops))
-        self.assertTrue(is_extremal({"kraus": kraus_ops}))
-
-    def test_non_extremal_channel(self):
-        """Test that a non-extremal channel is correctly identified."""
-        A1 = np.sqrt(0.5) * np.array([[1, 0], [0, 1]])
-        A2 = np.sqrt(0.5) * np.array([[1, 0], [0, 1]])
-        kraus_ops = [A1, A2]
-        self.assertFalse(is_extremal(kraus_ops))
-        self.assertFalse(is_extremal({"kraus": kraus_ops}))
-
-    def test_choi_input(self):
-        """Test that a channel provided as a Choi matrix is correctly processed."""
-        U = np.array([[0, 1], [1, 0]])
-        kraus_ops = [U]
-        choi = kraus_to_choi(kraus_ops)
-        self.assertTrue(is_extremal(choi))
-        self.assertTrue(is_extremal({"choi": choi}))
-
-    def test_example_from_watrous(self):
-        """Test the example 2.33 from Watrous's book."""
-        A0 = (1 / np.sqrt(6)) * np.array([[2, 0], [0, 1], [0, 1], [0, 0]])
-        A1 = (1 / np.sqrt(6)) * np.array([[0, 0], [1, 0], [1, 0], [0, 2]])
-        kraus_ops = [A0, A1]
-        self.assertTrue(is_extremal(kraus_ops))
-
-    def test_depolarizing_channel(self):
-        """Test the depolarizing channel, which is not extremal for d>2."""
-        d = 2
-        p = 0.75
-        identity_matrix = np.eye(d)
-        X = np.array([[0, 1], [1, 0]])
-        Y = np.array([[0, -1j], [1j, 0]])
-        Z = np.array([[1, 0], [0, -1]])
-        K0 = np.sqrt(1 - 3 * p / 4) * identity_matrix
-        K1 = np.sqrt(p / 4) * X
-        K2 = np.sqrt(p / 4) * Y
-        K3 = np.sqrt(p / 4) * Z
-        kraus_ops = [K0, K1, K2, K3]
-        self.assertFalse(is_extremal(kraus_ops))
+# Test cases for unitary channels (which are extremal)
+@pytest.mark.parametrize(
+    "channel, expected",
+    [
+        # Direct list of Kraus operators
+        ([np.array([[0, 1], [1, 0]])], True),
+        # Dictionary representation with "kraus" key
+        ({"kraus": [np.array([[0, 1], [1, 0]])]}, True),
+    ],
+)
+def test_extremal_unitary_channel(channel, expected):
+    """Verify that unitary channels are correctly identified as extremal."""
+    assert is_extremal(channel) == expected
 
 
-if __name__ == "__main__":
-    unittest.main()
+# Test cases for non-extremal channels
+@pytest.mark.parametrize(
+    "channel, expected",
+    [
+        (
+            [
+                np.sqrt(0.5) * np.array([[1, 0], [0, 1]]),
+                np.sqrt(0.5) * np.array([[1, 0], [0, 1]]),
+            ],
+            False,
+        ),
+        (
+            {
+                "kraus": [
+                    np.sqrt(0.5) * np.array([[1, 0], [0, 1]]),
+                    np.sqrt(0.5) * np.array([[1, 0], [0, 1]]),
+                ]
+            },
+            False,
+        ),
+    ],
+)
+def test_non_extremal_channel(channel, expected):
+    """Verify that non-extremal channels are correctly identified."""
+    assert is_extremal(channel) == expected
+
+
+# Test cases where the channel is provided as a Choi matrix
+@pytest.mark.parametrize(
+    "channel, expected",
+    [
+        (kraus_to_choi([np.array([[0, 1], [1, 0]])]), True),
+        ({"choi": kraus_to_choi([np.array([[0, 1], [1, 0]])])}, True),
+    ],
+)
+def test_choi_input(channel, expected):
+    """Verify that a channel provided as a Choi matrix is correctly processed."""
+    assert is_extremal(channel) == expected
+
+
+# Test example from Watrous's book (example 2.33)
+@pytest.mark.parametrize(
+    "channel, expected",
+    [
+        (
+            [
+                (1 / np.sqrt(6)) * np.array([[2, 0], [0, 1], [0, 1], [0, 0]]),
+                (1 / np.sqrt(6)) * np.array([[0, 0], [1, 0], [1, 0], [0, 2]]),
+            ],
+            True,
+        ),
+    ],
+)
+def test_example_from_watrous(channel, expected):
+    """Test the example 2.33 from Watrous's *Theory of Quantum Information*."""
+    assert is_extremal(channel) == expected
+
+
+# Test depolarizing channel, which is non-extremal for d > 2 (here d=2)
+@pytest.mark.parametrize(
+    "channel, expected",
+    [
+        (
+            [
+                np.sqrt(1 - 3 * 0.75 / 4) * np.eye(2),
+                np.sqrt(0.75 / 4) * np.array([[0, 1], [1, 0]]),
+                np.sqrt(0.75 / 4) * np.array([[0, -1j], [1j, 0]]),
+                np.sqrt(0.75 / 4) * np.array([[1, 0], [0, -1]]),
+            ],
+            False,
+        ),
+    ],
+)
+def test_depolarizing_channel(channel, expected):
+    """Test that the depolarizing channel is correctly identified as non-extremal."""
+    assert is_extremal(channel) == expected
+
+
+def test_empty_kraus_operators():
+    """Ensure an error is raised when the input is an empty list."""
+    with pytest.raises(ValueError, match="The channel must contain at least one Kraus operator."):
+        is_extremal([])
+
+
+def test_invalid_dictionary_key():
+    """Ensure an error is raised when the dictionary does not contain 'kraus' or 'choi'."""
+    with pytest.raises(
+        ValueError,
+        match="Dictionary must have a 'kraus' or 'choi' key.",
+    ):
+        is_extremal({"invalid_key": np.array([[1, 0], [0, 1]])})
+
+
+def test_unsupported_input_type():
+    """Ensure an error is raised when the input type is not supported."""
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Unsupported channel format. Provide Kraus operators, "
+            "a Choi matrix, or a dictionary."
+        ),
+    ):
+        is_extremal(42)  # Passing an integer instead of a valid quantum channel representation
+
+
+def test_invalid_callable_object():
+    """Ensure an error is raised when an object has a non-callable 'kraus' method."""
+    class InvalidChannel:
+        kraus = [np.array([[1, 0], [0, 1]])]  # kraus is a list, not a method
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Unsupported channel format. Provide Kraus operators, "
+            "a Choi matrix, or a dictionary."
+        ),
+    ):
+        is_extremal(InvalidChannel())

--- a/toqito/channel_props/tests/test_is_extremal.py
+++ b/toqito/channel_props/tests/test_is_extremal.py
@@ -9,24 +9,25 @@ from toqito.channel_props.is_extremal import is_extremal
 
 # Test cases for unitary channels (which are extremal)
 @pytest.mark.parametrize(
-    "channel, expected",
+    "phi, expected",
     [
-        # Direct list of Kraus operators
+        # Direct flat list of Kraus operators
         ([np.array([[0, 1], [1, 0]])], True),
-        # Dictionary representation with "kraus" key
-        ({"kraus": [np.array([[0, 1], [1, 0]])]}, True),
+        # Nested list of Kraus operators
+        ([[np.array([[0, 1], [1, 0]])]], True),
     ],
 )
-def test_extremal_unitary_channel(channel, expected):
+def test_extremal_unitary_channel(phi, expected):
     """Verify that unitary channels are correctly identified as extremal."""
-    assert is_extremal(channel) == expected
+    assert is_extremal(phi) == expected
 
 
 # Test cases for non-extremal channels
 @pytest.mark.parametrize(
-    "channel, expected",
+    "phi, expected",
     [
         (
+            # Flat list: two identical Kraus operators.
             [
                 np.sqrt(0.5) * np.array([[1, 0], [0, 1]]),
                 np.sqrt(0.5) * np.array([[1, 0], [0, 1]]),
@@ -34,57 +35,65 @@ def test_extremal_unitary_channel(channel, expected):
             False,
         ),
         (
-            {
-                "kraus": [
-                    np.sqrt(0.5) * np.array([[1, 0], [0, 1]]),
-                    np.sqrt(0.5) * np.array([[1, 0], [0, 1]]),
-                ]
-            },
+            # Nested list version of the above.
+            [
+                [np.sqrt(0.5) * np.array([[1, 0], [0, 1]])],
+                [np.sqrt(0.5) * np.array([[1, 0], [0, 1]])],
+            ],
             False,
         ),
     ],
 )
-def test_non_extremal_channel(channel, expected):
+def test_non_extremal_channel(phi, expected):
     """Verify that non-extremal channels are correctly identified."""
-    assert is_extremal(channel) == expected
+    assert is_extremal(phi) == expected
 
 
 # Test cases where the channel is provided as a Choi matrix
 @pytest.mark.parametrize(
-    "channel, expected",
+    "phi, expected",
     [
         (kraus_to_choi([np.array([[0, 1], [1, 0]])]), True),
-        ({"choi": kraus_to_choi([np.array([[0, 1], [1, 0]])])}, True),
     ],
 )
-def test_choi_input(channel, expected):
+def test_choi_input(phi, expected):
     """Verify that a channel provided as a Choi matrix is correctly processed."""
-    assert is_extremal(channel) == expected
+    assert is_extremal(phi) == expected
 
 
 # Test example from Watrous's book (example 2.33)
 @pytest.mark.parametrize(
-    "channel, expected",
+    "phi, expected",
     [
         (
+            # Flat list representation.
             [
                 (1 / np.sqrt(6)) * np.array([[2, 0], [0, 1], [0, 1], [0, 0]]),
                 (1 / np.sqrt(6)) * np.array([[0, 0], [1, 0], [1, 0], [0, 2]]),
             ],
             True,
         ),
+        (
+            # Nested list representation.
+            [
+                [(1 / np.sqrt(6)) * np.array([[2, 0], [0, 1], [0, 1], [0, 0]])],
+                [(1 / np.sqrt(6)) * np.array([[0, 0], [1, 0], [1, 0], [0, 2]])],
+            ],
+            True,
+        ),
     ],
 )
-def test_example_from_watrous(channel, expected):
+def test_example_from_watrous(phi, expected):
     """Test the example 2.33 from Watrous's *Theory of Quantum Information*."""
-    assert is_extremal(channel) == expected
+    assert is_extremal(phi) == expected
 
 
 # Test depolarizing channel, which is non-extremal for d > 2 (here d=2)
 @pytest.mark.parametrize(
-    "channel, expected",
+    "phi, expected",
     [
         (
+            # Flat list representation of depolarizing channel Kraus ops.
             [
                 np.sqrt(1 - 3 * 0.75 / 4) * np.eye(2),
                 np.sqrt(0.75 / 4) * np.array([[0, 1], [1, 0]]),
@@ -95,48 +104,29 @@ def test_example_from_watrous(channel, expected):
         ),
     ],
 )
-def test_depolarizing_channel(channel, expected):
+def test_depolarizing_channel(phi, expected):
     """Test that the depolarizing channel is correctly identified as non-extremal."""
-    assert is_extremal(channel) == expected
+    assert is_extremal(phi) == expected
 
+
+# <- Tests for ValueError conditions ->
 
 def test_empty_kraus_operators():
     """Ensure an error is raised when the input is an empty list."""
     with pytest.raises(ValueError, match="The channel must contain at least one Kraus operator."):
         is_extremal([])
 
+def test_empty_nested_list():
+    """Ensure an error is raised when a nested list contains no Kraus operators."""
+    with pytest.raises(ValueError, match="The channel must contain at least one Kraus operator."):
+        is_extremal([[]])
 
-def test_invalid_dictionary_key():
-    """Ensure an error is raised when the dictionary does not contain 'kraus' or 'choi'."""
-    with pytest.raises(
-        ValueError,
-        match="Dictionary must have a 'kraus' or 'choi' key.",
-    ):
-        is_extremal({"invalid_key": np.array([[1, 0], [0, 1]])})
-
+def test_invalid_list_contents():
+    """Ensure an error is raised when the input list contains invalid elements."""
+    with pytest.raises(ValueError, match="Channel must be a list \\(or nested list\\) of Kraus operators."):
+        is_extremal([1, np.array([[0, 1], [1, 0]])])
 
 def test_unsupported_input_type():
     """Ensure an error is raised when the input type is not supported."""
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Unsupported channel format. Provide Kraus operators, "
-            "a Choi matrix, or a dictionary."
-        ),
-    ):
-        is_extremal(42)  # Passing an integer instead of a valid quantum channel representation
-
-
-def test_invalid_callable_object():
-    """Ensure an error is raised when an object has a non-callable 'kraus' method."""
-    class InvalidChannel:
-        kraus = [np.array([[1, 0], [0, 1]])]  # kraus is a list, not a method
-
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Unsupported channel format. Provide Kraus operators, "
-            "a Choi matrix, or a dictionary."
-        ),
-    ):
-        is_extremal(InvalidChannel())
+    with pytest.raises(ValueError, match="Channel must be a list of Kraus operators or a Choi matrix."):
+        is_extremal(42)  # Passing an integer

--- a/toqito/channel_props/tests/test_is_extremal.py
+++ b/toqito/channel_props/tests/test_is_extremal.py
@@ -1,0 +1,61 @@
+"""Tests for the is_extremal function in the toqito library."""
+
+import unittest
+
+import numpy as np
+
+from toqito.channel_ops.kraus_to_choi import kraus_to_choi
+from toqito.channel_props.is_extremal import is_extremal
+
+
+class TestIsExtremal(unittest.TestCase):
+    """Test suite for checking extremality of quantum channels."""
+
+    def test_extremal_unitary_channel(self):
+        """Test that a unitary channel is correctly identified as extremal."""
+        U = np.array([[0, 1], [1, 0]])
+        kraus_ops = [U]
+        self.assertTrue(is_extremal(kraus_ops))
+        self.assertTrue(is_extremal({"kraus": kraus_ops}))
+
+    def test_non_extremal_channel(self):
+        """Test that a non-extremal channel is correctly identified."""
+        A1 = np.sqrt(0.5) * np.array([[1, 0], [0, 1]])
+        A2 = np.sqrt(0.5) * np.array([[1, 0], [0, 1]])
+        kraus_ops = [A1, A2]
+        self.assertFalse(is_extremal(kraus_ops))
+        self.assertFalse(is_extremal({"kraus": kraus_ops}))
+
+    def test_choi_input(self):
+        """Test that a channel provided as a Choi matrix is correctly processed."""
+        U = np.array([[0, 1], [1, 0]])
+        kraus_ops = [U]
+        choi = kraus_to_choi(kraus_ops)
+        self.assertTrue(is_extremal(choi))
+        self.assertTrue(is_extremal({"choi": choi}))
+
+    def test_example_from_watrous(self):
+        """Test the example 2.33 from Watrous's book."""
+        A0 = (1 / np.sqrt(6)) * np.array([[2, 0], [0, 1], [0, 1], [0, 0]])
+        A1 = (1 / np.sqrt(6)) * np.array([[0, 0], [1, 0], [1, 0], [0, 2]])
+        kraus_ops = [A0, A1]
+        self.assertTrue(is_extremal(kraus_ops))
+
+    def test_depolarizing_channel(self):
+        """Test the depolarizing channel, which is not extremal for d>2."""
+        d = 2
+        p = 0.75
+        identity_matrix = np.eye(d)
+        X = np.array([[0, 1], [1, 0]])
+        Y = np.array([[0, -1j], [1j, 0]])
+        Z = np.array([[1, 0], [0, -1]])
+        K0 = np.sqrt(1 - 3 * p / 4) * identity_matrix
+        K1 = np.sqrt(p / 4) * X
+        K2 = np.sqrt(p / 4) * Y
+        K3 = np.sqrt(p / 4) * Z
+        kraus_ops = [K0, K1, K2, K3]
+        self.assertFalse(is_extremal(kraus_ops))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/toqito/matrix_ops/vec.py
+++ b/toqito/matrix_ops/vec.py
@@ -1,4 +1,4 @@
-"""Vec operation is used to perform the unvec operation on a matrix."""
+"""Performs the vec operation on a matrix."""
 
 import numpy as np
 
@@ -8,12 +8,7 @@ def vec(mat: np.ndarray) -> np.ndarray:
 
     For more info, see Section: The Operator-Vector Correspondence from :cite:`Watrous_2018_TQI`.
 
-    Stacks the rows of the matrix on top of each other to
-    obtain the "vec" representation of the matrix.
-
-    The vec function is a linear mapping that in essence converts each row to
-    column, and then continually stacks the columns on top of each other.
-    An example is helpful.
+    The function reorders the given matrix into a column vector by stacking the columns of the matrix sequentially.
 
     For instance, for the following matrix:
 
@@ -27,7 +22,7 @@ def vec(mat: np.ndarray) -> np.ndarray:
     it holds that
 
     .. math::
-        \text{vec}(X) = \begin{pmatrix} 1 & 2 & 3 & 4 \end{pmatrix}^T
+        \text{vec}(X) = \begin{pmatrix} 1 & 3 & 2 & 4 \end{pmatrix}^T
 
     More formally, the vec operation is defined by
 
@@ -66,7 +61,7 @@ def vec(mat: np.ndarray) -> np.ndarray:
     Performing the :math:`\text{vec}` operation on :math:`A` yields
 
     .. math::
-        \text{vec}(A) = \left[1, 2, 3, 4 \right]^{T}.
+        \text{vec}(A) = \left[1, 3, 2, 4 \right]^{T}.
 
     >>> from toqito.matrix_ops import vec
     >>> import numpy as np


### PR DESCRIPTION
## Description
This PR fixes the vec operator documentation in matrix_ops/ so it correctly describes the function’s behavior (column stacking using Fortran order) and updates the math example accordingly.

## Changes
- [x] Removed the misleading "unvec" reference.
- [x] Updated the description to indicate that the function stacks columns, not rows.
- [x] Corrected the example math to reflect the proper output: `[1, 3, 2, 4]^T`.

## Checklist
 - [x] Used ruff for errors related to code style and formatting. All checks were passed.
 - [x] Verified all previous and newly added unit tests pass in pytest.
 - [x] The Sphinx build completed with 8 warnings, but these are unrelated to this PR. 
 - [x] Used linkcheck to check for broken links in the documentation
 - [x] The Sphinx doctest build completed with some failures, but these are unrelated to this PR. 