### PR TITLE
Fixed typo is_unextendible_product_basis.py

### DIFF
--- a/toqito/state_props/is_unextendible_product_basis.py
+++ b/toqito/state_props/is_unextendible_product_basis.py
@@ -23,6 +23,7 @@ def is_unextendible_product_basis(vecs: list[np.ndarray], dims: list[int]) -> tu
     Examples
     ==========
     See :func:`toqito.states.tile`. All the states together form a UPB:
+    
     >>> import numpy as np
     >>> from toqito.states import tile
     >>> from toqito.state_props import is_unextendible_product_basis

--- a/toqito/state_props/is_unextendible_product_basis.py
+++ b/toqito/state_props/is_unextendible_product_basis.py
@@ -23,7 +23,7 @@ def is_unextendible_product_basis(vecs: list[np.ndarray], dims: list[int]) -> tu
     Examples
     ==========
     See :func:`toqito.states.tile`. All the states together form a UPB:
-    
+
     >>> import numpy as np
     >>> from toqito.states import tile
     >>> from toqito.state_props import is_unextendible_product_basis


### PR DESCRIPTION
There's a missing carriage return in `is_unextendible_product_basis.py` which makes the docs render badly, and potentially skips a doctest. This PR adds it.

I used the following `grep` command to check that it was the only occurence:
```bash
grep -rI -B 1 '>>>' . | grep -vE '>>>|^--$' | grep -v '/docs/
```


## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
