### PR TITLE
docs: add docstring examples to four public functions

### DIFF
--- a/toqito/matrix_ops/calculate_vector_matrix_dimension.py
+++ b/toqito/matrix_ops/calculate_vector_matrix_dimension.py
@@ -24,7 +24,7 @@ def calculate_vector_matrix_dimension(item: np.ndarray) -> int:
     Example:
     ==========
 
-    Consider a three dimensional vector:
+    Consider the following three-dimensional vector:
 
     .. math::
         v = \left[ 1, 0, 0 \right]^{\text{T}}.
@@ -37,17 +37,18 @@ def calculate_vector_matrix_dimension(item: np.ndarray) -> int:
     >>> calculate_vector_matrix_dimension(v)
     3
 
-    For the density matrix of a two dimensional quantum system
+    For the density matrix of some two-dimensional quantum system
 
     .. math::
-        \rho = \frac{1}{2} \begin{pmatrix}
+        \rho = \frac{1}{2} 
+                \begin{pmatrix}
                     1 & 0 \\
                     0 & 1
                 \end{pmatrix}
 
     >>> from toqito.matrix_ops import calculate_vector_matrix_dimension
     >>> import numpy as np
-    >>> rho = np.array([[1/2,0],[0,1/2]])
+    >>> rho = np.array([[1/2, 0],[0, 1/2]])
     >>> calculate_vector_matrix_dimension(rho)
     2
 

--- a/toqito/matrix_ops/calculate_vector_matrix_dimension.py
+++ b/toqito/matrix_ops/calculate_vector_matrix_dimension.py
@@ -40,7 +40,7 @@ def calculate_vector_matrix_dimension(item: np.ndarray) -> int:
     For the density matrix of some two-dimensional quantum system
 
     .. math::
-        \rho = \frac{1}{2} 
+        \rho = \frac{1}{2}
                 \begin{pmatrix}
                     1 & 0 \\
                     0 & 1

--- a/toqito/matrix_ops/calculate_vector_matrix_dimension.py
+++ b/toqito/matrix_ops/calculate_vector_matrix_dimension.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 def calculate_vector_matrix_dimension(item: np.ndarray) -> int:
-    """Calculate the dimension of a vector or a square matrix, including 2D representations of vectors.
+    r"""Calculate the dimension of a vector or a square matrix, including 2D representations of vectors.
 
     This function determines the dimension of the provided item, treating 1D arrays as vectors,
     2D arrays with one dimension being 1 as vector representations, and square 2D arrays as density matrices.
@@ -20,6 +20,36 @@ def calculate_vector_matrix_dimension(item: np.ndarray) -> int:
         If the input is not a numpy array, not a 1D array (vector), a 2D array representing a vector, or a square 2D
         array (density matrix).
     :return: The dimension of the vector or matrix.
+
+    Example:
+    ==========
+
+    Consider a three dimensional vector:
+
+    .. math::
+        v = \left[ 1, 0, 0 \right]^{\text{T}}.
+
+    For this case, the dimension of the vector is equal to its length
+
+    >>> from toqito.matrix_ops import calculate_vector_matrix_dimension
+    >>> import numpy as np
+    >>> v = np.array([1, 0, 0])
+    >>> calculate_vector_matrix_dimension(v)
+    3
+
+    For the density matrix of a two dimensional quantum system
+
+    .. math::
+        \rho = \frac{1}{2} \begin{pmatrix}
+                    1 & 0 \\
+                    0 & 1
+                \end{pmatrix}
+
+    >>> from toqito.matrix_ops import calculate_vector_matrix_dimension
+    >>> import numpy as np
+    >>> rho = np.array([[1/2,0],[0,1/2]])
+    >>> calculate_vector_matrix_dimension(rho)
+    2
 
     """
     # Check if the input is a numpy array

--- a/toqito/nonlocal_games/quantum_hedging.py
+++ b/toqito/nonlocal_games/quantum_hedging.py
@@ -56,6 +56,19 @@ class QuantumHedging:
     >>> np.around(molina_watrous.max_prob_outcome_a_primal(), decimals=2)
     np.float64(0.85)
 
+    This example demonstrates strong duality with matching primal and dual values, as can be seen below:
+
+    >>> np.around(molina_watrous.max_prob_outcome_a_dual(), decimals=2)
+    np.float64(0.85)
+
+    and
+
+    >>> np.around(molina_watrous.min_prob_outcome_a_primal(), decimals=2)
+    np.float64(0.15)
+    >>> np.around(molina_watrous.min_prob_outcome_a_dual(), decimals=2)
+    np.float64(0.15)
+
+
     References
     ==========
     .. bibliography::
@@ -83,8 +96,8 @@ class QuantumHedging:
         # action:
         #   π(y1 ⊗ y2 ⊗ x1 ⊗ x2) = y1 ⊗ x1 ⊗ y2 ⊗ x2
         # for all y1 ∈ Y1, y2 ∈ Y2, x1 ∈ X1, x2 ∈ X2.).
-        l_1 = list(range(self._num_reps ))
-        l_2 = list(range(self._num_reps , self._num_reps**2 ))
+        l_1 = list(range(self._num_reps))
+        l_2 = list(range(self._num_reps, self._num_reps**2))
         if self._num_reps == 1:
             self._pperm = np.array([1])
         else:
@@ -117,8 +130,7 @@ class QuantumHedging:
         """
         x_var = cvxpy.Variable((4**self._num_reps, 4**self._num_reps), hermitian=True)
         objective = cvxpy.Maximize(cvxpy.real(cvxpy.trace(self._q_a.conj().T @ x_var)))
-        constraints = [partial_trace(x_var, self._sys, self._dim) == np.identity(2**self._num_reps),
-                       x_var >> 0]
+        constraints = [partial_trace(x_var, self._sys, self._dim) == np.identity(2**self._num_reps), x_var >> 0]
         problem = cvxpy.Problem(objective, constraints)
 
         return problem.solve()
@@ -182,8 +194,7 @@ class QuantumHedging:
         """
         x_var = cvxpy.Variable((4**self._num_reps, 4**self._num_reps), hermitian=True)
         objective = cvxpy.Minimize(cvxpy.real(cvxpy.trace(self._q_a.conj().T @ x_var)))
-        constraints = [partial_trace(x_var, self._sys, self._dim) == np.identity(2**self._num_reps),
-                       x_var >> 0]
+        constraints = [partial_trace(x_var, self._sys, self._dim) == np.identity(2**self._num_reps), x_var >> 0]
         problem = cvxpy.Problem(objective, constraints)
 
         return problem.solve()

--- a/toqito/nonlocal_games/xor_game.py
+++ b/toqito/nonlocal_games/xor_game.py
@@ -112,6 +112,10 @@ class XORGame:
     >>> np.around(odd_cycle.classical_value(), decimals=1)
     np.float64(0.9)
 
+    We can also calculate the nonsignaling value of the odd cycle game.
+    >>> np.around(odd_cycle.nonsignaling_value(), decimals=1)
+    np.float64(1.0)
+
     References
     ==========
     .. bibliography::

--- a/toqito/states/mutually_unbiased_basis.py
+++ b/toqito/states/mutually_unbiased_basis.py
@@ -26,12 +26,14 @@ def mutually_unbiased_basis(dim: int) -> list[np.ndarray]:
         M_1 = \left\{\frac{|0\rangle + |1\rangle}{\sqrt{2}}, \frac{|0\rangle - |1\rangle}{\sqrt{2}}\right\}
         M_2 = \left\{\frac{|0\rangle + i|1\rangle}{\sqrt{2}}, \frac{|0\rangle - i|1\rangle}{\sqrt{2}}\right\}
 
+    The six vectors above are obtained accordingly:
+
     >>> from toqito.states import mutually_unbiased_basis
     >>> mubs = mutually_unbiased_basis(2)
     >>> len(mubs)
-    3
+    6
     >>> [vec.shape for vec in mubs]
-    [(2,), (2,), (2,)]
+    [(2,), (2,), (2,), (2,), (2,), (2,)]
 
     References
     ==========

--- a/toqito/states/mutually_unbiased_basis.py
+++ b/toqito/states/mutually_unbiased_basis.py
@@ -26,6 +26,13 @@ def mutually_unbiased_basis(dim: int) -> list[np.ndarray]:
         M_1 = \left\{\frac{|0\rangle + |1\rangle}{\sqrt{2}}, \frac{|0\rangle - |1\rangle}{\sqrt{2}}\right\}
         M_2 = \left\{\frac{|0\rangle + i|1\rangle}{\sqrt{2}}, \frac{|0\rangle - i|1\rangle}{\sqrt{2}}\right\}
 
+    >>> from toqito.matrix_ops import mutually_unbiased_basis
+    >>> mubs = mutually_unbiased_basis(2)
+    >>> len(mubs)
+    3
+    >>> [vec.shape for vec in mubs]
+    [(2,), (2,), (2,)]
+
     References
     ==========
     .. bibliography::

--- a/toqito/states/mutually_unbiased_basis.py
+++ b/toqito/states/mutually_unbiased_basis.py
@@ -26,7 +26,7 @@ def mutually_unbiased_basis(dim: int) -> list[np.ndarray]:
         M_1 = \left\{\frac{|0\rangle + |1\rangle}{\sqrt{2}}, \frac{|0\rangle - |1\rangle}{\sqrt{2}}\right\}
         M_2 = \left\{\frac{|0\rangle + i|1\rangle}{\sqrt{2}}, \frac{|0\rangle - i|1\rangle}{\sqrt{2}}\right\}
 
-    >>> from toqito.matrix_ops import mutually_unbiased_basis
+    >>> from toqito.states import mutually_unbiased_basis
     >>> mubs = mutually_unbiased_basis(2)
     >>> len(mubs)
     3


### PR DESCRIPTION
## Description
Closes #1082.

## Changes
- Added examples to `matrix_ops/calculate_vector_matrix_dimension`
- Added examples to `states/mutually_unbiased_basis`
- Added examples to `nonlocal_games/quantum_hedging` methods:
  - `max_prob_outcome_a_primal`
  - `max_prob_outcome_a_dual`
  - `min_prob_outcome_a_primal`
  - `min_prob_outcome_a_dual`
- Added examples to methods in `nonlocal_games/xor_game`:
  - `nonsignaling_value`

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.