### PR TITLE
Adding file renyi_entropy.py for calculating renyi entropies (Resolves #1088)

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -765,6 +765,17 @@ abstract = {One of the most cited books in physics of all time, Quantum Computat
   primaryClass={quant-ph}
 }
 
+@article{muller_lennert_renyi_2013,
+  author       = {M. Müller-Lennert and F. Dupuis and O. Szehr and S. Fehr and M. Tomamichel},
+  title        = {On Quantum Rényi Entropies: A New Generalization and Some Properties},
+  journal      = {arXiv preprint},
+  year         = {2013},
+  eprint       = {1306.3142},
+  archivePrefix = {arXiv},
+  primaryClass = {quant-ph},
+  url          = {https://arxiv.org/abs/1306.3142}
+}
+
 % Last name begins with N
 @article{Navascues_2008_AConvergent,
   title={A convergent hierarchy of semidefinite programs characterizing the set of quantum correlations},
@@ -870,6 +881,14 @@ abstract = {One of the most cited books in physics of all time, Quantum Computat
 }
   
 % Last name begins with Q
+@misc{quantiki_entropy,
+  author       = {{Quantiki contributors}},
+  title        = {Classical Entropy Measures},
+  year         = {2024},
+  url          = {https://www.quantiki.org/wiki/classical-entropy-measures},
+  note         = {Accessed: April 3, 2025}
+}
+
 @misc{Quantiki_EOF,
   author={Quantiki},
   title={Entanglement of Formation},

--- a/toqito/state_ops/__init__.py
+++ b/toqito/state_ops/__init__.py
@@ -1,3 +1,4 @@
 """State operations is a set of modules that implements various operations on quantum states."""
 
 from toqito.state_ops.schmidt_decomposition import schmidt_decomposition
+from toqito.state_ops.renyi_entropy import renyi_entropy

--- a/toqito/state_ops/renyi_entropy.py
+++ b/toqito/state_ops/renyi_entropy.py
@@ -1,10 +1,10 @@
-""" Calculates the renyi entropy for a given density matrix. Takes into account the special cases of alpha = 0,1 or infty """
+"""Calculates the renyi entropy for a given density matrix. Valid for special cases of alpha = 0,1 or infty."""
 
 import numpy as np
 
-def renyi_entropy(rho: np.ndarray, alpha: float, tolerance: float = 1e-10) -> float
-    
-    r"""Calculate the Renyi entropy for a quantum density matrix. 
+
+def renyi_entropy(rho: np.ndarray, alpha: float, tolerance: float = 1e-10) -> float:
+    r"""Calculate the Renyi entropy for a quantum density matrix.
 
     The Rényi entropy of order :math:`\alpha` for a density matrix :math:`\rho` is given by :cite:`quantiki_entropy`
 
@@ -14,15 +14,15 @@ def renyi_entropy(rho: np.ndarray, alpha: float, tolerance: float = 1e-10) -> fl
     where :math:`\lambda_i` are the eigenvalues of :math:`\rho`.
 
     Special cases :cite:`muller_lennert_renyi_2013`
-        - For :math:`\alpha = 0` (Hartley entropy):  
-          .. math:: S_0(\rho) = \log_2 d,  
+        - For :math:`\alpha = 0` (Hartley entropy):
+          .. math:: S_0(\rho) = \log_2 d,
           where :math:`d` is the rank of :math:`\rho`.
-        - For :math:`\alpha = 1` (Shannon entropy):  
+        - For :math:`\alpha = 1` (Shannon entropy):
           .. math:: S_1(\rho) = -\sum_i \lambda_i \log_2 \lambda_i.
-        - For :math:`\alpha \to \infty` (Min-entropy):  
+        - For :math:`\alpha \to \infty` (Min-entropy):
           .. math:: S_{\infty}(\rho) = -\log_2 \max_i \lambda_i.
 
-    
+
     Examples
     ========
     Compute the Rényi entropy of a pure state:
@@ -38,7 +38,7 @@ def renyi_entropy(rho: np.ndarray, alpha: float, tolerance: float = 1e-10) -> fl
     >>> renyi_entropy(rho_mixed, alpha=2)
     1.0
 
-    
+
     References
     ==========
     .. bibliography::
@@ -49,31 +49,26 @@ def renyi_entropy(rho: np.ndarray, alpha: float, tolerance: float = 1e-10) -> fl
     :param tolerance: The numerical tolerance for eigenvalues (default is :math:`10^{-10}`).
     :raises ValueError: If the density matrix does not have trace equal to 1.
     :return: The Rényi entropy value.
+
     """
-    
-    
     if not np.allclose(np.trace(rho), 1.0, atol=1e-10):
         raise ValueError("The density matrix must have trace equal to 1")
-    
+
     rho = np.array(rho)
     eigenvalues = np.linalg.eigvalsh(rho)
     eigenvalues = eigenvalues[eigenvalues > tolerance]
 
-    
     if alpha == 0:
         renyi = np.log2(len(eigenvalues))
-      
-  
+
     elif alpha == 1:
         renyi = (-1) * np.sum(np.log2(eigenvalues) * eigenvalues)
 
-    
     elif np.isinf(alpha):
         renyi = (-1) * np.log2(np.max(eigenvalues))
 
-    
     else:
-        pow_eigvals = np.power(eigenvalues,[alpha])
-        renyi = np.log2(np.sum(pow_eigvals))/(1 - alpha)
-    
+        pow_eigvals = np.power(eigenvalues, [alpha])
+        renyi = np.log2(np.sum(pow_eigvals)) / (1 - alpha)
+
     return renyi

--- a/toqito/state_ops/renyi_entropy.py
+++ b/toqito/state_ops/renyi_entropy.py
@@ -1,2 +1,43 @@
 # Includes code to calculate the renyi entropy of a given state, as a wavefunction or a density matrix
 # Takes into account the special cases of \alpha = 0,1 or \infty
+
+import numpy as np
+
+# Defining the function for Renyi Entropy
+def renyi(rho,alpha):
+    """
+    Calculate the Rényi entropy for a quantum density matrix rho with parameter alpha.
+    
+    Parameters:
+    -----------
+    rho : numpy.ndarray
+        Density matrix (must be Hermitian, positive semi-definite with trace 1)
+    alpha : float
+        The order of Rényi entropy
+        
+    Returns:
+    --------
+    float
+        The Rényi entropy value
+    """
+  
+    rho = np.array(rho)
+    eigenvalues = np.linalg.eigvalsh(rho)
+    eigenvalues = eigenvalues[eigenvalues > 1e-10]
+
+    # First resolving the special values of alpha
+    if(alpha == 0):
+      renyi = np.log2(len(eigenvalues))
+      
+  
+    elif(alpha == 1):
+      renyi = (-1) * np.sum(np.log2(eigenvalues) * eigenvalues)
+
+    elif(np.isinf(alpha)):
+      renyi = (-1) * np.log2(np.max(eigenvalues))
+
+    else:
+      pow_eigvals = np.power(eigenvalues,[alpha])
+      renyi = np.log2(np.sum(pow_eigvals))/(1 - alpha)
+    
+    return renyi

--- a/toqito/state_ops/renyi_entropy.py
+++ b/toqito/state_ops/renyi_entropy.py
@@ -1,0 +1,2 @@
+# Includes code to calculate the renyi entropy of a given state, as a wavefunction or a density matrix
+# Takes into account the special cases of \alpha = 0,1 or \infty

--- a/toqito/state_ops/renyi_entropy.py
+++ b/toqito/state_ops/renyi_entropy.py
@@ -71,4 +71,4 @@ def renyi_entropy(rho: np.ndarray, alpha: float, tolerance: float = 1e-10) -> fl
         pow_eigvals = np.power(eigenvalues, [alpha])
         renyi = np.log2(np.sum(pow_eigvals)) / (1 - alpha)
 
-    return renyi
+    return float(abs(renyi))

--- a/toqito/state_ops/renyi_entropy.py
+++ b/toqito/state_ops/renyi_entropy.py
@@ -1,43 +1,97 @@
-# Includes code to calculate the renyi entropy of a given state, as a wavefunction or a density matrix
-# Takes into account the special cases of \alpha = 0,1 or \infty
+""" Calculates the renyi entropy for a given density matrix. Takes into account the special cases of alpha = 0,1 or infinity """
 
 import numpy as np
 
-# Defining the function for Renyi Entropy
-def renyi(rho,alpha):
-    """
-    Calculate the Rényi entropy for a quantum density matrix rho with parameter alpha.
+def renyi_entropy(rho: np.ndarray, alpha: float, tolerance: float = 1e-10) -> float
     
+    r"""Calculate the Renyi entropy for a quantum density matrix. 
+    
+
     Parameters:
     -----------
-    rho : numpy.ndarray
-        Density matrix (must be Hermitian, positive semi-definite with trace 1)
-    alpha : float
-        The order of Rényi entropy
-        
+    rho : Density matrix (must be Hermitian, positive semi-definite with trace 1)
+    alpha : The order of Rényi entropy
+    tolerance : The numerical tolerance for eigenvalues (default is 1e-10)
+
     Returns:
     --------
-    float
-        The Rényi entropy value
+    The Renyi entropy value.
+    
+    
+    Description:
+    ------------
+    The Renyi entropy of order :math:`\alpha` for a density matrix :math:`\rho` is given by:
+
+    .. math::
+        S_{\alpha}(\rho) = \frac{1}{1 - \alpha} \log_2 \left( \sum_i \lambda_i^{\alpha} \right),
+
+    where :math:`\lambda_i` are the eigenvalues of :math:`\rho`.
+
+    Special cases:
+        - For :math:`\alpha = 0` (Hartley entropy):  
+          .. math:: S_0(\rho) = \log_2 d,  
+          where :math:`d` is the rank of :math:`\rho`.
+        - For :math:`\alpha = 1` (Shannon entropy):  
+          .. math:: S_1(\rho) = -\sum_i \lambda_i \log_2 \lambda_i.
+        - For :math:`\alpha \to \infty` (Min-entropy):  
+          .. math:: S_{\infty}(\rho) = -\log_2 \max_i \lambda_i.
+
+    
+    Examples:
+    ---------
+    Compute the Renyi entropy of a pure state:
+
+    >>> import numpy as np
+    >>> rho = np.array([[1, 0], [0, 0]])  # Pure state
+    >>> renyi_entropy(rho, alpha=1)
+    0.0
+
+    Compute the Renyi entropy of a maximally mixed state:
+
+    >>> rho_mixed = np.array([[0.5, 0], [0, 0.5]])  # Maximally mixed state
+    >>> renyi_entropy(rho_mixed, alpha=2)
+    1.0
+
+    
+    References:
+    -----------
+    .. bibliography::
+        :filter: docname in docnames
+
+    :param rho: The quantum density matrix (must be Hermitian, positive semi-definite, and have trace 1).
+    :param alpha: The order of Renyi entropy.
+    :param tolerance: The numerical tolerance for eigenvalues (default is :math:`10^{-10}`).
+    :raises ValueError: If the density matrix does not have trace equal to 1.
+    :return: The Renyi entropy value.
+
+    .. seealso::
+        `Classical Entropy Measures <https://www.quantiki.org/wiki/classical-entropy-measures>`_
+        `Quantum Renyi Divergences <https://arxiv.org/abs/1306.3142>`_
     """
-  
+    
+    
+    if not np.allclose(np.trace(rho), 1.0, atol=1e-10):
+        raise ValueError("The density matrix must have trace equal to 1")
+    
     rho = np.array(rho)
     eigenvalues = np.linalg.eigvalsh(rho)
-    eigenvalues = eigenvalues[eigenvalues > 1e-10]
+    eigenvalues = eigenvalues[eigenvalues > tolerance]
 
-    # First resolving the special values of alpha
-    if(alpha == 0):
-      renyi = np.log2(len(eigenvalues))
+    
+    if alpha == 0:
+        renyi = np.log2(len(eigenvalues))
       
   
-    elif(alpha == 1):
-      renyi = (-1) * np.sum(np.log2(eigenvalues) * eigenvalues)
+    elif alpha == 1:
+        renyi = (-1) * np.sum(np.log2(eigenvalues) * eigenvalues)
 
-    elif(np.isinf(alpha)):
-      renyi = (-1) * np.log2(np.max(eigenvalues))
+    
+    elif np.isinf(alpha):
+        renyi = (-1) * np.log2(np.max(eigenvalues))
 
+    
     else:
-      pow_eigvals = np.power(eigenvalues,[alpha])
-      renyi = np.log2(np.sum(pow_eigvals))/(1 - alpha)
+        pow_eigvals = np.power(eigenvalues,[alpha])
+        renyi = np.log2(np.sum(pow_eigvals))/(1 - alpha)
     
     return renyi

--- a/toqito/state_ops/renyi_entropy.py
+++ b/toqito/state_ops/renyi_entropy.py
@@ -1,33 +1,19 @@
-""" Calculates the renyi entropy for a given density matrix. Takes into account the special cases of alpha = 0,1 or infinity """
+""" Calculates the renyi entropy for a given density matrix. Takes into account the special cases of alpha = 0,1 or infty """
 
 import numpy as np
 
 def renyi_entropy(rho: np.ndarray, alpha: float, tolerance: float = 1e-10) -> float
     
     r"""Calculate the Renyi entropy for a quantum density matrix. 
-    
 
-    Parameters:
-    -----------
-    rho : Density matrix (must be Hermitian, positive semi-definite with trace 1)
-    alpha : The order of Rényi entropy
-    tolerance : The numerical tolerance for eigenvalues (default is 1e-10)
-
-    Returns:
-    --------
-    The Renyi entropy value.
-    
-    
-    Description:
-    ------------
-    The Renyi entropy of order :math:`\alpha` for a density matrix :math:`\rho` is given by:
+    The Rényi entropy of order :math:`\alpha` for a density matrix :math:`\rho` is given by :cite:`quantiki_entropy`
 
     .. math::
         S_{\alpha}(\rho) = \frac{1}{1 - \alpha} \log_2 \left( \sum_i \lambda_i^{\alpha} \right),
 
     where :math:`\lambda_i` are the eigenvalues of :math:`\rho`.
 
-    Special cases:
+    Special cases :cite:`muller_lennert_renyi_2013`
         - For :math:`\alpha = 0` (Hartley entropy):  
           .. math:: S_0(\rho) = \log_2 d,  
           where :math:`d` is the rank of :math:`\rho`.
@@ -37,36 +23,32 @@ def renyi_entropy(rho: np.ndarray, alpha: float, tolerance: float = 1e-10) -> fl
           .. math:: S_{\infty}(\rho) = -\log_2 \max_i \lambda_i.
 
     
-    Examples:
-    ---------
-    Compute the Renyi entropy of a pure state:
+    Examples
+    ========
+    Compute the Rényi entropy of a pure state:
 
     >>> import numpy as np
     >>> rho = np.array([[1, 0], [0, 0]])  # Pure state
     >>> renyi_entropy(rho, alpha=1)
     0.0
 
-    Compute the Renyi entropy of a maximally mixed state:
+    Compute the Rényi entropy of a maximally mixed state:
 
     >>> rho_mixed = np.array([[0.5, 0], [0, 0.5]])  # Maximally mixed state
     >>> renyi_entropy(rho_mixed, alpha=2)
     1.0
 
     
-    References:
-    -----------
+    References
+    ==========
     .. bibliography::
         :filter: docname in docnames
 
     :param rho: The quantum density matrix (must be Hermitian, positive semi-definite, and have trace 1).
-    :param alpha: The order of Renyi entropy.
+    :param alpha: The order of Rényi entropy.
     :param tolerance: The numerical tolerance for eigenvalues (default is :math:`10^{-10}`).
     :raises ValueError: If the density matrix does not have trace equal to 1.
-    :return: The Renyi entropy value.
-
-    .. seealso::
-        `Classical Entropy Measures <https://www.quantiki.org/wiki/classical-entropy-measures>`_
-        `Quantum Renyi Divergences <https://arxiv.org/abs/1306.3142>`_
+    :return: The Rényi entropy value.
     """
     
     

--- a/toqito/state_ops/renyi_entropy.py
+++ b/toqito/state_ops/renyi_entropy.py
@@ -14,13 +14,10 @@ def renyi_entropy(rho: np.ndarray, alpha: float, tolerance: float = 1e-10) -> fl
     where :math:`\lambda_i` are the eigenvalues of :math:`\rho`.
 
     Special cases :cite:`muller_lennert_renyi_2013`
-        - For :math:`\alpha = 0` (Hartley entropy) \\
-          .. math:: S_0(\rho) = \log_2 d,
+        - For :math:`\alpha = 0` (Hartley entropy):  :math: 'S_0(\rho) = \log_2 d',
           where :math:`d` is the rank of :math:`\rho`.
-        - For :math:`\alpha = 1` (Shannon entropy) \\
-          .. math:: S_1(\rho) = -\sum_i \lambda_i \log_2 \lambda_i.
-        - For :math:`\alpha \to \infty` (Min-entropy) \\
-          .. math:: S_{\infty}(\rho) = -\log_2 \max_i \lambda_i.
+        - For :math:`\alpha = 1` (Shannon entropy):  :math: 'S_1(\rho) = -\sum_i \lambda_i \log_2 \lambda_i'.
+        - For :math:`\alpha \to \infty` (Min-entropy): :math: 'S_{\infty}(\rho) = -\log_2 \max_i \lambda_i'.
 
 
     Examples

--- a/toqito/state_ops/renyi_entropy.py
+++ b/toqito/state_ops/renyi_entropy.py
@@ -14,12 +14,12 @@ def renyi_entropy(rho: np.ndarray, alpha: float, tolerance: float = 1e-10) -> fl
     where :math:`\lambda_i` are the eigenvalues of :math:`\rho`.
 
     Special cases :cite:`muller_lennert_renyi_2013`
-        - For :math:`\alpha = 0` (Hartley entropy):
+        - For :math:`\alpha = 0` (Hartley entropy) \\
           .. math:: S_0(\rho) = \log_2 d,
           where :math:`d` is the rank of :math:`\rho`.
-        - For :math:`\alpha = 1` (Shannon entropy):
+        - For :math:`\alpha = 1` (Shannon entropy) \\
           .. math:: S_1(\rho) = -\sum_i \lambda_i \log_2 \lambda_i.
-        - For :math:`\alpha \to \infty` (Min-entropy):
+        - For :math:`\alpha \to \infty` (Min-entropy) \\
           .. math:: S_{\infty}(\rho) = -\log_2 \max_i \lambda_i.
 
 

--- a/toqito/state_ops/tests/test_renyi_entropy.py
+++ b/toqito/state_ops/tests/test_renyi_entropy.py
@@ -1,0 +1,27 @@
+import pytest
+import numpy as np
+from toqito.state_ops import renyi_entropy
+
+# Example density matrices for testing
+rho_pure = np.array([[1, 0], [0, 0]])  # Taking a pure state density matrix
+rho_mixed = np.array([[0.5, 0], [0, 0.5]])  # Taking a maximum mixed state
+invalid_rho = np.array([[0.5, 0], [0, 0.4]])  # Taking error case, trace not equals 1
+
+def test_alpha_0():
+    assert renyi_entropy(rho_pure, 0) == pytest.approx(0.0)
+    assert renyi_entropy(rho_mixed, 0) == pytest.approx(np.log2(2))
+
+def test_alpha_1():
+    assert renyi_entropy(rho_pure, 1) == pytest.approx(0.0)
+    assert renyi_entropy(rho_mixed, 1) == pytest.approx(1.0)
+
+def test_alpha_inf():
+    assert renyi_entropy(rho_pure, np.inf) == pytest.approx(0.0)
+    assert renyi_entropy(rho_mixed, np.inf) == pytest.approx(1.0)
+
+def test_invalid_density_matrix():
+    with pytest.raises(ValueError, match="The density matrix must have trace equal to 1"):
+        renyi_entropy(invalid_rho, 1)  # Should raise ValueError
+
+def test_general_alpha():
+    assert renyi_entropy(rho_mixed, 2) == pytest.approx(np.log2(0.5**2 + 0.5**2)/(1-2))

--- a/toqito/state_ops/tests/test_renyi_entropy.py
+++ b/toqito/state_ops/tests/test_renyi_entropy.py
@@ -1,5 +1,8 @@
-import pytest
+"""Test Renyi Entropy."""
+
 import numpy as np
+import pytest
+
 from toqito.state_ops import renyi_entropy
 
 # Example density matrices for testing
@@ -7,21 +10,31 @@ rho_pure = np.array([[1, 0], [0, 0]])  # Taking a pure state density matrix
 rho_mixed = np.array([[0.5, 0], [0, 0.5]])  # Taking a maximum mixed state
 invalid_rho = np.array([[0.5, 0], [0, 0.4]])  # Taking error case, trace not equals 1
 
+
 def test_alpha_0():
+    """Testing the Renyi Entropy of order 0 for the pure and mixed state."""
     assert renyi_entropy(rho_pure, 0) == pytest.approx(0.0)
     assert renyi_entropy(rho_mixed, 0) == pytest.approx(np.log2(2))
 
+
 def test_alpha_1():
+    """Testing the Renyi Entropy of order 1 for the pure and mixed state."""
     assert renyi_entropy(rho_pure, 1) == pytest.approx(0.0)
     assert renyi_entropy(rho_mixed, 1) == pytest.approx(1.0)
 
+
 def test_alpha_inf():
+    """Testing the Renyi Entropy of order infty for the pure state and mixed."""
     assert renyi_entropy(rho_pure, np.inf) == pytest.approx(0.0)
     assert renyi_entropy(rho_mixed, np.inf) == pytest.approx(1.0)
 
+
 def test_invalid_density_matrix():
+    """Testing the Renyi Entropy of incorrect density matrix as trial input."""
     with pytest.raises(ValueError, match="The density matrix must have trace equal to 1"):
         renyi_entropy(invalid_rho, 1)  # Should raise ValueError
 
+
 def test_general_alpha():
-    assert renyi_entropy(rho_mixed, 2) == pytest.approx(np.log2(0.5**2 + 0.5**2)/(1-2))
+    """Testing the Renyi Entropy of order alpha = 2 for the pure state and mixed."""
+    assert renyi_entropy(rho_mixed, 2) == pytest.approx(np.log2(0.5**2 + 0.5**2) / (1 - 2))


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->

This pull request includes a .py file to calculate the renyi entropy of a given state provided as a density matrix. It is an attempt that Resolves #1088  

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [x] Change 1 Adds a new file in the folder state_ops within the toqito folder in the repository called renyi_entropy.py
  -  [x] Change 2 Adds a new file in the tests folder within state_ops called as test_renyi_entropy.py with test cases
  -  [x] Change 3 Modifies the existing __init__.py to initialize the renyi_entropy

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
