### PR TITLE
Add mypy to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,10 @@ repos:
       stages: [commit-msg]
       args: []
 
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.10.0  
+  hooks:
+    - id: mypy
+      args: ["--ignore-missing-imports"]  
+      stages: [pre-commit]
+


### PR DESCRIPTION
## Description
fixes: #1010 
This PR adds MyPy to the pre-commit hook 

## Changes
```.pre-commit-config.yaml```

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [ ] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [ ] Use `linkcheck` to check for broken links in the documentation
  -  [ ] Use `doctest` to verify the examples in the function docstrings work as expected.
