### PR TITLE
Fixed fourier.py

### DIFF
--- a/toqito/matrices/fourier.py
+++ b/toqito/matrices/fourier.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 
+
 def fourier(dim: int) -> np.ndarray:
     r"""Generate the Fourier transform matrix :cite:`WikiDFT`.
 

--- a/toqito/matrices/fourier.py
+++ b/toqito/matrices/fourier.py
@@ -49,8 +49,8 @@ def fourier(dim: int) -> np.ndarray:
 
     Parameters
     ----------
-    dim : int
-        The size of the Fourier matrix.
+    :param dim: The size of the Fourier matrix.
+    :return: The Fourier matrix of dimension :code:`dim`.
 
     Returns
     -------

--- a/toqito/matrices/fourier.py
+++ b/toqito/matrices/fourier.py
@@ -47,15 +47,8 @@ def fourier(dim: int) -> np.ndarray:
     .. bibliography::
         :filter: docname in docnames
 
-    Parameters
-    ----------
     :param dim: The size of the Fourier matrix.
     :return: The Fourier matrix of dimension :code:`dim`.
-
-    Returns
-    -------
-    np.ndarray
-        The Fourier matrix of dimension :code:`dim`.
     """
     # Primitive root of unity.
     root_unity = np.exp(2 * 1j * np.pi / dim)

--- a/toqito/matrices/fourier.py
+++ b/toqito/matrices/fourier.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-
 def fourier(dim: int) -> np.ndarray:
     r"""Generate the Fourier transform matrix :cite:`WikiDFT`.
 
@@ -12,7 +11,7 @@ def fourier(dim: int) -> np.ndarray:
     The Fourier matrix is defined as:
 
     .. math::
-        W_N = \frac{1}{N}
+        W_N = \frac{1}{\sqrt{N}}
         \begin{pmatrix}
             1 & 1 & 1 & 1 & \ldots & 1 \\
             1 & \omega & \omega^2 & \omega^3 & \ldots & \omega^{N-1} \\
@@ -20,20 +19,19 @@ def fourier(dim: int) -> np.ndarray:
             1 & \omega^3 & \omega^6 & \omega^9 & \ldots & \omega^{3(N-1)} \\
             \vdots & \vdots & \vdots & \vdots & \ddots & \vdots \\
             1 & \omega^{N-1} & \omega^{2(N-1)} & \omega^{3(N-1)} &
-            \ldots & \omega^{3(N-1)}
+            \ldots & \omega^{(N-1)(N-1)}
         \end{pmatrix}
 
     Examples
-    ==========
+    ========
 
-    The Fourier matrix generated from :math:`d = 3` yields the following
-    matrix:
+    The Fourier matrix generated from :math:`d = 3` yields the following matrix:
 
     .. math::
-        W_3 = \frac{1}{3}
+        W_3 = \frac{1}{\sqrt{3}}
         \begin{pmatrix}
             1 & 1 & 1 \\
-            0 & \omega & \omega^2 \\
+            1 & \omega & \omega^2 \\
             1 & \omega^2 & \omega^4
         \end{pmatrix}
 
@@ -48,13 +46,19 @@ def fourier(dim: int) -> np.ndarray:
     .. bibliography::
         :filter: docname in docnames
 
+    Parameters
+    ----------
+    dim : int
+        The size of the Fourier matrix.
 
-    :param dim: The size of the Fourier matrix.
-    :return: The Fourier matrix of dimension :code:`dim`.
-
+    Returns
+    -------
+    np.ndarray
+        The Fourier matrix of dimension :code:`dim`.
     """
     # Primitive root of unity.
     root_unity = np.exp(2 * 1j * np.pi / dim)
     entry_1 = np.arange(0, dim)[:, None]
     entry_2 = np.arange(0, dim)
     return np.power(root_unity, entry_1 * entry_2) / np.sqrt(dim)
+


### PR DESCRIPTION
## Description
This PR improves the docstring formatting of the `fourier` function for better readability and accuracy in rendered documentation. It ensures the mathematical expressions for the Fourier matrix are consistent and correctly typeset, without modifying the core logic of the function.
Fixes #1147 

## Changes
- [x] Corrected the matrix formula rendering in the LaTeX-style math block for `W_N`.
  - [x] Updated the example Fourier matrix `W_3` to reflect consistent notation and fix indexing inaccuracies.

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
