### PR TITLE
Clarification of documentation in getting started and contributing guide regarding python version

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -16,8 +16,8 @@ We welcome contributions from external contributors, and this document describes
 
 .. warning::
      It would be better to avoid an editable installation via :code:`pip` as :code:`poetry` is a better dependency resolver. 
-
-4. As stated in :ref:`getting_started_reference-label`, ensure you have Python 3.10 or greater installed on your machine or in 
+ddddd
+4. As stated in :ref:`getting_started_reference-label`, ensure you have Python 3.10 to 3.12 installed on your machine or in 
    a virtual environment (`pyenv <https://github.com/pyenv/pyenv>`_, `pyenv tutorial <https://realpython.com/intro-to-pyenv/>`_).
    Consider using a `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_.
    You can also use :code:`pyenv` with :code:`virtualenv` `to manage different Python

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -16,7 +16,7 @@ We welcome contributions from external contributors, and this document describes
 
 .. warning::
      It would be better to avoid an editable installation via :code:`pip` as :code:`poetry` is a better dependency resolver. 
-ddddd
+
 4. As stated in :ref:`getting_started_reference-label`, ensure you have Python 3.10 to 3.12 installed on your machine or in 
    a virtual environment (`pyenv <https://github.com/pyenv/pyenv>`_, `pyenv tutorial <https://realpython.com/intro-to-pyenv/>`_).
    Consider using a `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -14,9 +14,7 @@ Installing
 1. Ensure you have Python 3.10 or greater installed on your machine or in 
 a virtual environment (`pyenv <https://github.com/pyenv/pyenv>`_, `pyenv tutorial <https://realpython.com/intro-to-pyenv/>`_). 
 .. warning::
-
-    Python 3.13 is **not yet supported** due to incompatibilities with some dependencies 
-    (e.g., ``cvxopt``).
+      Python 3.13 is not yet due to incompatibilities with some dependencies (e.g., :code:`cvxopt`).
 
 2. Consider using a `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_.
 You can also use :code:`pyenv` with :code:`virtualenv` `to manage different Python versions <https://github.com/pyenv/pyenv-virtualenv>`_. 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -13,6 +13,10 @@ Installing
 
 1. Ensure you have Python 3.10 or greater installed on your machine or in 
 a virtual environment (`pyenv <https://github.com/pyenv/pyenv>`_, `pyenv tutorial <https://realpython.com/intro-to-pyenv/>`_). 
+.. warning::
+
+    Python 3.13 is **not yet supported** due to incompatibilities with some dependencies 
+    (e.g., ``cvxopt``).
 
 2. Consider using a `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_.
 You can also use :code:`pyenv` with :code:`virtualenv` `to manage different Python versions <https://github.com/pyenv/pyenv-virtualenv>`_. 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -15,7 +15,7 @@ Installing
 a virtual environment (`pyenv <https://github.com/pyenv/pyenv>`_, `pyenv tutorial <https://realpython.com/intro-to-pyenv/>`_). 
 
 .. warning::
-    Python 3.13 is not yet due to incompatibilities with some dependencies (e.g., :code:`cvxopt`).
+    Python 3.13 is not yet supported due to incompatibilities with some dependencies (e.g., :code:`cvxopt`).
 
 2. Consider using a `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_.
 You can also use :code:`pyenv` with :code:`virtualenv` `to manage different Python versions <https://github.com/pyenv/pyenv-virtualenv>`_. 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -13,8 +13,9 @@ Installing
 
 1. Ensure you have Python 3.10 or greater installed on your machine or in 
 a virtual environment (`pyenv <https://github.com/pyenv/pyenv>`_, `pyenv tutorial <https://realpython.com/intro-to-pyenv/>`_). 
+
 .. warning::
-      Python 3.13 is not yet due to incompatibilities with some dependencies (e.g., :code:`cvxopt`).
+    Python 3.13 is not yet due to incompatibilities with some dependencies (e.g., :code:`cvxopt`).
 
 2. Consider using a `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_.
 You can also use :code:`pyenv` with :code:`virtualenv` `to manage different Python versions <https://github.com/pyenv/pyenv-virtualenv>`_. 


### PR DESCRIPTION
## Description
As described in #1150, installation of toqito with python 3.13 fails due to cvxopt. Until fixed, this problem will now be mentioned in the documentation under "getting started" and "contributing guide" to simplify installation.

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [ ] Pointing out python 3.13 is not supported in "Getting started" and "contributing guide"

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [ ] Use `ruff` for errors related to code style and formatting.
  -  [ ] Verify all previous and newly added unit tests pass in `pytest`.
  -  [ ] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [ ] Use `linkcheck` to check for broken links in the documentation
  -  [ ] Use `doctest` to verify the examples in the function docstrings work as expected.
