### PR TITLE
fix: enforce strict positivity in is_totally_positive and update tests

### DIFF
--- a/toqito/matrix_props/is_totally_positive.py
+++ b/toqito/matrix_props/is_totally_positive.py
@@ -75,6 +75,6 @@ def is_totally_positive(mat: np.ndarray, tol: float = 1e-6, sub_sizes: list | No
             for kr in sub_ind_r:
                 for kc in sub_ind_c:
                     d = np.linalg.det(mat[np.ix_(kr, kc)])
-                    if d < -tol or abs(np.imag(d)) > tol:
+                    if d < tol or abs(np.imag(d)) > tol:
                         return False
     return True

--- a/toqito/matrix_props/tests/test_is_totally_positive.py
+++ b/toqito/matrix_props/tests/test_is_totally_positive.py
@@ -27,8 +27,10 @@ from toqito.matrix_props import is_totally_positive
         (np.array([[1, 2], [3, 4 - 1e-10]]), 1e-9, None, False),
         # Test a matrix that is just a single row or column.
         (np.array([[1, 2, 3]]), 1e-6, None, True),
-        # Test the identity matrix, which should be totally positive.
-        (np.identity(3), 1e-6, None, True),
+        # Test the identity matrix, which is not totally positive.
+        (np.identity(3), 1e-6, None, False),
+        # Test a matrix with a zero determinant.
+        (np.array([[1, 2], [2, 4]]), 1e-6, None, False),
     ],
 )
 def test_is_totally_positive(mat, tol, sub_sizes, expected_result):


### PR DESCRIPTION
## Description
Modifies `is_totally_positive.py` and its corresponding test file to ensure strict positivity of all minors.  
Closes #1098.

## Changes
  - Adjusts test case for identity matrix (identity matrix has minors equal to 0, so it's not totally positive)
  - Adds new test case: 2x2 matrix with zero determinant
  - Updates logic in `is_totally_positive.py` (line 78) to enforce strict positivity 

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [x] Use `linkcheck` to check for broken links in the documentation
  -  [x] Use `doctest` to verify the examples in the function docstrings work as expected.
