### PR TITLE
fix: fixing ruff lint style in fourier

### DIFF
--- a/toqito/matrices/fourier.py
+++ b/toqito/matrices/fourier.py
@@ -49,6 +49,7 @@ def fourier(dim: int) -> np.ndarray:
 
     :param dim: The size of the Fourier matrix.
     :return: The Fourier matrix of dimension :code:`dim`.
+
     """
     # Primitive root of unity.
     root_unity = np.exp(2 * 1j * np.pi / dim)


### PR DESCRIPTION
Looks like a few minor lint errors snuck in from https://github.com/vprusso/toqito/pull/1151