### PR TITLE
Flat list of Kraus operators is possible as input for kraus_to_choi

### DIFF
--- a/toqito/channel_ops/kraus_to_choi.py
+++ b/toqito/channel_ops/kraus_to_choi.py
@@ -16,7 +16,7 @@ def kraus_to_choi(kraus_ops: list[list[np.ndarray]], sys: int = 2) -> np.ndarray
     that the Choi matrix is the result of applying the map to the second subsystem of the
     standard maximally entangled (unnormalized) state. The Kraus operators are expected to be
     input as a list of numpy arrays (i.e. [[:math:`A_1`, :math:`B_1`],...,[:math:`A_n`, :math:`B_n`]]).
-    In case the map is CP (completely positive), it suffices to input a flat list of operators omitting 
+    In case the map is CP (completely positive), it suffices to input a flat list of operators omitting
     their conjugate transpose (i.e. [:math:`K_1`,..., :math:`K_n`]).
 
     This function was adapted from the QETLAB package.

--- a/toqito/channel_ops/kraus_to_choi.py
+++ b/toqito/channel_ops/kraus_to_choi.py
@@ -15,7 +15,7 @@ def kraus_to_choi(kraus_ops: list[list[np.ndarray]], sys: int = 2) -> np.ndarray
     The Choi matrix of the list of Kraus operators, :code:`kraus_ops`. The default convention is
     that the Choi matrix is the result of applying the map to the second subsystem of the
     standard maximally entangled (unnormalized) state. The Kraus operators are expected to be
-    input as a list of numpy arrays (i.e. [[:math:`A_1`, :math:`B_1`],...,[:math:`A_n`, :math:`B_n`]]). 
+    input as a list of numpy arrays (i.e. [[:math:`A_1`, :math:`B_1`],...,[:math:`A_n`, :math:`B_n`]]).
     In case the map is CP (completely positive), it suffices to input a flat list of operators omitting 
     their conjugate transpose (i.e. [:math:`K_1`,..., :math:`K_n`]).
 
@@ -26,7 +26,8 @@ def kraus_to_choi(kraus_ops: list[list[np.ndarray]], sys: int = 2) -> np.ndarray
 
     The transpose map:
 
-    The Choi matrix of the transpose map is the swap operator. Notice that the transpose map is *not* completely positive.
+    The Choi matrix of the transpose map is the swap operator. Notice that the transpose map
+    is *not* completely positive.
 
     >>> import numpy as np
     >>> from toqito.channel_ops import kraus_to_choi

--- a/toqito/channel_ops/kraus_to_choi.py
+++ b/toqito/channel_ops/kraus_to_choi.py
@@ -15,7 +15,7 @@ def kraus_to_choi(kraus_ops: list[list[np.ndarray]], sys: int = 2) -> np.ndarray
     The Choi matrix of the list of Kraus operators, :code:`kraus_ops`. The default convention is
     that the Choi matrix is the result of applying the map to the second subsystem of the
     standard maximally entangled (unnormalized) state. The Kraus operators are expected to be
-    input as a list of numpy arrays (i.e. [[:math:`A_1`, :math:`B_1`],...,[:math:`A_n`, :math:`B_n`]]).
+    input as a list of numpy arrays (i.e. [[:code:`A_1`, :code:`B_1`],...,[:code:`A_n`, :code:`B_n`]]).
     In case the map is CP (completely positive), it suffices to input a flat list of operators omitting
     their conjugate transpose (i.e. [:math:`K_1`,..., :math:`K_n`]).
 

--- a/toqito/channel_ops/kraus_to_choi.py
+++ b/toqito/channel_ops/kraus_to_choi.py
@@ -15,9 +15,9 @@ def kraus_to_choi(kraus_ops: list[list[np.ndarray]], sys: int = 2) -> np.ndarray
     The Choi matrix of the list of Kraus operators, :code:`kraus_ops`. The default convention is
     that the Choi matrix is the result of applying the map to the second subsystem of the
     standard maximally entangled (unnormalized) state. The Kraus operators are expected to be
-    input as a list of numpy arrays (i.e. [[:math:`A_1`,:math:`B_1`],...,[:math:`A_n`,:math:`B_n`]]). 
+    input as a list of numpy arrays (i.e. [[:math:`A_1`, :math:`B_1`],...,[:math:`A_n`, :math:`B_n`]]). 
     In case the map is CP (completely positive), it suffices to input a flat list of operators omitting 
-    their conjugate transpose (i.e. [:math:`K_1`,...,:math:`K_n`]).
+    their conjugate transpose (i.e. [:math:`K_1`,..., :math:`K_n`]).
 
     This function was adapted from the QETLAB package.
 

--- a/toqito/channel_ops/kraus_to_choi.py
+++ b/toqito/channel_ops/kraus_to_choi.py
@@ -15,7 +15,9 @@ def kraus_to_choi(kraus_ops: list[list[np.ndarray]], sys: int = 2) -> np.ndarray
     The Choi matrix of the list of Kraus operators, :code:`kraus_ops`. The default convention is
     that the Choi matrix is the result of applying the map to the second subsystem of the
     standard maximally entangled (unnormalized) state. The Kraus operators are expected to be
-    input as a list of numpy arrays.
+    input as a list of numpy arrays (i.e. [[:math:`A_1`,:math:`B_1`],...,[:math:`A_n`,:math:`B_n`]]). 
+    In case the map is CP (completely positive), it suffices to input a flat list of operators omitting 
+    their conjugate transpose (i.e. [:math:`K_1`,...,:math:`K_n`]).
 
     This function was adapted from the QETLAB package.
 
@@ -24,7 +26,7 @@ def kraus_to_choi(kraus_ops: list[list[np.ndarray]], sys: int = 2) -> np.ndarray
 
     The transpose map:
 
-    The Choi matrix of the transpose map is the swap operator.
+    The Choi matrix of the transpose map is the swap operator. Notice that the transpose map is *not* completely positive.
 
     >>> import numpy as np
     >>> from toqito.channel_ops import kraus_to_choi


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->
A small addition to the documentation of "kraus_to_choi" clarifies that it's sufficient to only input Kraus operators without their conjugate transpose for CP. This effectively closes issues #79 and #74.

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [ ] See above.

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [ ] Use `ruff` for errors related to code style and formatting.
  -  [ ] Verify all previous and newly added unit tests pass in `pytest`.
  -  [ ] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [ ] Use `linkcheck` to check for broken links in the documentation
  -  [ ] Use `doctest` to verify the examples in the function docstrings work as expected.
