### PR TITLE
Fixed random_ginibre.py

### DIFF
--- a/toqito/rand/random_ginibre.py
+++ b/toqito/rand/random_ginibre.py
@@ -40,7 +40,7 @@ def random_ginibre(dim_n: int, dim_m: int, seed: int | None = None) -> np.ndarra
     :param dim_n: The number of rows of the Ginibre random matrix.
     :param dim_m: The number of columns of the Ginibre random matrix.
     :param seed: A seed used to instantiate numpy's random number generator.
-    :return: A :code:`dim_n`-by-:code:`dim_m` Ginibre random density matrix.
+    :return: A :code:`dim_n`-by-:code:`dim_m` Ginibre random matrix.
 
     """
     gen = np.random.default_rng(seed=seed)


### PR DESCRIPTION
## Description
Fixes a misleading return docstring in the ```random_ginibre``` function that incorrectly labels the output as a "density matrix" instead of a "Ginibre random matrix. Fixes #1157 

## Changes


  -  [x] Updated the return docstring in ```random_ginibre``` to correctly state the output is a "Ginibre random matrix"


## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [ ] Use `ruff` for errors related to code style and formatting.
  -  [ ] Verify all previous and newly added unit tests pass in `pytest`.
  -  [ ] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
  -  [ ] Use `linkcheck` to check for broken links in the documentation
  -  [ ] Use `doctest` to verify the examples in the function docstrings work as expected.
