### PR TITLE
chore: normalize coeffs if not normalized.

### DIFF
--- a/toqito/states/ghz.py
+++ b/toqito/states/ghz.py
@@ -81,11 +81,11 @@ def ghz(dim: int, num_qubits: int, coeff: list[int] | None = None) -> np.ndarray
         coeff = coeff / norm
 
     # Initialize the GHZ state vector.
-    ghz_state = np.zeros((dim ** num_qubits, 1))
+    ghz_state = np.zeros((dim**num_qubits, 1))
     # Fill the state vector with the corresponding coefficients.
     for i in range(dim):
         # Calculate the index for the tensor product state |i, i, ..., i>.
-        index = sum(i * (dim ** k) for k in range(num_qubits))
+        index = sum(i * (dim**k) for k in range(num_qubits))
         ghz_state[index] = coeff[i]
 
     return ghz_state

--- a/toqito/states/ghz.py
+++ b/toqito/states/ghz.py
@@ -63,23 +63,29 @@ def ghz(dim: int, num_qubits: int, coeff: list[int] | None = None) -> np.ndarray
     :returns: Numpy vector array as GHZ state.
 
     """
-    if coeff is None:
-        coeff = np.ones(dim) / np.sqrt(dim)
-
-    # Error checking:
     if dim < 1:
         raise ValueError("InvalidDim: `dim` must be at least 1.")
     if num_qubits < 1:
         raise ValueError("InvalidNumQubits: `num_qubits` must be at least 1.")
+    
+    if coeff is None:
+        coeff = np.ones(dim)
+    else:
+        coeff = np.array(coeff)
     if len(coeff) != dim:
         raise ValueError("InvalidCoeff: The variable `coeff` must be a vector of length equal to `dim`.")
+    
+    # Normalize coefficients if they are not.
+    norm = np.linalg.norm(coeff)
+    if not np.isclose(norm, 1.0):
+        coeff = coeff / norm
 
     # Initialize the GHZ state vector.
-    ret_ghz_state = np.zeros((dim**num_qubits, 1))
-
-    # Fill the GHZ state vector with the appropriate coefficients.
+    ghz_state = np.zeros((dim ** num_qubits, 1))
+    # Fill the state vector with the corresponding coefficients.
     for i in range(dim):
-        index = sum(i * dim**k for k in range(num_qubits))
-        ret_ghz_state[index] = coeff[i]
+        # Calculate the index for the tensor product state |i, i, ..., i>.
+        index = sum(i * (dim ** k) for k in range(num_qubits))
+        ghz_state[index] = coeff[i]
 
-    return ret_ghz_state
+    return ghz_state

--- a/toqito/states/ghz.py
+++ b/toqito/states/ghz.py
@@ -67,14 +67,14 @@ def ghz(dim: int, num_qubits: int, coeff: list[int] | None = None) -> np.ndarray
         raise ValueError("InvalidDim: `dim` must be at least 1.")
     if num_qubits < 1:
         raise ValueError("InvalidNumQubits: `num_qubits` must be at least 1.")
-    
+
     if coeff is None:
         coeff = np.ones(dim)
     else:
         coeff = np.array(coeff)
     if len(coeff) != dim:
         raise ValueError("InvalidCoeff: The variable `coeff` must be a vector of length equal to `dim`.")
-    
+
     # Normalize coefficients if they are not.
     norm = np.linalg.norm(coeff)
     if not np.isclose(norm, 1.0):

--- a/toqito/states/tests/test_ghz.py
+++ b/toqito/states/tests/test_ghz.py
@@ -1,4 +1,5 @@
 """Test ghz."""
+
 import numpy as np
 import pytest
 
@@ -17,7 +18,8 @@ e2_4 = np.array([[0], [0], [1], [0]])
 e3_4 = np.array([[0], [0], [0], [1]])
 # Pre-computed expected GHZ state for 7 qudits in C^4: 1/sqrt(30) (|0000000> + 2|1111111> + 3|2222222> + 4|3333333>)
 ghz_4_7 = (
-    1 / np.sqrt(30)
+    1
+    / np.sqrt(30)
     * (
         tensor(e0_4, e0_4, e0_4, e0_4, e0_4, e0_4, e0_4)
         + 2 * tensor(e1_4, e1_4, e1_4, e1_4, e1_4, e1_4, e1_4)
@@ -25,6 +27,7 @@ ghz_4_7 = (
         + 4 * tensor(e3_4, e3_4, e3_4, e3_4, e3_4, e3_4, e3_4)
     )
 )
+
 
 @pytest.mark.parametrize(
     "dim, num_qubits, coeff, expected_state",

--- a/toqito/states/tests/test_ghz.py
+++ b/toqito/states/tests/test_ghz.py
@@ -6,43 +6,110 @@ import pytest
 from toqito.matrix_ops import tensor
 from toqito.states import ghz
 
-# Define standard basis vectors for qubits.
 e_0, e_1 = np.array([[1], [0]]), np.array([[0], [1]])
-# Pre-computed expected GHZ state for 3 qubits: 1/sqrt(2) (|000> + |111>)
 ghz_2_3 = 1 / np.sqrt(2) * (tensor(e_0, e_0, e_0) + tensor(e_1, e_1, e_1))
-
-# Define standard basis vectors for qudits in dimension 4.
-e0_4 = np.array([[1], [0], [0], [0]])
-e1_4 = np.array([[0], [1], [0], [0]])
-e2_4 = np.array([[0], [0], [1], [0]])
-e3_4 = np.array([[0], [0], [0], [1]])
-# Pre-computed expected GHZ state for 7 qudits in C^4: 1/sqrt(30) (|0000000> + 2|1111111> + 3|2222222> + 4|3333333>)
-ghz_4_7 = (
-    1
-    / np.sqrt(30)
-    * (
-        tensor(e0_4, e0_4, e0_4, e0_4, e0_4, e0_4, e0_4)
-        + 2 * tensor(e1_4, e1_4, e1_4, e1_4, e1_4, e1_4, e1_4)
-        + 3 * tensor(e2_4, e2_4, e2_4, e2_4, e2_4, e2_4, e2_4)
-        + 4 * tensor(e3_4, e3_4, e3_4, e3_4, e3_4, e3_4, e3_4)
-    )
-)
 
 
 @pytest.mark.parametrize(
-    "dim, num_qubits, coeff, expected_state",
+    "dim, num_qubits, coeff, expected_res",
     [
-        # Test the standard 3-qubit GHZ state using the default normalized coefficients.
+        # Produces the 3-qubit GHZ state: `1/sqrt(2) * (|000> + |111>)`.
         (2, 3, None, ghz_2_3),
-        # Test the same 3-qubit GHZ state when non-normalized coefficients are provided.
-        (2, 3, [2, 2], ghz_2_3),
-        # Test the 7-qudit (dim=4) GHZ state with already normalized coefficients.
-        (4, 7, np.array([1, 2, 3, 4]) / np.sqrt(30), ghz_4_7),
-        # Test the same 7-qudit state when non-normalized coefficients are provided.
-        (4, 7, [1, 2, 3, 4], ghz_4_7),
     ],
 )
-def test_ghz_valid_inputs(dim, num_qubits, coeff, expected_state):
-    """Test that ghz returns the expected state regardless of input coefficient normalization."""
-    result = ghz(dim, num_qubits, coeff)
+def test_ghz(dim, num_qubits, coeff, expected_res):
+    """Test function works as expected for a valid input."""
+    res = ghz(dim, num_qubits, coeff)
+    np.testing.assert_allclose(res, expected_res)
+
+
+def test_ghz_4_7():
+    r"""The following generates the following GHZ state in `(C^4)^{\otimes 7}`.
+
+    `1/sqrt(30) * (|0000000> + 2|1111111> + 3|2222222> + 4|3333333>)`.
+    """
+    e0_4 = np.array([[1], [0], [0], [0]])
+    e1_4 = np.array([[0], [1], [0], [0]])
+    e2_4 = np.array([[0], [0], [1], [0]])
+    e3_4 = np.array([[0], [0], [0], [1]])
+
+    expected_res = (
+        1
+        / np.sqrt(30)
+        * (
+            tensor(e0_4, e0_4, e0_4, e0_4, e0_4, e0_4, e0_4)
+            + 2 * tensor(e1_4, e1_4, e1_4, e1_4, e1_4, e1_4, e1_4)
+            + 3 * tensor(e2_4, e2_4, e2_4, e2_4, e2_4, e2_4, e2_4)
+            + 4 * tensor(e3_4, e3_4, e3_4, e3_4, e3_4, e3_4, e3_4)
+        )
+    )
+
+    res = ghz(4, 7, np.array([1, 2, 3, 4]) / np.sqrt(30))
+    np.testing.assert_allclose(res, expected_res)
+
+
+@pytest.mark.parametrize(
+    "dim, num_qubits, coeff",
+    [
+        # Invalid dimensions.
+        (0, 2, None),
+        # Invalid qubits.
+        (2, 0, None),
+        # Invalid coefficients.
+        (2, 3, [1, 2, 3, 4, 5]),
+    ],
+)
+def test_ghz_invalid_input(dim, num_qubits, coeff):
+    """Tests for invalid dimensions."""
+    with np.testing.assert_raises(ValueError):
+        ghz(dim, num_qubits, coeff)
+
+
+def test_ghz_non_normalized_coeff_2_3():
+    """Test that non-normalized coefficients for a 3-qubit GHZ state are normalized correctly.
+
+    We pass [2, 2] instead of the normalized [1/sqrt(2), 1/sqrt(2)].
+    """
+    # For 3-qubit with dim=2, [2,2] has norm 2*sqrt(2) which normalizes to [1/sqrt(2), 1/sqrt(2)].
+    dim = 2
+    num_qubits = 3
+    non_normalized_coeff = [2, 2]
+
+    # Expected state is the standard GHZ state: 1/sqrt(2) (|000> + |111>).
+    expected_state = ghz_2_3
+    result = ghz(dim, num_qubits, non_normalized_coeff)
+    np.testing.assert_allclose(result, expected_state)
+
+
+def test_ghz_non_normalized_coeff_4_7():
+    r"""Test that non-normalized coefficients are normalized correctly.
+
+    We pass [1, 2, 3, 4] instead of the normalized [1,2,3,4]/sqrt(30).
+    The expected state is
+    \[
+        \frac{1}{\sqrt{30}} \left(|0000000\rangle + 2|1111111\rangle + 3|2222222\rangle + 4|3333333\rangle\right).
+    \]
+    """
+    dim = 4
+    num_qubits = 7
+    # Non-normalized coefficients.
+    non_normalized_coeff = [1, 2, 3, 4]
+    # Compute normalization factor.
+    normalized_coeff = np.array(non_normalized_coeff) / np.linalg.norm(non_normalized_coeff)
+
+    # Define the standard basis vectors for C^4.
+    e0_4 = np.array([[1], [0], [0], [0]])
+    e1_4 = np.array([[0], [1], [0], [0]])
+    e2_4 = np.array([[0], [0], [1], [0]])
+    e3_4 = np.array([[0], [0], [0], [1]])
+
+    # Build the expected GHZ state using the normalized coefficients.
+    expected_state = (
+        normalized_coeff[0] * tensor(e0_4, e0_4, e0_4, e0_4, e0_4, e0_4, e0_4)
+        + normalized_coeff[1] * tensor(e1_4, e1_4, e1_4, e1_4, e1_4, e1_4, e1_4)
+        + normalized_coeff[2] * tensor(e2_4, e2_4, e2_4, e2_4, e2_4, e2_4, e2_4)
+        + normalized_coeff[3] * tensor(e3_4, e3_4, e3_4, e3_4, e3_4, e3_4, e3_4)
+    )
+
+    result = ghz(dim, num_qubits, non_normalized_coeff)
     np.testing.assert_allclose(result, expected_state)

--- a/toqito/states/tests/test_ghz.py
+++ b/toqito/states/tests/test_ghz.py
@@ -1,65 +1,45 @@
 """Test ghz."""
-
 import numpy as np
 import pytest
 
 from toqito.matrix_ops import tensor
 from toqito.states import ghz
 
+# Define standard basis vectors for qubits.
 e_0, e_1 = np.array([[1], [0]]), np.array([[0], [1]])
+# Pre-computed expected GHZ state for 3 qubits: 1/sqrt(2) (|000> + |111>)
 ghz_2_3 = 1 / np.sqrt(2) * (tensor(e_0, e_0, e_0) + tensor(e_1, e_1, e_1))
 
-
-@pytest.mark.parametrize(
-    "dim, num_qubits, coeff, expected_res",
-    [
-        # Produces the 3-qubit GHZ state: `1/sqrt(2) * (|000> + |111>)`.
-        (2, 3, None, ghz_2_3),
-    ],
-)
-def test_ghz(dim, num_qubits, coeff, expected_res):
-    """Test function works as expected for a valid input."""
-    res = ghz(dim, num_qubits, coeff)
-    np.testing.assert_allclose(res, expected_res)
-
-
-def test_ghz_4_7():
-    r"""The following generates the following GHZ state in `(C^4)^{\otimes 7}`.
-
-    `1/sqrt(30) * (|0000000> + 2|1111111> + 3|2222222> + 4|3333333>)`.
-    """
-    e0_4 = np.array([[1], [0], [0], [0]])
-    e1_4 = np.array([[0], [1], [0], [0]])
-    e2_4 = np.array([[0], [0], [1], [0]])
-    e3_4 = np.array([[0], [0], [0], [1]])
-
-    expected_res = (
-        1
-        / np.sqrt(30)
-        * (
-            tensor(e0_4, e0_4, e0_4, e0_4, e0_4, e0_4, e0_4)
-            + 2 * tensor(e1_4, e1_4, e1_4, e1_4, e1_4, e1_4, e1_4)
-            + 3 * tensor(e2_4, e2_4, e2_4, e2_4, e2_4, e2_4, e2_4)
-            + 4 * tensor(e3_4, e3_4, e3_4, e3_4, e3_4, e3_4, e3_4)
-        )
+# Define standard basis vectors for qudits in dimension 4.
+e0_4 = np.array([[1], [0], [0], [0]])
+e1_4 = np.array([[0], [1], [0], [0]])
+e2_4 = np.array([[0], [0], [1], [0]])
+e3_4 = np.array([[0], [0], [0], [1]])
+# Pre-computed expected GHZ state for 7 qudits in C^4: 1/sqrt(30) (|0000000> + 2|1111111> + 3|2222222> + 4|3333333>)
+ghz_4_7 = (
+    1 / np.sqrt(30)
+    * (
+        tensor(e0_4, e0_4, e0_4, e0_4, e0_4, e0_4, e0_4)
+        + 2 * tensor(e1_4, e1_4, e1_4, e1_4, e1_4, e1_4, e1_4)
+        + 3 * tensor(e2_4, e2_4, e2_4, e2_4, e2_4, e2_4, e2_4)
+        + 4 * tensor(e3_4, e3_4, e3_4, e3_4, e3_4, e3_4, e3_4)
     )
-
-    res = ghz(4, 7, np.array([1, 2, 3, 4]) / np.sqrt(30))
-    np.testing.assert_allclose(res, expected_res)
-
+)
 
 @pytest.mark.parametrize(
-    "dim, num_qubits, coeff",
+    "dim, num_qubits, coeff, expected_state",
     [
-        # Invalid dimensions.
-        (0, 2, None),
-        # Invalid qubits.
-        (2, 0, None),
-        # Invalid coefficients.
-        (2, 3, [1, 2, 3, 4, 5]),
+        # Test the standard 3-qubit GHZ state using the default normalized coefficients.
+        (2, 3, None, ghz_2_3),
+        # Test the same 3-qubit GHZ state when non-normalized coefficients are provided.
+        (2, 3, [2, 2], ghz_2_3),
+        # Test the 7-qudit (dim=4) GHZ state with already normalized coefficients.
+        (4, 7, np.array([1, 2, 3, 4]) / np.sqrt(30), ghz_4_7),
+        # Test the same 7-qudit state when non-normalized coefficients are provided.
+        (4, 7, [1, 2, 3, 4], ghz_4_7),
     ],
 )
-def test_ghz_invalid_input(dim, num_qubits, coeff):
-    """Tests for invalid dimensions."""
-    with np.testing.assert_raises(ValueError):
-        ghz(dim, num_qubits, coeff)
+def test_ghz_valid_inputs(dim, num_qubits, coeff, expected_state):
+    """Test that ghz returns the expected state regardless of input coefficient normalization."""
+    result = ghz(dim, num_qubits, coeff)
+    np.testing.assert_allclose(result, expected_state)

--- a/toqito/states/w_state.py
+++ b/toqito/states/w_state.py
@@ -96,11 +96,11 @@ def w_state(num_qubits: int, coeff: list[int] = None) -> np.ndarray:
         coeff = coeff / norm
 
     # Initialize a state vector of appropriate size.
-    ret_w_state = csr_array((2 ** num_qubits, 1)).toarray()
+    ret_w_state = csr_array((2**num_qubits, 1)).toarray()
     # Fill the vector so that the state has the single excitation distributed according to coeff.
     # Note: The ordering assumes that the binary representation corresponds to qubits in little-endian order.
     for i in range(num_qubits):
         # The position for an excitation on qubit i is at index 2**i.
         # We assign the coefficient to the position corresponding to an excitation in that qubit.
-        ret_w_state[2 ** i] = coeff[num_qubits - i - 1]
+        ret_w_state[2**i] = coeff[num_qubits - i - 1]
     return np.around(ret_w_state, 4)

--- a/toqito/states/w_state.py
+++ b/toqito/states/w_state.py
@@ -81,17 +81,26 @@ def w_state(num_qubits: int, coeff: list[int] = None) -> np.ndarray:
                   1-by-`num_qubts` vector of coefficients.
 
     """
-    if coeff is None:
-        coeff = np.ones(num_qubits) / np.sqrt(num_qubits)
-
     if num_qubits < 2:
         raise ValueError("InvalidNumQubits: `num_qubits` must be at least 2.")
+    if coeff is None:
+        coeff = np.ones(num_qubits)
+    else:
+        coeff = np.array(coeff)
     if len(coeff) != num_qubits:
         raise ValueError("InvalidCoeff: The variable `coeff` must be a vector of length equal to `num_qubits`.")
 
-    ret_w_state = csr_array((2**num_qubits, 1)).toarray()
+    # Normalize coefficients if necessary.
+    norm = np.linalg.norm(coeff)
+    if not np.isclose(norm, 1.0):
+        coeff = coeff / norm
 
+    # Initialize a state vector of appropriate size.
+    ret_w_state = csr_array((2 ** num_qubits, 1)).toarray()
+    # Fill the vector so that the state has the single excitation distributed according to coeff.
+    # Note: The ordering assumes that the binary representation corresponds to qubits in little-endian order.
     for i in range(num_qubits):
-        ret_w_state[2**i] = coeff[num_qubits - i - 1]
-
+        # The position for an excitation on qubit i is at index 2**i.
+        # We assign the coefficient to the position corresponding to an excitation in that qubit.
+        ret_w_state[2 ** i] = coeff[num_qubits - i - 1]
     return np.around(ret_w_state, 4)


### PR DESCRIPTION
Closes: #1125 

- Checks if sum of `coeff` list for `ghz.py` and `w_state.py` is close to `1.0`. If not, normalization is carried out.

If this is merged, we can also close out: https://github.com/vprusso/toqito/pull/1127