### PR TITLE
fix: update np testing for rand functions.

### DIFF
--- a/toqito/rand/random_density_matrix.py
+++ b/toqito/rand/random_density_matrix.py
@@ -116,6 +116,6 @@ def random_density_matrix(
     if distance_metric == "bures":
         gin = random_unitary(dim, is_real, seed=seed) + np.identity(dim) @ gin
 
-    rho = gin @ np.array(gin).conj().T
+    rho = gin @ gin.conj().T
 
     return np.divide(rho, np.trace(rho))

--- a/toqito/rand/tests/test_random_circulant_gram_matrix.py
+++ b/toqito/rand/tests/test_random_circulant_gram_matrix.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal, assert_equal
+from numpy.testing import assert_allclose, assert_equal
 
 from toqito.rand.random_circulant_gram_matrix import random_circulant_gram_matrix
 
@@ -29,7 +29,7 @@ def test_random_circulant_gram_matrix(dim):
     assert_equal(circulant_matrix.shape, (dim, dim))
 
     # Check that the matrix is symmetric.
-    assert_array_almost_equal(circulant_matrix, circulant_matrix.T)
+    assert_allclose(circulant_matrix, circulant_matrix.T)
 
     # Check that the matrix is real.
     assert_equal(np.isreal(circulant_matrix).all(), True)
@@ -37,7 +37,7 @@ def test_random_circulant_gram_matrix(dim):
     # Check that the matrix is positive semi-definite by verifying
     # all eigenvalues are non-negative.
     eigenvalues = np.linalg.eigvalsh(circulant_matrix)
-    assert_array_almost_equal((eigenvalues >= 0), True)
+    assert_allclose((eigenvalues >= 0), True)
 
 
 @pytest.mark.parametrize(
@@ -61,4 +61,4 @@ def test_random_circulant_gram_matrix(dim):
 def test_random_circulant_gram_matrix_with_seed(dim, expected):
     """Test that the random_circulant_gram_matrix produces expected inputs with a seed."""
     mat = random_circulant_gram_matrix(dim, seed=123)
-    assert_array_almost_equal(mat, expected)
+    assert_allclose(mat, expected)

--- a/toqito/rand/tests/test_random_density_matrix.py
+++ b/toqito/rand/tests/test_random_density_matrix.py
@@ -2,7 +2,8 @@
 
 import numpy as np
 import pytest
-from numpy.ma.testutils import assert_array_almost_equal
+from numpy.testing import assert_allclose
+
 
 from toqito.matrix_props import is_density, is_positive_semidefinite
 from toqito.rand import random_density_matrix
@@ -79,4 +80,4 @@ def test_random_density_matrix(dim, is_real, distance_metric):
 def test_seed(dim, is_real, k_param, distance_metric, expected):
     """Test that the function produces the expected output using a seed."""
     dm = random_density_matrix(dim, is_real, k_param=k_param, distance_metric=distance_metric, seed=124)
-    assert_array_almost_equal(dm, expected)
+    assert_allclose(dm, expected)

--- a/toqito/rand/tests/test_random_ginibre.py
+++ b/toqito/rand/tests/test_random_ginibre.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from numpy.ma.testutils import assert_array_almost_equal
+from numpy.testing import assert_allclose
 
 from toqito.rand import random_ginibre
 
@@ -43,7 +43,7 @@ def test_random_ginibre_dims(dim_n, dim_m):
 def test_seed(dim_n, dim_m, expected):
     """Test that the function returns the expected output when seeded."""
     gin_mat = random_ginibre(dim_n, dim_m, seed=123)
-    assert_array_almost_equal(gin_mat, expected)
+    assert_allclose(gin_mat, expected)
 
 
 @pytest.mark.parametrize(

--- a/toqito/rand/tests/test_random_orthonormal_basis.py
+++ b/toqito/rand/tests/test_random_orthonormal_basis.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from numpy.ma.testutils import assert_array_almost_equal
+from numpy.testing import assert_allclose
 
 from toqito.matrix_props import is_orthonormal
 from toqito.rand import random_orthonormal_basis
@@ -34,4 +34,4 @@ def test_random_orth_basis_int_dim(input_dim, bool):
 def test_seed(dim, is_real, expected):
     """Test that the function returns the expected output when seeded."""
     basis = random_orthonormal_basis(dim, is_real, seed=124)
-    assert_array_almost_equal(basis, expected)
+    assert_allclose(basis, expected, rtol=1e-05)

--- a/toqito/rand/tests/test_random_povm.py
+++ b/toqito/rand/tests/test_random_povm.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from numpy.ma.testutils import assert_array_almost_equal
+from numpy.testing import assert_allclose
 
 from toqito.rand import random_povm
 
@@ -52,4 +52,4 @@ def test_random_povm_validity(dim, num_inputs, num_outputs):
 def test_seed(dim, num_inputs, num_outputs, expected):
     """Test that the function returns the expected output when seeded."""
     povms = random_povm(dim=dim, num_inputs=num_inputs, num_outputs=num_outputs, seed=123)
-    assert_array_almost_equal(povms, expected)
+    assert_allclose(povms, expected, rtol=1e-05)

--- a/toqito/rand/tests/test_random_psd_operator.py
+++ b/toqito/rand/tests/test_random_psd_operator.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal, assert_equal
+from numpy.testing import assert_allclose, assert_equal
 
 from toqito.matrix_props import is_positive_semidefinite
 from toqito.rand import random_psd_operator
@@ -78,4 +78,4 @@ def test_random_psd_operator(dim, is_real):
 def test_random_psd_operator_with_seed(dim, is_real, seed, expected_mat):
     """Test that random_psd_operator function returns the expected output when seeded."""
     matrix = random_psd_operator(dim, is_real, seed)
-    assert_array_almost_equal(matrix, expected_mat, decimal=5)
+    assert_allclose(matrix, expected_mat)

--- a/toqito/rand/tests/test_random_state_vector.py
+++ b/toqito/rand/tests/test_random_state_vector.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from numpy.ma.testutils import assert_array_almost_equal
+from numpy.testing import assert_allclose
 
 from toqito.rand import random_state_vector
 from toqito.state_props import is_pure
@@ -68,4 +68,4 @@ def test_random_state_vector(dim, is_real, k_param):
 def test_seed(dim, is_real, k_param, expected):
     """Test that the function returns the expected output when seeded."""
     vec = random_state_vector(dim, is_real=is_real, k_param=k_param, seed=123)
-    assert_array_almost_equal(vec, expected)
+    assert_allclose(vec, expected)

--- a/toqito/rand/tests/test_random_states.py
+++ b/toqito/rand/tests/test_random_states.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from numpy.ma.testutils import assert_array_almost_equal
+from numpy.testing import assert_allclose
 
 from toqito.rand import random_states
 from toqito.state_props import is_pure
@@ -99,4 +99,4 @@ def test_seed(num_states, dim, expected):
     assert len(states) == len(expected)
 
     for state, expected_state in zip(states, expected):
-        assert_array_almost_equal(state, expected_state)
+        assert_allclose(state, expected_state)

--- a/toqito/rand/tests/test_random_unitary.py
+++ b/toqito/rand/tests/test_random_unitary.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from numpy.ma.testutils import assert_array_almost_equal
+from numpy.testing import assert_allclose
 
 from toqito.matrix_props import is_unitary
 from toqito.rand import random_unitary
@@ -55,4 +55,4 @@ def test_non_square_dims(dim_n, dim_m, is_real):
 def test_seed(dim, is_real, expected):
     """Test that the function returns the expected output when seeded."""
     mat = random_unitary(dim=dim, is_real=is_real, seed=124)
-    assert_array_almost_equal(mat, expected)
+    assert_allclose(mat, expected, rtol=1e-05)


### PR DESCRIPTION
Closes: #1166 

The `assert_array_almost_equal` function is internally written in such a way that it converts its inputs to a real type before the comparison. 

When the output density matrix is complex (even if some entries have zero imaginary parts) and it is compared to an expected complex (or sometimes a real) array, the internal conversion may discard the imaginary part. This triggers the warning about “casting complex values to real.”


