### PR TITLE
fix: warning for solver solution channel fidelity.

### DIFF
--- a/toqito/channel_metrics/channel_fidelity.py
+++ b/toqito/channel_metrics/channel_fidelity.py
@@ -6,7 +6,7 @@ import numpy as np
 from toqito.channels import partial_trace
 
 
-def channel_fidelity(choi_1: np.ndarray, choi_2: np.ndarray) -> float:
+def channel_fidelity(choi_1: np.ndarray, choi_2: np.ndarray, eps: float = 1e-7) -> float:
     r"""Compute the channel fidelity between two quantum channels :cite:`Katariya_2021_Geometric`.
 
     Let :math:`\Phi : \text{L}(\mathcal{Y}) \rightarrow \text{L}(\mathcal{X})` and
@@ -71,6 +71,7 @@ def channel_fidelity(choi_1: np.ndarray, choi_2: np.ndarray) -> float:
     :raises ValueError: If matrices are not square.
     :param choi_1: The Choi matrix of the first quantum channel.
     :param choi_2: The Choi matrix of the second quantum channel.
+    :param eps: The solver tolerance for convergence to feasability.
     :return: The channel fidelity between the channels specified by the quantum channels
              corresponding to the Choi matrices :code:`choi_1` and :code:`choi_2`.
 
@@ -97,4 +98,4 @@ def channel_fidelity(choi_1: np.ndarray, choi_2: np.ndarray) -> float:
 
     problem = cvxpy.Problem(objective, constraints)
 
-    return problem.solve(solver="SCS")
+    return problem.solve(solver=cvxpy.SCS, eps=eps)

--- a/toqito/channel_metrics/tests/test_channel_fidelity.py
+++ b/toqito/channel_metrics/tests/test_channel_fidelity.py
@@ -13,24 +13,24 @@ depolarizing_channel = depolarizing(4)
 @pytest.mark.parametrize(
     "input1, input2, expected_value",
     [
-        # fidelity of identical channels
+        # Fidelity of identical channels.
         (dephasing_channel, dephasing_channel, 1),
-        # fidelity of different channels
+        # Fidelity of different channels.
         (dephasing_channel, depolarizing_channel, 1 / 2),
     ],
 )
 def test_channel_fidelity(input1, input2, expected_value):
     """Test functions works as expected for valid inputs."""
-    calculated_value = channel_fidelity(input1, input2)
-    assert pytest.approx(expected_value, 1e-3) == calculated_value
+    calculated_value = channel_fidelity(input1, input2, 1e-4)
+    assert pytest.approx(expected_value, 1e-4) == calculated_value
 
 
 @pytest.mark.parametrize(
     "input1, input2, expected_msg",
     [
-        # Inconsistent dimensions between Choi matrices
+        # Inconsistent dimensions between Choi matrices.
         (depolarizing_channel, depolarizing(2), "The Choi matrices provided should be of equal dimension."),
-        # Non-square inputs for channel fidelity
+        # Non-square inputs for channel fidelity.
         (
             np.array([[1, 2, 3], [4, 5, 6]]),
             np.array([[1, 2, 3], [4, 5, 6]]),


### PR DESCRIPTION
Closes: #1169 

- Added argument to specify `eps` for threshold to attain solver feasibility. 