### PR TITLE
fix: compute generalized inverse sqrt to avoid nans in output matrix.

### DIFF
--- a/toqito/measurements/pretty_good_measurement.py
+++ b/toqito/measurements/pretty_good_measurement.py
@@ -72,5 +72,17 @@ def pretty_good_measurement(states: list[np.ndarray], probs: list[float] | None 
     states = [to_density_matrix(state) for state in states]
     p_var = sum(probs[i] * states[i] for i in range(n))
 
-    p_var_sqrt = scipy.linalg.fractional_matrix_power(p_var, -1 / 2)
+    # Generalized inverse square‐root. This performs a spectral decomposition and inverts only the nonzero 
+    # eigenvalues while leaving the zero subspace alone.
+
+    # Eigen‐decompose.
+    vals, vecs = np.linalg.eigh(p_var)
+
+    # Build Λ^{-1/2} with a threshold.
+    tol = 1e-8
+    inv_sqrt = np.diag([1/np.sqrt(v) if v>tol else 0. for v in vals])
+
+    # Reconstruct.
+    p_var_sqrt = vecs @ inv_sqrt @ vecs.T
+
     return [p_var_sqrt @ (probs[i] * states[i]) @ p_var_sqrt for i in range(n)]


### PR DESCRIPTION
PGM and PBM (for certain values) were causing `nan` outputs in the resulting matrices. Computing a generalized inverse square-root fixes this issue for extreme values. 