### PR TITLE
docs: Add a documentation example in matrix_props.is_totally_positive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,2 @@
-.DS_Store
-.vscode
-.python-version
-.idea/
-.coverage
-*.dat
-*.ipynb
-*.hdf5
-*.ipynb_checkpoints
-*.jupyter_cache
-_build
-__pycache__/
-docs/build/
-toqito.egg-info/
-dist/
-build/
-coverage.xml
-jupyter_execute/
-venv/*
+# Created by venv; see https://docs.python.org/3/library/venv.html
+*

--- a/toqito/matrix_props/is_totally_positive.py
+++ b/toqito/matrix_props/is_totally_positive.py
@@ -40,6 +40,40 @@ def is_totally_positive(mat: np.ndarray, tol: float = 1e-6, sub_sizes: list | No
     .. math::
         \text{det}(X) = 1 \times 4 - 2 \times 3 = 4 - 6 = 2
 
+    Our function indicates that this matrix is indeed totally positive.
+
+    .. jupyter-execute::
+        import numpy as np
+        from toqito.matrix_props import is_totally_positive
+
+        A = np.array([[1, 2], [3, 4]])
+
+        is_totally_positive(A)
+
+    However, the following example matrix :math:`B` defined as
+
+    .. math::
+        B = \begin{pmatrix}
+                1 & 2 \\
+                3 & -4
+            \end{pmatrix}
+
+    is not totally positive. The 2x2 minor of :math:`B` is the determinant of the entire matrix :math:`B`. The
+    determinant of :math:`B` is calculated as:
+
+    .. math::
+        \text{det}(B) = 1 \times -4 - 2 \times 3 = -4 - 6 = -10
+
+    Since the determinant is negative, :math:`B` is not totally positive.
+
+    .. jupyter-execute::
+        import numpy as np
+        from toqito.matrix_props import is_totally_positive
+
+        B = np.array([[1, 2], [3, -4]])
+
+        is_totally_positive(B)
+
     References
     ==========
     .. bibliography::


### PR DESCRIPTION
## Description
Adds the examples on the docstring for the matrix_props.is_totally_possitive function. Closes #1206  

## Changes

  -  [x] Added the Jupyter-execute for the first example already created.
  -  [x] Created another example for when the matrix is not totally positive.
  -  [x] Added the Jupyter-execute for the new example created.

## Checklist

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
