### PR TITLE
Fix docs dependency syntax to use >= instead of ==

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,8 @@
-furo == 2024.8.6
-sphinxcontrib-bibtex == 2.6.3
-sympy == 1.13.3
-matplotlib == 3.10.1
-sphinx-autoapi == 3.5.0
-sphinx-copybutton == 0.5.2
-jupyter-sphinx==0.5.3
-sphinx-gallery == 0.19.0
-
+furo >= 2024.8.6
+sphinxcontrib-bibtex >= 2.6.3
+sympy >= 1.13.3
+matplotlib >= 3.10.1
+sphinx-autoapi >= 3.5.0
+sphinx-copybutton >= 0.5.2
+jupyter-sphinx >= 0.5.3
+sphinx-gallery >= 0.19.0


### PR DESCRIPTION
Fixes #1193

Changed documentation dependency syntax from exact version matching (==) to minimum version specifiers (>=) in `docs/requirements.txt`.

This allows for more flexible dependency management while ensuring minimum required versions are met, following PEP 440 version specifier guidelines.

## Changes
- Updated all 8 dependencies in docs/requirements.txt from `==` to `>=`
- Maintains same minimum version requirements  
- Allows compatible newer versions to be installed 
