### PR TITLE
Fix refs.bib

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -200,17 +200,17 @@ primaryClass = {quant-ph}
 }
 
 @article{Chen_2013_MultipartiteRank4,
-doi = {10.1088/1751-8113/46/27/275304},
-url = {https://dx.doi.org/10.1088/1751-8113/46/27/275304},
-year = {2013},
-month = {jun},
-publisher = {IOP Publishing},
-volume = {46},
-number = {27},
-pages = {275304},
-author = {Chen, Lin and Đoković, Dragomir Ž},
-title = {Separability problem for multipartite states of rank at most 4},
-journal = {Journal of Physics A: Mathematical and Theoretical},
+  title = {Separability problem for multipartite states of rank at most 4},
+  doi = {10.1088/1751-8113/46/27/275304},
+  url = {https://dx.doi.org/10.1088/1751-8113/46/27/275304},
+  year = {2013},
+  month = {jun},
+  publisher = {IOP Publishing},
+  journal = {Journal of Physics A: Mathematical and Theoretical},
+  volume = {46},
+  number = {27},
+  pages = {275304},
+  author = {Chen, Lin and Đoković, Dragomir Ž},
 }
 
 @article{Choi_1992_Generalized,


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->

Fix several issues with `refs.bib` as identified in #1256.

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [x] Fix `Chen_2013_MultipartiteRank4`
  -  [x] Remove duplicate key `Hall_2006_Indecomposable`
  -  [x] Remove all instances of `keywords` and `abstract`

@purva-thakre 