### PR TITLE
Tutorial for PGM and PBM. New bibtex entry for pretty_good_measurement.py

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -46,6 +46,15 @@
   month=jun, pages={3593-3604} 
 }
 
+@article{Belavkin_1975_Optimal,
+  author = {Belavkin, V. P.},
+  title  = {Optimal distinction of non-orthogonal quantum signals},
+  journal = {Radio Engineering and Electronic Physics},
+  volume  = {20},
+  pages   = {39--47},
+  year    = {1975}
+}
+
 @article{Bennett_1992_Communication,
   title = {Communication via one- and two-particle operators on {E}instein-{P}odolsky-{R}osen states},
   author = {Bennett, Charles H. and Wiesner, Stephen J.},
@@ -856,6 +865,19 @@ address = {USA},
   month={Sep}, pages={415301}
 }
 
+@article{LoChau1997,
+  title     = {Is Quantum Bit Commitment Really Possible?},
+  author    = {Hoi-Kwong Lo and H. F. Chau},
+  journal   = {Physical Review Letters},
+  volume    = {78},
+  number    = {17},
+  pages     = {3410--3413},
+  year      = {1997},
+  publisher = {American Physical Society},
+  doi       = {10.1103/PhysRevLett.78.3410},
+  url       = {https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.78.3410}
+}
+
 % Last name begins with M
 @misc{Matsumoto_2010_Reverse,
   title={Reverse test and quantum analogue of classical fidelity and generalized fidelity}, 
@@ -904,6 +926,21 @@ address = {USA},
   eprint={1202.4010},
   archivePrefix={arXiv},
   primaryClass={quant-ph}
+}
+
+@article{Mayers_1997_Unconditionally,
+  title={Unconditionally Secure Quantum Bit Commitment is Impossible},
+  author={Mayers, Dominic},
+  journal={Phys. Rev. Lett.},
+  volume={78},
+  issue={17},
+  pages={3414--3417},
+  numpages={4},
+  year={1997},
+  month={Apr},
+  publisher={American Physical Society},
+  doi={10.1103/PhysRevLett.78.3414},
+  url={https://link.aps.org/doi/10.1103/PhysRevLett.78.3414}
 }
 
 % Last name begins with N

--- a/examples/involvingstates/example_PBM.py
+++ b/examples/involvingstates/example_PBM.py
@@ -4,7 +4,7 @@ The Pretty Good and Pretty Bad Measurements
 
 In this tutorial, we will explore the "pretty good measurement" (PGM) and its
 novel counterpart, the "pretty bad measurement" (PBM), as introduced by
-McIrvin, Mohan, and Sikora :footcite:`McIrvin_2024_Pretty`. These measurements
+McIrvin et.al :footcite:`McIrvin_2024_Pretty`. These measurements
 provide elegant, easy-to-construct tools for two opposing goals in quantum
 information: state discrimination and state exclusion.
 

--- a/examples/involvingstates/example_PBM.py
+++ b/examples/involvingstates/example_PBM.py
@@ -1,0 +1,221 @@
+"""
+The Pretty Good and Pretty Bad Measurements
+===========================================
+
+In this tutorial, we will explore the "pretty good measurement" (PGM) and its
+novel counterpart, the "pretty bad measurement" (PBM), as introduced by
+McIrvin, Mohan, and Sikora :footcite:`McIrvin_2024_Pretty`. These measurements
+provide elegant, easy-to-construct tools for two opposing goals in quantum
+information: state discrimination and state exclusion.
+
+We will verify their core properties and replicate some of the key numerical
+results and figures from the paper using :code:`|toqito⟩`.
+"""
+
+# %%
+# Background: Discrimination vs. Exclusion
+# ----------------------------------------
+#
+# The standard quantum state discrimination task involves Alice sending Bob a
+# quantum state :math:`\rho_i` chosen from a known ensemble
+# :math:`\{(p_i, \rho_i)\}_{i=1}^k`. Bob's goal is to perform a measurement
+# that maximizes his probability of correctly guessing the index :math:`i`.
+# The best possible probability is denoted :math:`P_{\text{Best}}`. The "pretty good
+# measurement" (PGM) is a well-known and effective heuristic for this task.
+#
+# The state exclusion task is the opposite: Bob wins if he correctly guesses
+# a state that Alice *did not* send. This is equivalent to minimizing the
+# probability of correctly guessing the state Alice *did* send. The minimum
+# possible success probability for discrimination is :math:`P_{\text{Worst}}`. The
+# "pretty bad measurement" (PBM) is a new heuristic designed to approximate
+# this worst-case performance.
+#
+# A key result from :footcite:`McIrvin_2024_Pretty` is the tight relationship
+# between the success probabilities of these two measurements:
+#
+# .. math::
+#    P_{\text{PGM}} + (k-1)P_{\text{PBM}} = 1
+#
+# This implies a performance hierarchy against the optimal probabilities and the
+# blind guessing probability (:math:`1/k`):
+#
+# .. math::
+#    P_{\text{Best}} \ge P_{\text{PGM}} \ge \frac{1}{k} \ge P_{\text{PBM}} \ge P_{\text{Worst}}
+#
+# We will verify this hierarchy with a concrete example.
+
+# %%
+# Numerical Example: The Trine States
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# Figure 3 of the paper :footcite:`McIrvin_2024_Pretty` analyzes the performance
+# of these measurements for the three **trine states** with a uniform prior
+# probability. The trine states are a classic example of a set that is
+# antidistinguishable but not distinguishable.
+#
+# Our plan is to:
+#
+# 1.  Generate the trine states and assume uniform prior probabilities.
+# 2.  Compute the optimal win/loss probabilities, :math:`P_{\text{Best}}`
+#     and :math:`P_{\text{Worst}}`, using :code:`|toqito⟩`'s SDP solvers.
+# 3.  Construct the PGM and PBM measurement operators.
+# 4.  Calculate the success probabilities :math:`P_{\text{PGM}}` and :math:`P_{\text{PBM}}`.
+# 5.  Print and compare all values, verifying the performance hierarchy and
+#     the relationship between :math:`P_{\text{PGM}}` and :math:`P_{\text{PBM}}`.
+
+import numpy as np
+from toqito.measurements import pretty_bad_measurement, pretty_good_measurement
+from toqito.states import trine
+from toqito.state_opt import state_distinguishability, state_exclusion
+
+
+def calculate_success_prob(
+    states: list[np.ndarray],
+    probs: list[float],
+    povm_operators: list[np.ndarray],
+) -> float:
+    """Calculate the success probability Σ pᵢ Tr(ρᵢ Mᵢ).
+
+    This helper is robust to `states` being either state vectors or density matrices.
+    """
+    success_prob = 0
+    num_states = len(states)
+    for i in range(num_states):
+        state = states[i]
+        op = povm_operators[i]
+        # Check if input is a vector (pure state) or matrix (density matrix)
+        if state.ndim == 1 or (state.ndim == 2 and min(state.shape) == 1):
+            # It's a vector (or column/row vector)
+            state_vec = state.flatten()
+            prob_i = state_vec.conj().T @ op @ state_vec
+        else:
+            # It's a density matrix
+            prob_i = np.trace(op @ state)
+        success_prob += probs[i] * prob_i
+    return np.real(success_prob)
+
+# 1. Define the states and probabilities.
+state_vectors = trine()
+k = len(state_vectors)
+probs = [1 / k] * k
+
+print(f"Analyzing k={k} trine states with uniform probability.")
+
+# 2. Compute the optimal benchmark values.
+p_best, _ = state_distinguishability(state_vectors, probs)
+p_worst, _ = state_exclusion(state_vectors, probs)
+
+print(f"\nOptimal Benchmarks:")
+print(f"  P_Best  = {p_best:.4f} (Max discrimination probability)")
+print(f"  P_Worst = {p_worst:.4f} (Min discrimination probability)")
+
+# 3. Compute the PGM and PBM operators. 
+pgm_operators = pretty_good_measurement(state_vectors, probs)
+pbm_operators = pretty_bad_measurement(state_vectors, probs)
+
+# 4. Calculate PGM and PBM success probabilities.
+p_pgm = calculate_success_prob(state_vectors, probs, pgm_operators)
+p_pbm = calculate_success_prob(state_vectors, probs, pbm_operators)
+
+print(f"\nHeuristic Measurements:")
+print(f"  P_PGM = {p_pgm:.4f}")
+print(f"  P_PBM = {p_pbm:.4f}")
+
+# 5. Verify the core relationship and the hierarchy.
+relation_lhs = p_pgm + (k - 1) * p_pbm
+print(f"\nVerifying P_PGM + (k-1)*P_PBM = 1:")
+print(f"  {p_pgm:.4f} + ({k-1})*{p_pbm:.4f} = {relation_lhs:.4f} -> {np.isclose(relation_lhs, 1)}")
+
+print("\nVerifying hierarchy (P_Best >= P_PGM >= 1/k >= P_PBM >= P_Worst):")
+print(f"  {p_best:.4f} >= {p_pgm:.4f}  ?  {p_best >= p_pgm or np.isclose(p_best, p_pgm)}")
+print(f"  {p_pgm:.4f} >= {1/k:.4f}  ?  {p_pgm >= 1/k or np.isclose(p_pgm, 1/k)}")
+print(f"  {1/k:.4f} >= {p_pbm:.4f}  ?  {1/k >= p_pbm or np.isclose(1/k, p_pbm)}")
+print(f"  {p_pbm:.4f} >= {p_worst:.4f}?  {p_pbm >= p_worst or np.isclose(p_pbm, p_worst)}")
+
+
+# %%
+# The results perfectly match those presented in Figure 3 of the paper. For
+# the trine states, the PGM is optimal (:math:`P_{\text{PGM}} = P_{\text{Best}} = 2/3`)
+# and the worst possible measurement gives zero success probability
+# (:math:`P_{\text{Worst}} = 0`).
+#
+# Our calculated value for the PBM is :math:`1/6 \approx 0.1667`, which is a
+# good approximation of the true worst case. We also explicitly confirm
+# the identity :math:`P_{\text{PGM}} + (k-1)P_{\text{PBM}} = 1` and the full
+# performance hierarchy.
+
+# %%
+# Visualizing Performance on Random States
+# ----------------------------------------
+#
+# Figures 4 and 5 in the paper :footcite:`McIrvin_2024_Pretty` show that for many randomly generated
+# states, the PGM and PBM probabilities cluster around the blind guessing
+# baseline of :math:`1/k`. We can reproduce a similar plot.
+#
+# We will generate 100 random ensembles of :math:`k=4` qubit states and plot
+# the resulting :math:`P_{\text{PGM}}` and :math:`P_{\text{PBM}}` values.
+
+import matplotlib.pyplot as plt
+
+from toqito.rand import random_density_matrix
+
+# Number of random ensembles to generate.
+num_instances = 100
+k = 4  # Number of states in each ensemble.
+dim = 2  # Dimension of states (qubits).
+
+pgm_results = []
+pbm_results = []
+
+for i in range(num_instances):
+    # Generate a random ensemble of k density matrices.
+    rand_states = [random_density_matrix(dim, seed=(i * k) + j) for j in range(k)]
+    # Generate random prior probabilities.
+    rand_probs = np.random.dirichlet(np.ones(k))
+
+    # Calculate PGM and PBM probabilities.
+    pgm_ops = pretty_good_measurement(rand_states, rand_probs)
+    pbm_ops = pretty_bad_measurement(rand_states, rand_probs)
+
+    pgm_prob = calculate_success_prob(rand_states, rand_probs, pgm_ops)
+    pbm_prob = calculate_success_prob(rand_states, rand_probs, pbm_ops)
+    pgm_results.append(pgm_prob)
+    pbm_results.append(pbm_prob)
+
+# Create the plot.
+fig, ax = plt.subplots(figsize=(8, 5), dpi=100)
+sample_indices = range(num_instances)
+ax.scatter(sample_indices, pgm_results, alpha=0.7, label="$P_{PGM}$", c="blue", s=20)
+ax.scatter(sample_indices, pbm_results, alpha=0.7, label="$P_{PBM}$", c="red", s=20)
+
+# Add blind guessing line for reference.
+blind_guess_prob = 1 / k
+ax.axhline(
+    y=blind_guess_prob,
+    color="black",
+    linestyle="--",
+    label=f"Blind Guessing (1/k = {blind_guess_prob:.2f})",
+)
+
+ax.set_xlabel("Random Instance Index", fontsize=12)
+ax.set_ylabel("Discrimination Success Probability", fontsize=12)
+ax.set_title(f"PGM and PBM Performance for {num_instances} Random Ensembles (k={k})", fontsize=14)
+ax.legend()
+ax.grid(True, linestyle=":", alpha=0.6)
+plt.tight_layout()
+plt.show()
+
+# %%
+# This plot clearly illustrates the theoretical bounds. Every blue dot
+# (:math:`P_{\text{PGM}}`) lies on or above the blind guessing line, and every
+# red dot (:math:`P_{\text{PBM}}`) lies on or below it. This provides strong
+# numerical evidence for the inequalities
+# :math:`P_{\text{PGM}} \ge 1/k \ge P_{\text{PBM}}`, confirming that the PGM is
+# always a better-than-random guess and the PBM is always a worse-than-random
+# guess for state discrimination.
+#
+#
+# References
+# ----------
+#
+# .. footbibliography::

--- a/toqito/measurements/pretty_bad_measurement.py
+++ b/toqito/measurements/pretty_bad_measurement.py
@@ -8,21 +8,16 @@ from toqito.measurements import pretty_good_measurement
 def pretty_bad_measurement(
     states: list[np.ndarray], probs: list[float] | None = None, tol: float = 1e-8
 ) -> list[np.ndarray]:
-    r"""Return the set of pretty bad measurements from a set of vectors and corresponding probabilities.
+    r"""Return the set of pretty bad measurements from an ensemble.
 
-    This computes the "pretty bad measurement" as defined in :footcite:`Hughston_1993_Complete` and is an analogous idea
-    to the "pretty good measurement" from :footcite:`McIrvin_2024_Pretty`. The "pretty bad measurement" is useful in the
-    context of state exclusion where the pretty good measurement is often used for minimum-error quantum state
-    discrimination.
+    This computes the "pretty bad measurement" (PBM) as defined in
+    :footcite:`McIrvin_2024_Pretty`. The PBM is an analogue to the "pretty
+    good measurement" and is useful for approximating the optimal measurement
+    for state exclusion.
 
-    The pretty bad measurement (PBM) is defined in terms of an offset of the pretty good measurement (PGM). Recall that
-    the PGM is defined as a set of POVMs :math:`(G_1, \ldots, G_n)` such that
-
-    .. math::
-        G_i = P^{-1/2} \left(p_i \rho_i\right) P^{-1/2} \quad \text{where} \quad
-        P = \sum_{i=1}^n p_i \rho_i.
-
-    By proxy, the corresponding PBM is defined as a set of POVMs :math:`(B_1, \ldots, B_n)` where
+    The PBM is defined in terms of the pretty good measurement (PGM).
+    Given the PGM operators :math:`(G_1, \ldots, G_n)`, the corresponding PBM
+    is the set of POVMs :math:`(B_1, \ldots, B_n)` where
 
     .. math::
         B_i = \frac{1}{n - 1} \left(\mathbb{I} - G_i\right).
@@ -47,23 +42,20 @@ def pretty_bad_measurement(
 
      states = trine()
      probs = [1 / 3, 1 / 3, 1 / 3]
-
      pbm = pretty_bad_measurement(states, probs)
-
      pbm
-
 
     References
     ==========
     .. footbibliography::
 
-
-
-    :raises ValueError: If number of vectors does not match number of probabilities.
+    :raises ValueError: If number of states does not match number of probabilities.
     :raises ValueError: If probabilities do not sum to 1.
-    :param states: A collection of either states provided as either vectors or density matrices.
-    :param probs: A set of probabilities.
+    :param states: A collection of states provided as either vectors or density matrices.
+    :param probs: A set of fixed probabilities for each quantum state.
+                  If not provided, a uniform distribution is assumed.
     :param tol: A tolerance value for numerical comparisons.
+    :return: A list of POVM operators for the PBM.
 
     """
     n = len(states)

--- a/toqito/measurements/pretty_good_measurement.py
+++ b/toqito/measurements/pretty_good_measurement.py
@@ -8,12 +8,13 @@ from toqito.matrix_ops import to_density_matrix
 def pretty_good_measurement(
     states: list[np.ndarray], probs: list[float] | None = None, tol: float = 1e-8
 ) -> list[np.ndarray]:
-    r"""Return the set of pretty good measurements from a set of vectors and corresponding probabilities.
+    r"""Return the set of pretty good measurements from an ensemble.
 
-    This computes the "pretty good measurement" as initially defined in :footcite:`Hughston_1993_Complete`.
+    This computes the "pretty good measurement" (PGM), also known as the
+    square-root measurement, which is a widely used measurement for quantum
+    state discrimination :footcite:`Belavkin_1975_Optimal,Hughston_1993_Complete`.
 
-    The pretty good measurement (PGM) (also known as the "square root measurement") is the set of POVMs :math:`(G_1,
-    \ldots, G_n)` such that
+    The PGM is the set of POVMs :math:`(G_1, \ldots, G_n)` such that
 
     .. math::
         G_i = P^{-1/2} \left(p_i \rho_i\right) P^{-1/2} \quad \text{where} \quad
@@ -39,24 +40,20 @@ def pretty_good_measurement(
 
      states = trine()
      probs = [1 / 3, 1 / 3, 1 / 3]
-
      pgm = pretty_good_measurement(states, probs)
-
      pgm
 
     References
     ==========
     .. footbibliography::
 
-
-
     :raises ValueError: If number of vectors does not match number of probabilities.
     :raises ValueError: If probabilities do not sum to 1.
-    :param states: A collection of either states provided as either vectors or density matrices.
-    :param probs: A set of fixed probabilities for a given ensemble of quantum states.
-                  The function assumes a uniform probability distribution if the fixed
-                  probabilities for the input ensemble are not provided.
+    :param states: A collection of states provided as either vectors or density matrices.
+    :param probs: A set of fixed probabilities for each quantum state.
+                  If not provided, a uniform distribution is assumed.
     :param tol: A tolerance value for numerical comparisons.
+    :return: A list of POVM operators for the PGM.
 
     """
     n = len(states)


### PR DESCRIPTION
## Description
This PR adds a new tutorial script, `example_PBM.py`, that walks through the "pretty good" and "pretty bad" measurements (PGM and PBM), based on the [paper](https://arxiv.org/abs/2403.17252) by McIrvin et. al. It also adds a new bibtex entry based on the changes that were made in the `pretty_good_measurement.py` docstrings. 

You might notice I didn't include the "quantum anomaly detection" section (Figures 6 & 7) from the paper. I felt the tutorial was stronger by focusing on the core PGM/PBM concepts first without getting into the more complex state construction needed for that example. But please do let me know if I should also add them to the tutorial. 