### PR TITLE
perf: optimising basis state generation

### DIFF
--- a/toqito/states/basis.py
+++ b/toqito/states/basis.py
@@ -1,4 +1,4 @@
-"""Basis state represent the standard basis vectors of some n-dimensional Hilbert Space.
+"""A basis state represents the standard basis vectors of some n-dimensional Hilbert Space.
 
 Here, n can be given as a parameter as shown below.
 """
@@ -42,14 +42,14 @@ def basis(dim: int, pos: int) -> np.ndarray:
 
     :raises ValueError: If the input position is not in the range [0, dim - 1].
     :param dim: The dimension of the column vector.
-    :param pos: The position in which to place a 1.
+    :param pos: 0-indexed position of the basis vector where the 1 will be placed.
     :return: The column vector of dimension :code:`dim` with all entries set to `0` except the entry
-             at position `1`.
+             at `pos` which is set to `1`.
 
     """
-    if pos >= dim:
-        raise ValueError("Invalid: The `pos` variable needs to be less than `dim` for ket function.")
+    if pos >= dim or pos < 0:
+        raise ValueError("Invalid: The `pos` variable needs to be between [0, dim - 1] for ket function.")
 
-    ret = np.array(list(int(x) for x in list(f"{0:0{dim}}")))
+    ret = np.zeros(dim, dtype=np.int64)
     ret[pos] = 1
-    return ret.conj().T.reshape(-1, 1)
+    return ret.reshape(-1, 1)

--- a/toqito/states/tests/test_basis.py
+++ b/toqito/states/tests/test_basis.py
@@ -22,7 +22,16 @@ def test_basis(dim, pos, expected_result):
     np.testing.assert_array_equal(basis(dim, pos), expected_result)
 
 
-def test_basis_invalid_dim():
+@pytest.mark.parametrize(
+    "dim, pos",
+    [
+        # Test for dim = pos.
+        (4, 4),
+        # Test for pos < 0.
+        (4, -1),
+    ],
+)
+def test_basis_invalid_dim(dim, pos):
     """Tests for invalid dimension inputs."""
     with np.testing.assert_raises(ValueError):
-        basis(4, 4)
+        basis(dim, pos)


### PR DESCRIPTION
Performance Improvements to `toqito.states.basis`
 - [x] the function now raises a `ValueError` when `pos < 0` (in addition to the existing pos >= dim check). Corresponding unit tests have been added.

- [x] eliminated unnecessary intermediate conversions `(str → list → int → NumPy array)` and removed the redundant `ret.conj()` call, since the vector is guaranteed to be real-valued. 

- [x] achieved approximately `100x` speedup in wall-clock execution time, as measured via `line_profiler` across multiple dimensions `(4 <= dim <= 16384)`. Profiling was performed against four candidate implementations `(basis_v1–basis_v4)`, with the final approach based on direct zero-initialization and index assignment as implemeted in the PR.