### PR TITLE
perf: optimising depolarizing channel

### DIFF
--- a/toqito/channels/depolarizing.py
+++ b/toqito/channels/depolarizing.py
@@ -84,11 +84,12 @@ def depolarizing(dim: int, param_p: float = 0) -> np.ndarray:
     :param param_p: Depolarizing probability \(p \) \in [0,1] that mixes the input state
                     with the maximally mixed state. Default 0.
     :return: The Choi matrix of the completely depolarizing channel.
+    :raises ValueError: If `param_p` is outside the interval [0,1].
 
     """
     # Compute the Choi matrix of the depolarizing channel.
     if param_p > 1 or param_p < 0:
-        raise ValueError("the depolarizing probability must be between 0 and 1.")
+        raise ValueError("The depolarizing probability must be between 0 and 1.")
 
     result = np.zeros((dim**2, dim**2), dtype=np.float64)
     np.fill_diagonal(result, (1 - param_p) / dim)

--- a/toqito/channels/tests/test_depolarizing.py
+++ b/toqito/channels/tests/test_depolarizing.py
@@ -36,5 +36,5 @@ def test_depolarizing_partially_depolarizing():
 @pytest.mark.parametrize("param_p", [-0.1, 1.5])
 def test_depolarizing_invalid_param_p(param_p):
     """Test invalid input to param_p."""
-    with pytest.raises(ValueError, match=re.escape("the depolarizing probability must be between 0 and 1.")):
+    with pytest.raises(ValueError, match=re.escape("The depolarizing probability must be between 0 and 1.")):
         depolarizing(2, param_p)


### PR DESCRIPTION
We do not need `toqito.states.max_entangled` to calculate `|psi><psi|` instead we can set it up manually ini `O(dim^2)` which is slightly less expensive