### PR TITLE
regression analysis in toqito

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -81,7 +81,7 @@ jobs:
       id: defaults
       run: |
 
-        echo "benchmark_type=${{ github.event.inputs.benchmark_type || 'simple' }}" >> $GITHUB_OUTPUT
+        echo "benchmark_type=${{ github.event.inputs.benchmark_type || 'full' }}" >> $GITHUB_OUTPUT
         # echo "filter=${{ github.event.inputs.filter || '' }}" >> $GITHUB_OUTPUT
         # echo "function=${{ github.event.inputs.function || '' }}" >> $GITHUB_OUTPUT
         echo "filter=${{ github.event.inputs.filter || '' }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -116,7 +116,7 @@ jobs:
       run: |
         cd toqito
         poetry install --with dev
-        poetry add toqito pytest-benchmark --group dev pytest-memray sympy pygal
+        poetry add pytest-benchmark --group dev pytest-memray sympy pygal
     
     - name: Verify toqito installation
       run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -187,30 +187,33 @@ jobs:
       run: |
         cd toqito-bench
         echo "Running FULL benchmarks for toqito..."
-        echo "Benchmark file: ${{ env.BENCHMARK_FILE_TOQITO }}"
+        echo "Benchmark file: scripts/benchmark_toqito.py"
         echo "Filter applied: ${{ steps.defaults.outputs.filter || 'none' }}"
         echo "Function applied: ${{ steps.defaults.outputs.function || 'none' }}"
         echo "Storage: ${{ env.BENCHMARK_STORAGE }}/toqito/full"
 
+        # Make sure toqito is on the Python path
         export PYTHONPATH="../toqito:$PYTHONPATH"
 
-        PYTEST_CMD="poetry run pytest ${{ env.BENCHMARK_DIR }}/${{ env.BENCHMARK_FILE_TOQITO }}"
+        # Use poetry from the toqito env
+        cd ../toqito
+
+        PYTEST_CMD="poetry run pytest ../toqito-bench/scripts/benchmark_toqito.py"
         if [ -n "${{ steps.defaults.outputs.filter }}" ]; then
-          PYTEST_CMD="$PYTEST_CMD -k \"${{ steps.defaults.outputs.filter }}\""
+        PYTEST_CMD="$PYTEST_CMD -k \"${{ steps.defaults.outputs.filter }}\""
         fi
         if [ -n "${{ steps.defaults.outputs.function }}" ]; then
-          PYTEST_CMD="$PYTEST_CMD -m \"${{ steps.defaults.outputs.function }}\""
+        PYTEST_CMD="$PYTEST_CMD -m \"${{ steps.defaults.outputs.function }}\""
         fi
 
         PYTEST_CMD="$PYTEST_CMD \
-          --benchmark-warmup=on \
-          --benchmark-sort=name \
-          --benchmark-columns=min,max,mean,stddev,median,iqr,outliers,ops,rounds \
-          --benchmark-save=detailed_${{ env.TIMESTAMP }} \
-          --benchmark-storage=$(pwd)/${{ env.BENCHMARK_STORAGE }}/toqito/full \
-          --benchmark-verbose \
-          -v --tb=long"
-        
-        echo "Executing: $PYTEST_CMD currently in $(pwd)"
-        cd ../toqito-bench/ && eval "$PYTEST_CMD"
-        
+        --benchmark-warmup=on \
+        --benchmark-sort=name \
+        --benchmark-columns=min,max,mean,stddev,median,iqr,outliers,ops,rounds \
+        --benchmark-save=detailed_${{ env.TIMESTAMP }} \
+        --benchmark-storage=$(pwd)/../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/full \
+        --benchmark-verbose \
+        -v --tb=long"
+
+        echo "🔧 Executing: $PYTEST_CMD currently in $(pwd)"
+        eval "$PYTEST_CMD"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -212,5 +212,5 @@ jobs:
           -v --tb=long"
         
         echo "Executing: $PYTEST_CMD currently in $(pwd)"
-        cd toqito-bench/ && eval "$PYTEST_CMD"
+        cd ../toqito-bench/ && eval "$PYTEST_CMD"
         

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,7 +8,28 @@ on:
                 required: false
                 default: ''
                 type: string
-    
+            
+            benchmark_type:
+                description: 'Type of benchmark to run'
+                required: true
+                default: 'full'
+                type: choice
+                options:
+                    - 'full'
+                    #later add functionalities for functionwise benchmarking results
+            
+            fail_on_regression:
+                description: 'Fail the workflow if regressions are detected'
+                required: false
+                default: true
+                type: boolean
+            
+            regression_threshold:
+                description: 'Regression threshold percentage (e.g., 10 for 10%)'
+                required: false
+                default: '10'
+                type: string
+            
     pull_request:
         branches:
             - master
@@ -35,3 +56,19 @@ jobs:
         path: toqito
         ref: ${{ steps.target-ref.outputs.ref }}
         fetch-depth: 0
+    
+    - name: Display benchmark target info
+      run: |
+        cd toqito
+        echo "  BENCHMARK TARGET INFORMATION"
+        echo "================================"
+        echo "Repository: vprusso/toqito"
+        echo "Reference: ${{ steps.target-ref.outputs.ref }}"
+        echo "Commit SHA: $(git rev-parse HEAD)"
+        echo "Commit Message: $(git log -1 --pretty=format:'%s')"
+        echo "Author: $(git log -1 --pretty=format:'%an <%ae>')"
+        echo "Date: $(git log -1 --pretty=format:'%ad')"
+        echo "Benchmark Type: ${{ github.event.inputs.benchmark_type }}"
+        echo "Regression Threshold: ${{ github.event.inputs.regression_threshold }}%"
+        echo "Fail on Regression: ${{ github.event.inputs.fail_on_regression }}"
+        echo "================================"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -458,5 +458,5 @@ jobs:
                 sys.exit(1)
         else:
             print("\n✅ No performance regressions detected")
-EOF
+        EOF
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,10 @@ on:
                 required: false
                 default: ''
                 type: string
+    
+    pull_request:
+        branches:
+            - master
 
 jobs:
   benchmark-regression:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -85,7 +85,7 @@ jobs:
         # echo "filter=${{ github.event.inputs.filter || '' }}" >> $GITHUB_OUTPUT
         # echo "function=${{ github.event.inputs.function || '' }}" >> $GITHUB_OUTPUT
         echo "filter=${{ github.event.inputs.filter || 'TestPartialTraceBenchmarks' }}" >> $GITHUB_OUTPUT
-        echo "function=${{ github.event.inputs.function || 'test_bench__partial_trace__vary__dim' }}" >> $GITHUB_OUTPUT
+        echo "function=${{ github.event.inputs.function || '' }}" >> $GITHUB_OUTPUT
         echo "save_results=${{ github.event.inputs.save_results || 'true' }}" >> $GITHUB_OUTPUT
         echo "fail_on_regression=${{ github.event.inputs.fail_on_regression || 'true' }}" >> $GITHUB_OUTPUT  
         echo "regression_threshold=${{ github.event.inputs.regression_threshold || '10' }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -273,8 +273,10 @@ jobs:
         echo "✅ Simple benchmarks completed!"
  
         if [ "$SAVE" = "true" ]; then
-          RESULTS_FILE="../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION/Linux-CPython-3.11-64bit/simple_${{ env.TIMESTAMP }}.json"
+          RESULTS_DIR="../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION/Linux-CPython-3.11-64bit"
+          RESULTS_FILE=$(ls -1 $RESULTS_DIR/*simple_${{ env.TIMESTAMP }}.json | head -n 1)
           echo "RESULTS_FILE=$RESULTS_FILE" >> $GITHUB_ENV
+          echo "Using results file: $RESULTS_FILE"
         else
           echo "RESULTS_FILE=" >> $GITHUB_ENV  # No file to analyze
         fi

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -210,7 +210,7 @@ jobs:
           --benchmark-storage=$(pwd)/${{ env.BENCHMARK_STORAGE }}/toqito/full \
           --benchmark-verbose \
           -v --tb=long"
-        ]
+        
         echo "Executing: $PYTEST_CMD currently in $(pwd)"
         cd toqito-bench/ && eval "$PYTEST_CMD"
         

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -271,17 +271,22 @@ jobs:
         eval "$PYTEST_CMD"
 
         echo "✅ Simple benchmarks completed!"
-
-        RESULTS_FILE="../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/full/.benchmarks/Linux-CPython-3.11-64bit/detailed_${{ env.TIMESTAMP }}.json"
-        echo "RESULTS_FILE=$RESULTS_FILE" >> $GITHUB_ENV
-
+ 
         if [ "$SAVE" = "true" ]; then
-          RESULTS_FILE="../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION/.benchmarks/Linux-CPython-3.11-64bit/simple_${{ env.TIMESTAMP }}.json"
+          RESULTS_FILE="../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION/Linux-CPython-3.11-64bit/simple_${{ env.TIMESTAMP }}.json"
           echo "RESULTS_FILE=$RESULTS_FILE" >> $GITHUB_ENV
         else
           echo "RESULTS_FILE=" >> $GITHUB_ENV  # No file to analyze
         fi
 
+        echo "📁 Benchmark directory structure:"
+        BASE_DIR="../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito"
+        if [ -d "$BASE_DIR" ]; then
+          find "$BASE_DIR" -type d -exec echo "Directory: {}" \;
+          find "$BASE_DIR" -type f -exec echo "File: {}" \;
+        else
+          echo "No benchmark directory found at $BASE_DIR"
+        fi
 
     - name: Regression Analysis
       if: env.RESULTS_FILE != ''  # only run if we saved results

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,12 +54,12 @@ jobs:
     - name: Set default values for all trigger types
       id: defaults
       run: |
-        # Set defaults that work for both workflow_dispatch and other triggers
+
         echo "benchmark_type=${{ github.event.inputs.benchmark_type || 'full' }}" >> $GITHUB_OUTPUT
         echo "fail_on_regression=${{ github.event.inputs.fail_on_regression || 'true' }}" >> $GITHUB_OUTPUT  
         echo "regression_threshold=${{ github.event.inputs.regression_threshold || '10' }}" >> $GITHUB_OUTPUT
         
-        # For target_ref, use input if provided, otherwise use the current SHA
+
         if [ -n "${{ github.event.inputs.target_ref }}" ]; then
           echo "target_ref=${{ github.event.inputs.target_ref }}" >> $GITHUB_OUTPUT
           echo "📍 Using specified reference: ${{ github.event.inputs.target_ref }}"
@@ -91,7 +91,8 @@ jobs:
         echo "Commit Message: $(git log -1 --pretty=format:'%s')"
         echo "Author: $(git log -1 --pretty=format:'%an <%ae>')"
         echo "Date: $(git log -1 --pretty=format:'%ad')"
-        echo "Benchmark Type: ${{ github.event.inputs.benchmark_type }}"
-        echo "Regression Threshold: ${{ github.event.inputs.regression_threshold }}%"
-        echo "Fail on Regression: ${{ github.event.inputs.fail_on_regression }}"
+        echo "Benchmark Type: ${{  steps.defaults.outputs.benchmark_type }}"
+        echo "Regression Threshold: ${{ steps.defaults.outputs.regression_threshold }}%"
+        echo "Fail on Regression: ${{ steps.defaults.outputs.fail_on_regression  }}"
+        echo "Triggered by: ${{ github.event_name }}"
         echo "================================"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,13 +21,13 @@ on:
             filter:
                 description: 'Filter tests by name pattern (eg. "TestPartialTraceBenchmarks")'
                 required: false
-                default: ''
+                default: "TestPartialTraceBenchmarks"
                 type: string
             
             function:
                 description: 'Filter tests by function pattern (eg. "test_bench__partial_trace__vary__dim")'
                 required: false
-                default: ''
+                default: "test_bench__partial_trace__vary__dim"
                 type: string
             
             save_results:
@@ -217,3 +217,67 @@ jobs:
 
         echo "🔧 Executing: $PYTEST_CMD currently in $(pwd)"
         eval "$PYTEST_CMD"
+
+        echo "Benchmarks Completed!"
+
+        RESULTS_FILE="../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/full/.benchmarks/Linux-CPython-3.11-64bit/detailed_${{ env.TIMESTAMP }}.json"
+        echo "RESULTS_FILE=$RESULTS_FILE" >> $GITHUB_ENV
+    
+    - name: Run benchmark (simple)
+      if: steps.defaults.outputs.benchmark_type == 'simple'
+      run: |
+        cd toqito-bench
+        echo "Running SIMPLE benchmarks for toqito..."
+        echo "Benchmark file: ${{ env.BENCHMARK_FILE_TOQITO }}"
+        echo "Filter applied: ${{ steps.defaults.outputs.filter || 'none' }}"
+        echo "Function applied: ${{ steps.defaults.outputs.function || 'none' }}"
+
+        FILTER="${{ steps.defaults.outputs.filter }}"
+        FUNCTION="${{ steps.defaults.outputs.function }}"
+        SAVE="${{ steps.defaults.outputs.save_results }}"
+
+        if [ "$SAVE" = "true" ]; then
+          echo "💾 Storage: ${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION"
+        else
+          echo "💾 Storage: not saving results"
+        fi
+
+        export PYTHONPATH="../toqito:$PYTHONPATH"
+
+        cd ../toqito
+
+        PYTEST_CMD="poetry run pytest ../toqito-bench/scripts/benchmark_toqito.py"
+        if [ -n "${{ steps.defaults.outputs.filter }}" ]; then
+        PYTEST_CMD="$PYTEST_CMD -k \"${{ steps.defaults.outputs.filter }}\""
+        fi
+        if [ -n "${{ steps.defaults.outputs.function }}" ]; then
+        PYTEST_CMD="$PYTEST_CMD -m \"${{ steps.defaults.outputs.function }}\""
+        fi
+
+        PYTEST_CMD="$PYTEST_CMD \
+          --benchmark-sort=name \
+          --benchmark-columns=mean,median,stddev,ops \
+          --tb=short"
+        
+        if [ "$SAVE" = "true" ]; then
+          PYTEST_CMD="$PYTEST_CMD \
+            --benchmark-save=simple_${{ env.TIMESTAMP }} \
+            --benchmark-storage=$(pwd)/../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION \
+        fi
+
+        echo "🔧 Executing: $PYTEST_CMD currently in $(pwd)"
+        eval "$PYTEST_CMD"
+
+        echo "✅ Simple benchmarks completed!"
+
+        RESULTS_FILE="../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/full/.benchmarks/Linux-CPython-3.11-64bit/detailed_${{ env.TIMESTAMP }}.json"
+        echo "RESULTS_FILE=$RESULTS_FILE" >> $GITHUB_ENV
+
+        if [ "$SAVE" = "true" ]; then
+          RESULTS_FILE="../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION/.benchmarks/Linux-CPython-3.11-64bit/simple_${{ env.TIMESTAMP }}.json"
+          echo "RESULTS_FILE=$RESULTS_FILE" >> $GITHUB_ENV
+        else
+          echo "RESULTS_FILE=" >> $GITHUB_ENV  # No file to analyze
+        fi
+
+

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,3 +28,10 @@ jobs:
           echo "ref=${{ github.sha }}" >> $GITHUB_OUTPUT
           echo "Benchmarking current commit: ${{ github.sha }}"
         fi
+    
+    - name: Checkout toqito repository at the current/mentioned commit
+      uses: actions/checkout@v4
+      with:
+        path: toqito
+        ref: ${{ steps.target-ref.outputs.ref }}
+        fetch-depth: 0

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@ on:
             benchmark_type:
                 description: 'Type of benchmark to run'
                 required: true
-                default: 'full'
+                default: 'simple'
                 type: choice
                 options:
                     - 'full'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -377,12 +377,12 @@ jobs:
         BASE_FILE="$(realpath toqito-bench/${{ env.BASE_BENCHMARK_FILE }})"
         RESULTS_FILE="$(realpath "${{ env.RESULTS_FILE }}")"
         
-        THRESHOLD=${{ steps.defaults.outputs.regression_threshold }}
+        TOLERANCE=1e-6   # absolute difference tolerance
         FAIL_ON_REGRESSION=${{ steps.defaults.outputs.fail_on_regression }}
 
         echo "Baseline: $BASE_FILE"
         echo "Results:  $RESULTS_FILE"
-        echo "Threshold: $THRESHOLD%"
+        echo "Absolute tolerance: $TOLERANCE"
         echo "Fail on Regression: $FAIL_ON_REGRESSION"
 
         python3 <<EOF
@@ -390,7 +390,7 @@ jobs:
 
         base_file = "${BASE_FILE}"
         results_file = "${RESULTS_FILE}"
-        threshold = float("${THRESHOLD}")
+        tolerance = float("${TOLERANCE}")
         fail_on_regression = "${FAIL_ON_REGRESSION}".lower() == "true"
 
         # Validate files exist
@@ -417,32 +417,37 @@ jobs:
                 continue
             base_mean = base_map[name]["stats"]["mean"]
             curr_mean = r["stats"]["mean"]
-            change_pct = ((curr_mean - base_mean) / base_mean) * 100
+            abs_diff = abs(curr_mean - base_mean)
+            change_pct = ((curr_mean - base_mean) / base_mean) * 100 if base_mean != 0 else 0.0
+
+            # Mark as regression only if absolute difference exceeds tolerance
+            is_regression = abs_diff > tolerance
 
             indicators[name] = {
                 "baseline": base_mean,
                 "current": curr_mean,
+                "abs_diff": abs_diff,
                 "change_pct": change_pct,
-                "regression": change_pct > threshold
+                "regression": is_regression
             }
 
-            if change_pct > threshold:
-                regressions.append((name, base_mean, curr_mean, change_pct))
+            if is_regression:
+                regressions.append((name, base_mean, curr_mean, abs_diff, change_pct))
 
         print("📈 Regression Analysis Report")
         for name, data in indicators.items():
+            status = "⚠️ REGRESSION" if data['regression'] else "✅ within noise tolerance"
             print(f"- {name}: baseline={data['baseline']:.6f}, "
                   f"current={data['current']:.6f}, "
-                  f"Δ={data['change_pct']:.2f}% "
-                  f"{'⚠️ REGRESSION' if data['regression'] else '✅ OK'}")
+                  f"Δ_abs={data['abs_diff']:.6e}, "
+                  f"Δ_pct={data['change_pct']:.2f}% {status}")
 
         if regressions:
             print("\n❌ Regressions detected:")
-            for n, b, c, pct in regressions:
-                print(f"  {n}: {b:.6f} → {c:.6f} ({pct:.2f}% slower)")
+            for n, b, c, abs_d, pct in regressions:
+                print(f"  {n}: {b:.6f} → {c:.6f} (Δ_abs={abs_d:.6e}, Δ_pct={pct:.2f}%)")
             if fail_on_regression:
                 sys.exit(1)
         else:
             print("✅ No regressions found")
         EOF
-

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,7 +39,7 @@ on:
             fail_on_regression:
                 description: 'Fail the workflow if regressions are detected'
                 required: false
-                default: true
+                default: false
                 type: boolean
             
             regression_threshold:
@@ -63,18 +63,6 @@ env:
 jobs:
   benchmark-regression:
     runs-on: ubuntu-latest
-    
-    #steps:
-    # - name: Determine target reference
-    #   id: target-ref
-    #   run: |
-    #     if [ -n "${{ github.event.inputs.target_ref }}" ]; then
-    #       echo "ref=${{ github.event.inputs.target_ref }}" >> $GITHUB_OUTPUT
-    #       echo "Benchmarking specified reference: ${{ github.event.inputs.target_ref }}"
-    #     else
-    #       echo "ref=${{ github.sha }}" >> $GITHUB_OUTPUT
-    #       echo "Benchmarking current commit: ${{ github.sha }}"
-    #     fi
 
     steps:
     - name: Set default values for all trigger types
@@ -87,7 +75,7 @@ jobs:
         echo "filter=${{ github.event.inputs.filter || '' }}" >> $GITHUB_OUTPUT
         echo "function=${{ github.event.inputs.function || '' }}" >> $GITHUB_OUTPUT
         echo "save_results=${{ github.event.inputs.save_results || 'true' }}" >> $GITHUB_OUTPUT
-        echo "fail_on_regression=${{ github.event.inputs.fail_on_regression || 'true' }}" >> $GITHUB_OUTPUT  
+        echo "fail_on_regression=${{ github.event.inputs.fail_on_regression || 'false' }}" >> $GITHUB_OUTPUT  
         echo "regression_threshold=${{ github.event.inputs.regression_threshold || '10' }}" >> $GITHUB_OUTPUT
         
 
@@ -302,72 +290,6 @@ jobs:
           echo "No benchmark directory found at $BASE_DIR"
         fi
 
-    # - name: Regression Analysis
-    #   if: env.RESULTS_FILE != ''  # only run if we saved results
-    #   run: |
-    #     echo "📊 Running regression analysis..."
-    #     BASE_FILE="$(pwd)/toqito-bench/${{ env.BASE_BENCHMARK_FILE }}"
-    #     RESULTS_FILE="${{ env.RESULTS_FILE }}"  # already absolute
-    #     THRESHOLD=${{ steps.defaults.outputs.regression_threshold }}
-    #     FAIL_ON_REGRESSION=${{ steps.defaults.outputs.fail_on_regression }}
-
-    #     echo "Baseline: $BASE_FILE"
-    #     echo "Results:  $RESULTS_FILE"
-    #     echo "Threshold: $THRESHOLD%"
-    #     echo "Fail on Regression: $FAIL_ON_REGRESSION"
-
-    #     python3 <<EOF
-    #     import json, sys
-
-    #     base_file = "${BASE_FILE}"
-    #     results_file = "${RESULTS_FILE}"
-    #     threshold = float("${THRESHOLD}")
-    #     fail_on_regression = "${FAIL_ON_REGRESSION}".lower() == "true"
-
-    #     with open(base_file) as f:
-    #         base = json.load(f)
-    #     with open(results_file) as f:
-    #         results = json.load(f)
-
-    #     regressions = []
-    #     indicators = {}
-
-    #     # pytest-benchmark stores results in list-of-dicts format
-    #     base_map = {b["name"]: b for b in base["benchmarks"]}
-    #     for r in results["benchmarks"]:
-    #         name = r["name"]
-    #         if name not in base_map:
-    #             continue
-    #         base_mean = base_map[name]["stats"]["mean"]
-    #         curr_mean = r["stats"]["mean"]
-    #         change_pct = ((curr_mean - base_mean) / base_mean) * 100
-
-    #         indicators[name] = {
-    #             "baseline": base_mean,
-    #             "current": curr_mean,
-    #             "change_pct": change_pct,
-    #             "regression": change_pct > threshold
-    #         }
-
-    #         if change_pct > threshold:
-    #             regressions.append((name, base_mean, curr_mean, change_pct))
-
-    #     print("📈 Regression Analysis Report")
-    #     for name, data in indicators.items():
-    #         print(f"- {name}: baseline={data['baseline']:.6f}, "
-    #               f"current={data['current']:.6f}, "
-    #               f"Δ={data['change_pct']:.2f}% "
-    #               f"{'⚠️ REGRESSION' if data['regression'] else '✅ OK'}")
-
-    #     if regressions:
-    #         print("\n❌ Regressions detected:")
-    #         for n, b, c, pct in regressions:
-    #             print(f"  {n}: {b:.6f} → {c:.6f} ({pct:.2f}% slower)")
-    #         if fail_on_regression:
-    #             sys.exit(1)
-    #     else:
-    #         print("✅ No regressions found")
-    #     EOF
     - name: Regression Analysis
       if: env.RESULTS_FILE != ''  # only run if we have a results file
       run: |
@@ -393,7 +315,6 @@ jobs:
         results_file = "${RESULTS_FILE}"
         fail_on_regression = "${FAIL_ON_REGRESSION}".lower() == "true"
 
-        # Validate files exist
         if not os.path.isfile(base_file):
             print(f"❌ Baseline file not found: {base_file}")
             sys.exit(1)
@@ -411,7 +332,6 @@ jobs:
 
         print("📈 Regression Analysis Report")
 
-        # Map benchmarks by name for comparison
         base_map = {b["name"]: b for b in base.get("benchmarks", [])}
         for r in results.get("benchmarks", []):
             name = r["name"]
@@ -422,11 +342,9 @@ jobs:
             curr_mean = r["stats"]["mean"]
             base_stddev = base_map[name]["stats"].get("stddev", 0)
             
-            # Calculate percentage change
             percent_change = ((curr_mean - base_mean) / base_mean) * 100 if base_mean != 0 else 0
-            
-            # Use standard deviation as noise threshold (more scientific than fixed tolerance)
-            noise_threshold = base_stddev * 2  # 2 standard deviations
+
+            noise_threshold = base_stddev * 2
             abs_change = abs(curr_mean - base_mean)
             
             # Flag as regression if: change > noise AND change > 10%

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -118,9 +118,12 @@ jobs:
         poetry install --with dev
         poetry add pytest-benchmark --group dev pytest-memray sympy pygal
     
-    - name: Verify toqito installation
+    - name: Verify baseline benchmark exists
       run: |
-        cd toqito
-        echo " Verifying toqito installation..."
-        poetry run python -c "import toqito; print(f'toqito version: {toqito.__version__}')"
-        poetry run python -c "import toqito; print('✅ toqito imported successfully')"
+        BASE_FILE="toqito-bench/benchmarks/baseline.json"
+        if [ ! -f "$BASE_FILE" ]; then
+          echo "  Baseline benchmark file not found at $BASE_FILE"
+          echo "Please ensure the baseline benchmark exists in the toqito-bench repository"
+          exit 1
+        fi
+        echo "  Baseline benchmark found"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -62,14 +62,14 @@ jobs:
 
         if [ -n "${{ github.event.inputs.target_ref }}" ]; then
           echo "target_ref=${{ github.event.inputs.target_ref }}" >> $GITHUB_OUTPUT
-          echo "📍 Using specified reference: ${{ github.event.inputs.target_ref }}"
+          echo " Using specified reference: ${{ github.event.inputs.target_ref }}"
         else
           echo "target_ref=${{ github.sha }}" >> $GITHUB_OUTPUT
-          echo "📍 Using current commit: ${{ github.sha }}"
+          echo " Using current commit: ${{ github.sha }}"
         fi
         
         # Log the trigger type for debugging
-        echo "🔧 Workflow triggered by: ${{ github.event_name }}"
+        echo " Workflow triggered by: ${{ github.event_name }}"
 
 
     
@@ -111,3 +111,16 @@ jobs:
     
     - name: Install Poetry
       run: pip install poetry
+    
+    - name: Setup toqito environment
+      run: |
+        cd toqito
+        poetry install --with dev
+        poetry add toqito pytest-benchmark --group dev pytest-memray sympy pygal
+    
+    - name: Verify toqito installation
+      run: |
+        cd toqito
+        echo " Verifying toqito installation..."
+        poetry run python -c "import toqito; print(f'toqito version: {toqito.__version__}')"
+        poetry run python -c "import toqito; print('✅ toqito imported successfully')"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -134,7 +134,7 @@ jobs:
       with:
         repository: vprusso/toqito-bench
         path: toqito-bench
-        ref: master
+        ref: post_cycle
     
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,25 @@ on:
                 type: choice
                 options:
                     - 'full'
-                    #later add functionalities for functionwise benchmarking results
+                    - 'simple'
+            
+            filter:
+                description: 'Filter tests by name pattern (eg. "TestPartialTraceBenchmarks")'
+                required: false
+                default: ''
+                type: string
+            
+            function:
+                description: 'Filter tests by function pattern (eg. "test_bench__partial_trace__vary__dim")'
+                required: false
+                default: ''
+                type: string
+            
+            save_results:
+                description: 'Save benchmark results to storage'
+                required: false
+                default: true
+                type: boolean
             
             fail_on_regression:
                 description: 'Fail the workflow if regressions are detected'
@@ -33,6 +51,14 @@ on:
     pull_request:
         branches:
             - master
+
+env:
+    PYTHON_VERSION: '3.11'
+    BASE_BENCHMARK_FILE: "benchmarks/baseline.json"
+    BENCHMARK_FILE_TOQITO: "toqito-bench/scripts/benchmark_toqito.py"
+    BENCHMARK_STORAGE: "results"
+    BENCHMARK_DIR: "scripts"
+
 
 jobs:
   benchmark-regression:
@@ -56,6 +82,9 @@ jobs:
       run: |
 
         echo "benchmark_type=${{ github.event.inputs.benchmark_type || 'full' }}" >> $GITHUB_OUTPUT
+        echo "filter=${{ github.event.inputs.filter || '' }}" >> $GITHUB_OUTPUT
+        echo "function=${{ github.event.inputs.function || '' }}" >> $GITHUB_OUTPUT
+        echo "save_results=${{ github.event.inputs.save_results || 'true' }}" >> $GITHUB_OUTPUT
         echo "fail_on_regression=${{ github.event.inputs.fail_on_regression || 'true' }}" >> $GITHUB_OUTPUT  
         echo "regression_threshold=${{ github.event.inputs.regression_threshold || '10' }}" >> $GITHUB_OUTPUT
         
@@ -92,6 +121,9 @@ jobs:
         echo "Author: $(git log -1 --pretty=format:'%an <%ae>')"
         echo "Date: $(git log -1 --pretty=format:'%ad')"
         echo "Benchmark Type: ${{  steps.defaults.outputs.benchmark_type }}"
+        echo "Filter Applied: ${{ steps.defaults.outputs.filter || 'none' }}"
+        echo "Function Applied: ${{ steps.defaults.outputs.function || 'none' }}"
+        echo "Save Results: ${{ steps.defaults.outputs.save_results }}"
         echo "Regression Threshold: ${{ steps.defaults.outputs.regression_threshold }}%"
         echo "Fail on Regression: ${{ steps.defaults.outputs.fail_on_regression  }}"
         echo "Triggered by: ${{ github.event_name }}"
@@ -107,7 +139,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: ${{ env.PYTHON_VERSION }}
     
     - name: Install Poetry
       run: pip install poetry
@@ -115,15 +147,70 @@ jobs:
     - name: Setup toqito environment
       run: |
         cd toqito
+        echo "Setting up toqito development environment..."
         poetry install --with dev
         poetry add pytest-benchmark --group dev pytest-memray sympy pygal
+        echo "Environment setup complete"
     
     - name: Verify baseline benchmark exists
       run: |
-        BASE_FILE="toqito-bench/benchmarks/baseline.json"
+        BASE_FILE="toqito-bench/${{ env.BASE_BENCHMARK_FILE }}"
         if [ ! -f "$BASE_FILE" ]; then
           echo "  Baseline benchmark file not found at $BASE_FILE"
           echo "Please ensure the baseline benchmark exists in the toqito-bench repository"
           exit 1
         fi
-        echo "  Baseline benchmark found"
+        echo "  Baseline benchmark found !"
+    
+    - name: Prepare benchmark environment
+      run: |
+        echo "📁 Creating benchmark directories..."
+
+        TIMESTAMP=$(date +%Y_%m_%d__%H_%M_%S)
+        echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+
+        cd toqito-bench
+        mkdir -p ${{ env.BENCHMARK_STORAGE }}/toqito/full
+        mkdir -p ${{ env.BENCHMARK_STORAGE }}/toqito/simple
+
+        FILTER="${{ steps.defaults.outputs.filter }}"
+        FUNCTION="${{ steps.defaults.outputs.function }}"
+        if [ -n "$FILTER" ] || [ -n "$FUNCTION" ]; then
+          mkdir -p "${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION"
+        fi
+
+        echo "📁 Directory structure created"
+        ls -la ${{ env.BENCHMARK_STORAGE }}/toqito/
+    
+    - name: Run benchmark (full)
+      if: steps.defaults.outputs.benchmark_type == 'full'
+      run: |
+        cd toqito-bench
+        echo "Running FULL benchmarks for toqito..."
+        echo "Benchmark file: ${{ env.BENCHMARK_FILE_TOQITO }}"
+        echo "Filter applied: ${{ steps.defaults.outputs.filter || 'none' }}"
+        echo "Function applied: ${{ steps.defaults.outputs.function || 'none' }}"
+        echo "Storage: ${{ env.BENCHMARK_STORAGE }}/toqito/full"
+
+        export PYTHONPATH="../toqito:$PYTHONPATH"
+
+        PYTEST_CMD="poetry run pytest ${{ env.BENCHMARK_DIR }}/${{ env.BENCHMARK_FILE_TOQITO }}"
+        if [ -n "${{ steps.defaults.outputs.filter }}" ]; then
+          PYTEST_CMD="$PYTEST_CMD -k \"${{ steps.defaults.outputs.filter }}\""
+        fi
+        if [ -n "${{ steps.defaults.outputs.function }}" ]; then
+          PYTEST_CMD="$PYTEST_CMD -m \"${{ steps.defaults.outputs.function }}\""
+        fi
+
+        PYTEST_CMD="$PYTEST_CMD \
+          --benchmark-warmup=on \
+          --benchmark-sort=name \
+          --benchmark-columns=min,max,mean,stddev,median,iqr,outliers,ops,rounds \
+          --benchmark-save=detailed_${{ env.TIMESTAMP }} \
+          --benchmark-storage=$(pwd)/${{ env.BENCHMARK_STORAGE }}/toqito/full \
+          --benchmark-verbose \
+          -v --tb=long"
+        ]
+        echo "Executing: $PYTEST_CMD currently in $(pwd)"
+        cd toqito-bench/ && eval "$PYTEST_CMD"
+        

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -297,7 +297,7 @@ jobs:
         echo "Threshold: $THRESHOLD%"
         echo "Fail on Regression: $FAIL_ON_REGRESSION"
 
-        python3 <<'EOF'
+        python3 <<EOF
         import json, sys
 
         base_file = "${BASE_FILE}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -309,54 +309,54 @@ jobs:
         echo "Fail on Regression: $FAIL_ON_REGRESSION"
 
         python3 <<EOF
-    import json, sys
+        import json, sys
 
-    base_file = "${BASE_FILE}"
-    results_file = "${RESULTS_FILE}"
-    threshold = float("${THRESHOLD}")
-    fail_on_regression = "${FAIL_ON_REGRESSION}".lower() == "true"
+        base_file = "${BASE_FILE}"
+        results_file = "${RESULTS_FILE}"
+        threshold = float("${THRESHOLD}")
+        fail_on_regression = "${FAIL_ON_REGRESSION}".lower() == "true"
 
-    with open(base_file) as f:
-        base = json.load(f)
-    with open(results_file) as f:
-        results = json.load(f)
+        with open(base_file) as f:
+            base = json.load(f)
+        with open(results_file) as f:
+            results = json.load(f)
 
-    regressions = []
-    indicators = {}
+        regressions = []
+        indicators = {}
 
-    # pytest-benchmark stores results in list-of-dicts format
-    base_map = {b["name"]: b for b in base["benchmarks"]}
-    for r in results["benchmarks"]:
-        name = r["name"]
-        if name not in base_map:
-            continue
-        base_mean = base_map[name]["stats"]["mean"]
-        curr_mean = r["stats"]["mean"]
-        change_pct = ((curr_mean - base_mean) / base_mean) * 100
+        # pytest-benchmark stores results in list-of-dicts format
+        base_map = {b["name"]: b for b in base["benchmarks"]}
+        for r in results["benchmarks"]:
+            name = r["name"]
+            if name not in base_map:
+                continue
+            base_mean = base_map[name]["stats"]["mean"]
+            curr_mean = r["stats"]["mean"]
+            change_pct = ((curr_mean - base_mean) / base_mean) * 100
 
-        indicators[name] = {
-            "baseline": base_mean,
-            "current": curr_mean,
-            "change_pct": change_pct,
-            "regression": change_pct > threshold
-        }
+            indicators[name] = {
+                "baseline": base_mean,
+                "current": curr_mean,
+                "change_pct": change_pct,
+                "regression": change_pct > threshold
+            }
 
-        if change_pct > threshold:
-            regressions.append((name, base_mean, curr_mean, change_pct))
+            if change_pct > threshold:
+                regressions.append((name, base_mean, curr_mean, change_pct))
 
-    print("📈 Regression Analysis Report")
-    for name, data in indicators.items():
-        print(f"- {name}: baseline={data['baseline']:.6f}, "
-              f"current={data['current']:.6f}, "
-              f"Δ={data['change_pct']:.2f}% "
-              f"{'⚠️ REGRESSION' if data['regression'] else '✅ OK'}")
+        print("📈 Regression Analysis Report")
+        for name, data in indicators.items():
+            print(f"- {name}: baseline={data['baseline']:.6f}, "
+                  f"current={data['current']:.6f}, "
+                  f"Δ={data['change_pct']:.2f}% "
+                  f"{'⚠️ REGRESSION' if data['regression'] else '✅ OK'}")
 
-    if regressions:
-        print("\n❌ Regressions detected:")
-        for n, b, c, pct in regressions:
-            print(f"  {n}: {b:.6f} → {c:.6f} ({pct:.2f}% slower)")
-        if fail_on_regression:
-            sys.exit(1)
-    else:
-        print("✅ No regressions found")
-    EOF
+        if regressions:
+            print("\n❌ Regressions detected:")
+            for n, b, c, pct in regressions:
+                print(f"  {n}: {b:.6f} → {c:.6f} ({pct:.2f}% slower)")
+            if fail_on_regression:
+                sys.exit(1)
+        else:
+            print("✅ No regressions found")
+        EOF

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,8 +82,10 @@ jobs:
       run: |
 
         echo "benchmark_type=${{ github.event.inputs.benchmark_type || 'simple' }}" >> $GITHUB_OUTPUT
-        echo "filter=${{ github.event.inputs.filter || '' }}" >> $GITHUB_OUTPUT
-        echo "function=${{ github.event.inputs.function || '' }}" >> $GITHUB_OUTPUT
+        # echo "filter=${{ github.event.inputs.filter || '' }}" >> $GITHUB_OUTPUT
+        # echo "function=${{ github.event.inputs.function || '' }}" >> $GITHUB_OUTPUT
+        echo "filter=${{ github.event.inputs.filter || 'TestPartialTraceBenchmarks' }}" >> $GITHUB_OUTPUT
+        echo "function=${{ github.event.inputs.function || 'test_bench__partial_trace__vary__dim' }}" >> $GITHUB_OUTPUT
         echo "save_results=${{ github.event.inputs.save_results || 'true' }}" >> $GITHUB_OUTPUT
         echo "fail_on_regression=${{ github.event.inputs.fail_on_regression || 'true' }}" >> $GITHUB_OUTPUT  
         echo "regression_threshold=${{ github.event.inputs.regression_threshold || '10' }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@ on:
             benchmark_type:
                 description: 'Type of benchmark to run'
                 required: true
-                default: 'simple'
+                default: 'full'
                 type: choice
                 options:
                     - 'full'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -264,7 +264,7 @@ jobs:
         if [ "$SAVE" = "true" ]; then
           PYTEST_CMD="$PYTEST_CMD \
             --benchmark-save=simple_${{ env.TIMESTAMP }} \
-            --benchmark-storage=$(pwd)/../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION \"
+            --benchmark-storage=$(pwd)/../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION"
         fi
 
         echo "🔧 Executing: $PYTEST_CMD currently in $(pwd)"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -294,8 +294,8 @@ jobs:
       if: env.RESULTS_FILE != ''  # only run if we saved results
       run: |
         echo "📊 Running regression analysis..."
-        BASE_FILE="toqito-bench/${{ env.BASE_BENCHMARK_FILE }}"
-        RESULTS_FILE="${{ env.RESULTS_FILE }}"
+        BASE_FILE="$(pwd)/toqito-bench/${{ env.BASE_BENCHMARK_FILE }}"
+        RESULTS_FILE="$(pwd)/${{ env.RESULTS_FILE }}"
         THRESHOLD=${{ steps.defaults.outputs.regression_threshold }}
         FAIL_ON_REGRESSION=${{ steps.defaults.outputs.fail_on_regression }}
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -70,8 +70,6 @@ jobs:
       run: |
 
         echo "benchmark_type=${{ github.event.inputs.benchmark_type || 'full' }}" >> $GITHUB_OUTPUT
-        # echo "filter=${{ github.event.inputs.filter || '' }}" >> $GITHUB_OUTPUT
-        # echo "function=${{ github.event.inputs.function || '' }}" >> $GITHUB_OUTPUT
         echo "filter=${{ github.event.inputs.filter || '' }}" >> $GITHUB_OUTPUT
         echo "function=${{ github.event.inputs.function || '' }}" >> $GITHUB_OUTPUT
         echo "save_results=${{ github.event.inputs.save_results || 'true' }}" >> $GITHUB_OUTPUT
@@ -328,7 +326,7 @@ jobs:
             results = json.load(f)
 
         regressions = []
-        PERCENT_THRESHOLD = 10.0  # Flag if >10% slower
+        PERCENT_THRESHOLD = 20.0
 
         print("📈 Regression Analysis Report")
 
@@ -344,16 +342,17 @@ jobs:
             
             percent_change = ((curr_mean - base_mean) / base_mean) * 100 if base_mean != 0 else 0
 
-            noise_threshold = base_stddev * 2
+            noise_threshold = base_stddev * 2.5
             abs_change = abs(curr_mean - base_mean)
             
-            # Flag as regression if: change > noise AND change > 10%
             is_significant = abs_change > noise_threshold
             is_large_change = abs(percent_change) > PERCENT_THRESHOLD
             is_regression = is_significant and is_large_change and curr_mean > base_mean
-            
-            # Status indicators
-            if is_regression:
+            is_improvement = is_significant and is_large_change and curr_mean < base_mean
+
+            if is_improvement:
+              status = "🟢 IMPROVEMENT"
+            elif is_regression:
                 status = "🔴 REGRESSION"
                 regressions.append(name)
             elif is_large_change:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -387,10 +387,10 @@ jobs:
 
         python3 <<EOF
         import json, sys, os
+        import math
 
         base_file = "${BASE_FILE}"
         results_file = "${RESULTS_FILE}"
-        tolerance = float("${TOLERANCE}")
         fail_on_regression = "${FAIL_ON_REGRESSION}".lower() == "true"
 
         # Validate files exist
@@ -407,7 +407,9 @@ jobs:
             results = json.load(f)
 
         regressions = []
-        indicators = {}
+        PERCENT_THRESHOLD = 10.0  # Flag if >10% slower
+
+        print("📈 Regression Analysis Report")
 
         # Map benchmarks by name for comparison
         base_map = {b["name"]: b for b in base.get("benchmarks", [])}
@@ -415,39 +417,46 @@ jobs:
             name = r["name"]
             if name not in base_map:
                 continue
+            
             base_mean = base_map[name]["stats"]["mean"]
             curr_mean = r["stats"]["mean"]
-            abs_diff = abs(curr_mean - base_mean)
-            change_pct = ((curr_mean - base_mean) / base_mean) * 100 if base_mean != 0 else 0.0
-
-            # Mark as regression only if absolute difference exceeds tolerance
-            is_regression = abs_diff > tolerance
-
-            indicators[name] = {
-                "baseline": base_mean,
-                "current": curr_mean,
-                "abs_diff": abs_diff,
-                "change_pct": change_pct,
-                "regression": is_regression
-            }
-
+            base_stddev = base_map[name]["stats"].get("stddev", 0)
+            
+            # Calculate percentage change
+            percent_change = ((curr_mean - base_mean) / base_mean) * 100 if base_mean != 0 else 0
+            
+            # Use standard deviation as noise threshold (more scientific than fixed tolerance)
+            noise_threshold = base_stddev * 2  # 2 standard deviations
+            abs_change = abs(curr_mean - base_mean)
+            
+            # Flag as regression if: change > noise AND change > 10%
+            is_significant = abs_change > noise_threshold
+            is_large_change = abs(percent_change) > PERCENT_THRESHOLD
+            is_regression = is_significant and is_large_change and curr_mean > base_mean
+            
+            # Status indicators
             if is_regression:
-                regressions.append((name, base_mean, curr_mean, abs_diff, change_pct))
-
-        print("📈 Regression Analysis Report")
-        for name, data in indicators.items():
-            status = "⚠️ REGRESSION" if data['regression'] else "✅ within noise tolerance"
-            print(f"- {name}: baseline={data['baseline']:.6f}, "
-                  f"current={data['current']:.6f}, "
-                  f"Δ_abs={data['abs_diff']:.6e}, "
-                  f"Δ_pct={data['change_pct']:.2f}% {status}")
+                status = "🔴 REGRESSION"
+                regressions.append(name)
+            elif is_large_change:
+                status = "🟡 LARGE CHANGE" 
+            elif is_significant:
+                status = "🟠 SIGNIFICANT"
+            else:
+                status = "✅ OK"
+            
+            print(f"- {name}: {base_mean:.6f} → {curr_mean:.6f} "
+                  f"({percent_change:+.1f}%) {status}")
 
         if regressions:
-            print("\n❌ Regressions detected:")
-            for n, b, c, abs_d, pct in regressions:
-                print(f"  {n}: {b:.6f} → {c:.6f} (Δ_abs={abs_d:.6e}, Δ_pct={pct:.2f}%)")
+            print(f"\n❌ Found {len(regressions)} regressions:")
+            for name in regressions:
+                print(f"  - {name}")
+            
             if fail_on_regression:
+                print("Failing build due to performance regressions")
                 sys.exit(1)
         else:
-            print("✅ No regressions found")
-        EOF
+            print("\n✅ No performance regressions detected")
+EOF
+

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -81,7 +81,7 @@ jobs:
       id: defaults
       run: |
 
-        echo "benchmark_type=${{ github.event.inputs.benchmark_type || 'full' }}" >> $GITHUB_OUTPUT
+        echo "benchmark_type=${{ github.event.inputs.benchmark_type || 'simple' }}" >> $GITHUB_OUTPUT
         echo "filter=${{ github.event.inputs.filter || '' }}" >> $GITHUB_OUTPUT
         echo "function=${{ github.event.inputs.function || '' }}" >> $GITHUB_OUTPUT
         echo "save_results=${{ github.event.inputs.save_results || 'true' }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -84,7 +84,7 @@ jobs:
         echo "benchmark_type=${{ github.event.inputs.benchmark_type || 'simple' }}" >> $GITHUB_OUTPUT
         # echo "filter=${{ github.event.inputs.filter || '' }}" >> $GITHUB_OUTPUT
         # echo "function=${{ github.event.inputs.function || '' }}" >> $GITHUB_OUTPUT
-        echo "filter=${{ github.event.inputs.filter || 'TestPartialTraceBenchmarks' }}" >> $GITHUB_OUTPUT
+        echo "filter=${{ github.event.inputs.filter || '' }}" >> $GITHUB_OUTPUT
         echo "function=${{ github.event.inputs.function || '' }}" >> $GITHUB_OUTPUT
         echo "save_results=${{ github.event.inputs.save_results || 'true' }}" >> $GITHUB_OUTPUT
         echo "fail_on_regression=${{ github.event.inputs.fail_on_regression || 'true' }}" >> $GITHUB_OUTPUT  
@@ -192,38 +192,46 @@ jobs:
         echo "Benchmark file: scripts/benchmark_toqito.py"
         echo "Filter applied: ${{ steps.defaults.outputs.filter || 'none' }}"
         echo "Function applied: ${{ steps.defaults.outputs.function || 'none' }}"
-        echo "Storage: ${{ env.BENCHMARK_STORAGE }}/toqito/full"
 
-        # Make sure toqito is on the Python path
+        FILTER="${{ steps.defaults.outputs.filter }}"
+        FUNCTION="${{ steps.defaults.outputs.function }}"
+        SAVE="${{ steps.defaults.outputs.save_results }}"
+
+        STORAGE_DIR="$(pwd)/${{ env.BENCHMARK_STORAGE }}/toqito/full"
+        mkdir -p "$STORAGE_DIR"
+        echo "💾 Storage: $STORAGE_DIR"
+
         export PYTHONPATH="../toqito:$PYTHONPATH"
 
-        # Use poetry from the toqito env
         cd ../toqito
 
         PYTEST_CMD="poetry run pytest ../toqito-bench/scripts/benchmark_toqito.py"
-        if [ -n "${{ steps.defaults.outputs.filter }}" ]; then
-        PYTEST_CMD="$PYTEST_CMD -k \"${{ steps.defaults.outputs.filter }}\""
+        if [ -n "$FILTER" ]; then
+          PYTEST_CMD="$PYTEST_CMD -k \"$FILTER\""
         fi
-        if [ -n "${{ steps.defaults.outputs.function }}" ]; then
-        PYTEST_CMD="$PYTEST_CMD -m \"${{ steps.defaults.outputs.function }}\""
+        if [ -n "$FUNCTION" ]; then
+          PYTEST_CMD="$PYTEST_CMD -m \"$FUNCTION\""
         fi
 
         PYTEST_CMD="$PYTEST_CMD \
-        --benchmark-warmup=on \
-        --benchmark-sort=name \
-        --benchmark-columns=min,max,mean,stddev,median,iqr,outliers,ops,rounds \
-        --benchmark-save=detailed_${{ env.TIMESTAMP }} \
-        --benchmark-storage=$(pwd)/../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/full \
-        --benchmark-verbose \
-        -v --tb=long"
+          --benchmark-warmup=on \
+          --benchmark-sort=name \
+          --benchmark-columns=min,max,mean,stddev,median,iqr,outliers,ops,rounds \
+          --benchmark-save=detailed_${{ env.TIMESTAMP }} \
+          --benchmark-storage=$STORAGE_DIR \
+          --benchmark-verbose \
+          -v --tb=long"
 
         echo "🔧 Executing: $PYTEST_CMD currently in $(pwd)"
         eval "$PYTEST_CMD"
 
-        echo "Benchmarks Completed!"
+        echo "✅ Full benchmarks completed!"
 
-        RESULTS_FILE="../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/full/.benchmarks/Linux-CPython-3.11-64bit/detailed_${{ env.TIMESTAMP }}.json"
+        RESULTS_FILE=$(ls -1 "$STORAGE_DIR"/Linux-CPython-3.11-64bit/*detailed_${{ env.TIMESTAMP }}.json | head -n 1)
+        RESULTS_FILE="$(realpath "$RESULTS_FILE")"
         echo "RESULTS_FILE=$RESULTS_FILE" >> $GITHUB_ENV
+        echo "Using results file: $RESULTS_FILE"
+
     
     - name: Run benchmark (simple)
       if: steps.defaults.outputs.benchmark_type == 'simple'
@@ -294,12 +302,81 @@ jobs:
           echo "No benchmark directory found at $BASE_DIR"
         fi
 
+    # - name: Regression Analysis
+    #   if: env.RESULTS_FILE != ''  # only run if we saved results
+    #   run: |
+    #     echo "📊 Running regression analysis..."
+    #     BASE_FILE="$(pwd)/toqito-bench/${{ env.BASE_BENCHMARK_FILE }}"
+    #     RESULTS_FILE="${{ env.RESULTS_FILE }}"  # already absolute
+    #     THRESHOLD=${{ steps.defaults.outputs.regression_threshold }}
+    #     FAIL_ON_REGRESSION=${{ steps.defaults.outputs.fail_on_regression }}
+
+    #     echo "Baseline: $BASE_FILE"
+    #     echo "Results:  $RESULTS_FILE"
+    #     echo "Threshold: $THRESHOLD%"
+    #     echo "Fail on Regression: $FAIL_ON_REGRESSION"
+
+    #     python3 <<EOF
+    #     import json, sys
+
+    #     base_file = "${BASE_FILE}"
+    #     results_file = "${RESULTS_FILE}"
+    #     threshold = float("${THRESHOLD}")
+    #     fail_on_regression = "${FAIL_ON_REGRESSION}".lower() == "true"
+
+    #     with open(base_file) as f:
+    #         base = json.load(f)
+    #     with open(results_file) as f:
+    #         results = json.load(f)
+
+    #     regressions = []
+    #     indicators = {}
+
+    #     # pytest-benchmark stores results in list-of-dicts format
+    #     base_map = {b["name"]: b for b in base["benchmarks"]}
+    #     for r in results["benchmarks"]:
+    #         name = r["name"]
+    #         if name not in base_map:
+    #             continue
+    #         base_mean = base_map[name]["stats"]["mean"]
+    #         curr_mean = r["stats"]["mean"]
+    #         change_pct = ((curr_mean - base_mean) / base_mean) * 100
+
+    #         indicators[name] = {
+    #             "baseline": base_mean,
+    #             "current": curr_mean,
+    #             "change_pct": change_pct,
+    #             "regression": change_pct > threshold
+    #         }
+
+    #         if change_pct > threshold:
+    #             regressions.append((name, base_mean, curr_mean, change_pct))
+
+    #     print("📈 Regression Analysis Report")
+    #     for name, data in indicators.items():
+    #         print(f"- {name}: baseline={data['baseline']:.6f}, "
+    #               f"current={data['current']:.6f}, "
+    #               f"Δ={data['change_pct']:.2f}% "
+    #               f"{'⚠️ REGRESSION' if data['regression'] else '✅ OK'}")
+
+    #     if regressions:
+    #         print("\n❌ Regressions detected:")
+    #         for n, b, c, pct in regressions:
+    #             print(f"  {n}: {b:.6f} → {c:.6f} ({pct:.2f}% slower)")
+    #         if fail_on_regression:
+    #             sys.exit(1)
+    #     else:
+    #         print("✅ No regressions found")
+    #     EOF
     - name: Regression Analysis
-      if: env.RESULTS_FILE != ''  # only run if we saved results
+      if: env.RESULTS_FILE != ''  # only run if we have a results file
       run: |
         echo "📊 Running regression analysis..."
-        BASE_FILE="$(pwd)/toqito-bench/${{ env.BASE_BENCHMARK_FILE }}"
-        RESULTS_FILE="${{ env.RESULTS_FILE }}"  # already absolute
+        
+        # Absolute paths
+        BASE_FILE="$(realpath toqito-bench/${{ env.BASE_BENCHMARK_FILE }})"
+        RESULTS_FILE="$(realpath "${{ env.RESULTS_FILE }}")"
+        
         THRESHOLD=${{ steps.defaults.outputs.regression_threshold }}
         FAIL_ON_REGRESSION=${{ steps.defaults.outputs.fail_on_regression }}
 
@@ -309,12 +386,20 @@ jobs:
         echo "Fail on Regression: $FAIL_ON_REGRESSION"
 
         python3 <<EOF
-        import json, sys
+        import json, sys, os
 
         base_file = "${BASE_FILE}"
         results_file = "${RESULTS_FILE}"
         threshold = float("${THRESHOLD}")
         fail_on_regression = "${FAIL_ON_REGRESSION}".lower() == "true"
+
+        # Validate files exist
+        if not os.path.isfile(base_file):
+            print(f"❌ Baseline file not found: {base_file}")
+            sys.exit(1)
+        if not os.path.isfile(results_file):
+            print(f"❌ Results file not found: {results_file}")
+            sys.exit(1)
 
         with open(base_file) as f:
             base = json.load(f)
@@ -324,9 +409,9 @@ jobs:
         regressions = []
         indicators = {}
 
-        # pytest-benchmark stores results in list-of-dicts format
-        base_map = {b["name"]: b for b in base["benchmarks"]}
-        for r in results["benchmarks"]:
+        # Map benchmarks by name for comparison
+        base_map = {b["name"]: b for b in base.get("benchmarks", [])}
+        for r in results.get("benchmarks", []):
             name = r["name"]
             if name not in base_map:
                 continue
@@ -360,3 +445,4 @@ jobs:
         else:
             print("✅ No regressions found")
         EOF
+

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -96,3 +96,18 @@ jobs:
         echo "Fail on Regression: ${{ steps.defaults.outputs.fail_on_regression  }}"
         echo "Triggered by: ${{ github.event_name }}"
         echo "================================"
+    
+    - name: Checkout toqito-bench repository  
+      uses: actions/checkout@v4
+      with:
+        repository: vprusso/toqito-bench
+        path: toqito-bench
+        ref: master
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    
+    - name: Install Poetry
+      run: pip install poetry

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -264,7 +264,7 @@ jobs:
         if [ "$SAVE" = "true" ]; then
           PYTEST_CMD="$PYTEST_CMD \
             --benchmark-save=simple_${{ env.TIMESTAMP }} \
-            --benchmark-storage=$(pwd)/../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION \
+            --benchmark-storage=$(pwd)/../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION \"
         fi
 
         echo "🔧 Executing: $PYTEST_CMD currently in $(pwd)"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -239,7 +239,9 @@ jobs:
         SAVE="${{ steps.defaults.outputs.save_results }}"
 
         if [ "$SAVE" = "true" ]; then
-          echo "💾 Storage: ${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION"
+          STORAGE_DIR="$(pwd)/${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION"
+          mkdir -p "$STORAGE_DIR"
+          echo "💾 Storage: $STORAGE_DIR"
         else
           echo "💾 Storage: not saving results"
         fi
@@ -249,37 +251,39 @@ jobs:
         cd ../toqito
 
         PYTEST_CMD="poetry run pytest ../toqito-bench/scripts/benchmark_toqito.py"
-        if [ -n "${{ steps.defaults.outputs.filter }}" ]; then
-        PYTEST_CMD="$PYTEST_CMD -k \"${{ steps.defaults.outputs.filter }}\""
+        if [ -n "$FILTER" ]; then
+          PYTEST_CMD="$PYTEST_CMD -k \"$FILTER\""
         fi
-        if [ -n "${{ steps.defaults.outputs.function }}" ]; then
-        PYTEST_CMD="$PYTEST_CMD -m \"${{ steps.defaults.outputs.function }}\""
+        if [ -n "$FUNCTION" ]; then
+          PYTEST_CMD="$PYTEST_CMD -m \"$FUNCTION\""
         fi
 
         PYTEST_CMD="$PYTEST_CMD \
           --benchmark-sort=name \
           --benchmark-columns=mean,median,stddev,ops \
           --tb=short"
-        
+
         if [ "$SAVE" = "true" ]; then
           PYTEST_CMD="$PYTEST_CMD \
             --benchmark-save=simple_${{ env.TIMESTAMP }} \
-            --benchmark-storage=$(pwd)/../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION"
+            --benchmark-storage=$STORAGE_DIR"
         fi
 
         echo "🔧 Executing: $PYTEST_CMD currently in $(pwd)"
         eval "$PYTEST_CMD"
 
         echo "✅ Simple benchmarks completed!"
- 
+
         if [ "$SAVE" = "true" ]; then
-          RESULTS_DIR="../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito/$FILTER/$FUNCTION/Linux-CPython-3.11-64bit"
-          RESULTS_FILE=$(ls -1 $RESULTS_DIR/*simple_${{ env.TIMESTAMP }}.json | head -n 1)
+          RESULTS_FILE=$(ls -1 "$STORAGE_DIR"/Linux-CPython-3.11-64bit/*simple_${{ env.TIMESTAMP }}.json | head -n 1)
+          # Make absolute path
+          RESULTS_FILE="$(realpath "$RESULTS_FILE")"
           echo "RESULTS_FILE=$RESULTS_FILE" >> $GITHUB_ENV
           echo "Using results file: $RESULTS_FILE"
         else
-          echo "RESULTS_FILE=" >> $GITHUB_ENV  # No file to analyze
+          echo "RESULTS_FILE=" >> $GITHUB_ENV
         fi
+
 
         echo "📁 Benchmark directory structure:"
         BASE_DIR="../toqito-bench/${{ env.BENCHMARK_STORAGE }}/toqito"
@@ -295,7 +299,7 @@ jobs:
       run: |
         echo "📊 Running regression analysis..."
         BASE_FILE="$(pwd)/toqito-bench/${{ env.BASE_BENCHMARK_FILE }}"
-        RESULTS_FILE="$(pwd)/${{ env.RESULTS_FILE }}"
+        RESULTS_FILE="${{ env.RESULTS_FILE }}"  # already absolute
         THRESHOLD=${{ steps.defaults.outputs.regression_threshold }}
         FAIL_ON_REGRESSION=${{ steps.defaults.outputs.fail_on_regression }}
 
@@ -305,54 +309,54 @@ jobs:
         echo "Fail on Regression: $FAIL_ON_REGRESSION"
 
         python3 <<EOF
-        import json, sys
+    import json, sys
 
-        base_file = "${BASE_FILE}"
-        results_file = "${RESULTS_FILE}"
-        threshold = float("${THRESHOLD}")
-        fail_on_regression = "${FAIL_ON_REGRESSION}".lower() == "true"
+    base_file = "${BASE_FILE}"
+    results_file = "${RESULTS_FILE}"
+    threshold = float("${THRESHOLD}")
+    fail_on_regression = "${FAIL_ON_REGRESSION}".lower() == "true"
 
-        with open(base_file) as f:
-            base = json.load(f)
-        with open(results_file) as f:
-            results = json.load(f)
+    with open(base_file) as f:
+        base = json.load(f)
+    with open(results_file) as f:
+        results = json.load(f)
 
-        regressions = []
-        indicators = {}
+    regressions = []
+    indicators = {}
 
-        # pytest-benchmark stores results in list-of-dicts format
-        base_map = {b["name"]: b for b in base["benchmarks"]}
-        for r in results["benchmarks"]:
-            name = r["name"]
-            if name not in base_map:
-                continue
-            base_mean = base_map[name]["stats"]["mean"]
-            curr_mean = r["stats"]["mean"]
-            change_pct = ((curr_mean - base_mean) / base_mean) * 100
+    # pytest-benchmark stores results in list-of-dicts format
+    base_map = {b["name"]: b for b in base["benchmarks"]}
+    for r in results["benchmarks"]:
+        name = r["name"]
+        if name not in base_map:
+            continue
+        base_mean = base_map[name]["stats"]["mean"]
+        curr_mean = r["stats"]["mean"]
+        change_pct = ((curr_mean - base_mean) / base_mean) * 100
 
-            indicators[name] = {
-                "baseline": base_mean,
-                "current": curr_mean,
-                "change_pct": change_pct,
-                "regression": change_pct > threshold
-            }
+        indicators[name] = {
+            "baseline": base_mean,
+            "current": curr_mean,
+            "change_pct": change_pct,
+            "regression": change_pct > threshold
+        }
 
-            if change_pct > threshold:
-                regressions.append((name, base_mean, curr_mean, change_pct))
+        if change_pct > threshold:
+            regressions.append((name, base_mean, curr_mean, change_pct))
 
-        print("📈 Regression Analysis Report")
-        for name, data in indicators.items():
-            print(f"- {name}: baseline={data['baseline']:.6f}, "
-                  f"current={data['current']:.6f}, "
-                  f"Δ={data['change_pct']:.2f}% "
-                  f"{'⚠️ REGRESSION' if data['regression'] else '✅ OK'}")
+    print("📈 Regression Analysis Report")
+    for name, data in indicators.items():
+        print(f"- {name}: baseline={data['baseline']:.6f}, "
+              f"current={data['current']:.6f}, "
+              f"Δ={data['change_pct']:.2f}% "
+              f"{'⚠️ REGRESSION' if data['regression'] else '✅ OK'}")
 
-        if regressions:
-            print("\n❌ Regressions detected:")
-            for n, b, c, pct in regressions:
-                print(f"  {n}: {b:.6f} → {c:.6f} ({pct:.2f}% slower)")
-            if fail_on_regression:
-                sys.exit(1)
-        else:
-            print("✅ No regressions found")
-        EOF
+    if regressions:
+        print("\n❌ Regressions detected:")
+        for n, b, c, pct in regressions:
+            print(f"  {n}: {b:.6f} → {c:.6f} ({pct:.2f}% slower)")
+        if fail_on_regression:
+            sys.exit(1)
+    else:
+        print("✅ No regressions found")
+    EOF

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,26 @@
+name: Benchmark Regression Analysis
+
+on:
+    workflow_dispatch:
+        inputs:
+            target_ref:
+                description: 'SHA commit to benchmark.'
+                required: false
+                default: ''
+                type: string
+
+jobs:
+  benchmark-regression:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Determine target reference
+      id: target-ref
+      run: |
+        if [ -n "${{ github.event.inputs.target_ref }}" ]; then
+          echo "ref=${{ github.event.inputs.target_ref }}" >> $GITHUB_OUTPUT
+          echo "Benchmarking specified reference: ${{ github.event.inputs.target_ref }}"
+        else
+          echo "ref=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "Benchmarking current commit: ${{ github.sha }}"
+        fi

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -283,3 +283,69 @@ jobs:
         fi
 
 
+    - name: Regression Analysis
+      if: env.RESULTS_FILE != ''  # only run if we saved results
+      run: |
+        echo "📊 Running regression analysis..."
+        BASE_FILE="toqito-bench/${{ env.BASE_BENCHMARK_FILE }}"
+        RESULTS_FILE="${{ env.RESULTS_FILE }}"
+        THRESHOLD=${{ steps.defaults.outputs.regression_threshold }}
+        FAIL_ON_REGRESSION=${{ steps.defaults.outputs.fail_on_regression }}
+
+        echo "Baseline: $BASE_FILE"
+        echo "Results:  $RESULTS_FILE"
+        echo "Threshold: $THRESHOLD%"
+        echo "Fail on Regression: $FAIL_ON_REGRESSION"
+
+        python3 <<'EOF'
+        import json, sys
+
+        base_file = "${BASE_FILE}"
+        results_file = "${RESULTS_FILE}"
+        threshold = float("${THRESHOLD}")
+        fail_on_regression = "${FAIL_ON_REGRESSION}".lower() == "true"
+
+        with open(base_file) as f:
+            base = json.load(f)
+        with open(results_file) as f:
+            results = json.load(f)
+
+        regressions = []
+        indicators = {}
+
+        # pytest-benchmark stores results in list-of-dicts format
+        base_map = {b["name"]: b for b in base["benchmarks"]}
+        for r in results["benchmarks"]:
+            name = r["name"]
+            if name not in base_map:
+                continue
+            base_mean = base_map[name]["stats"]["mean"]
+            curr_mean = r["stats"]["mean"]
+            change_pct = ((curr_mean - base_mean) / base_mean) * 100
+
+            indicators[name] = {
+                "baseline": base_mean,
+                "current": curr_mean,
+                "change_pct": change_pct,
+                "regression": change_pct > threshold
+            }
+
+            if change_pct > threshold:
+                regressions.append((name, base_mean, curr_mean, change_pct))
+
+        print("📈 Regression Analysis Report")
+        for name, data in indicators.items():
+            print(f"- {name}: baseline={data['baseline']:.6f}, "
+                  f"current={data['current']:.6f}, "
+                  f"Δ={data['change_pct']:.2f}% "
+                  f"{'⚠️ REGRESSION' if data['regression'] else '✅ OK'}")
+
+        if regressions:
+            print("\n❌ Regressions detected:")
+            for n, b, c, pct in regressions:
+                print(f"  {n}: {b:.6f} → {c:.6f} ({pct:.2f}% slower)")
+            if fail_on_regression:
+                sys.exit(1)
+        else:
+            print("✅ No regressions found")
+        EOF

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,23 +38,46 @@ jobs:
   benchmark-regression:
     runs-on: ubuntu-latest
     
+    #steps:
+    # - name: Determine target reference
+    #   id: target-ref
+    #   run: |
+    #     if [ -n "${{ github.event.inputs.target_ref }}" ]; then
+    #       echo "ref=${{ github.event.inputs.target_ref }}" >> $GITHUB_OUTPUT
+    #       echo "Benchmarking specified reference: ${{ github.event.inputs.target_ref }}"
+    #     else
+    #       echo "ref=${{ github.sha }}" >> $GITHUB_OUTPUT
+    #       echo "Benchmarking current commit: ${{ github.sha }}"
+    #     fi
+
     steps:
-    - name: Determine target reference
-      id: target-ref
+    - name: Set default values for all trigger types
+      id: defaults
       run: |
+        # Set defaults that work for both workflow_dispatch and other triggers
+        echo "benchmark_type=${{ github.event.inputs.benchmark_type || 'full' }}" >> $GITHUB_OUTPUT
+        echo "fail_on_regression=${{ github.event.inputs.fail_on_regression || 'true' }}" >> $GITHUB_OUTPUT  
+        echo "regression_threshold=${{ github.event.inputs.regression_threshold || '10' }}" >> $GITHUB_OUTPUT
+        
+        # For target_ref, use input if provided, otherwise use the current SHA
         if [ -n "${{ github.event.inputs.target_ref }}" ]; then
-          echo "ref=${{ github.event.inputs.target_ref }}" >> $GITHUB_OUTPUT
-          echo "Benchmarking specified reference: ${{ github.event.inputs.target_ref }}"
+          echo "target_ref=${{ github.event.inputs.target_ref }}" >> $GITHUB_OUTPUT
+          echo "📍 Using specified reference: ${{ github.event.inputs.target_ref }}"
         else
-          echo "ref=${{ github.sha }}" >> $GITHUB_OUTPUT
-          echo "Benchmarking current commit: ${{ github.sha }}"
+          echo "target_ref=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "📍 Using current commit: ${{ github.sha }}"
         fi
+        
+        # Log the trigger type for debugging
+        echo "🔧 Workflow triggered by: ${{ github.event_name }}"
+
+
     
     - name: Checkout toqito repository at the current/mentioned commit
       uses: actions/checkout@v4
       with:
         path: toqito
-        ref: ${{ steps.target-ref.outputs.ref }}
+        ref: ${{ steps.defaults.outputs.target_ref }}
         fetch-depth: 0
     
     - name: Display benchmark target info
@@ -63,7 +86,7 @@ jobs:
         echo "  BENCHMARK TARGET INFORMATION"
         echo "================================"
         echo "Repository: vprusso/toqito"
-        echo "Reference: ${{ steps.target-ref.outputs.ref }}"
+        echo "Reference: ${{ steps.defaults.outputs.target_ref }}"
         echo "Commit SHA: $(git rev-parse HEAD)"
         echo "Commit Message: $(git log -1 --pretty=format:'%s')"
         echo "Author: $(git log -1 --pretty=format:'%an <%ae>')"


### PR DESCRIPTION
We introduce a new workflow named `Benchmark Regression Analysis` to support automated performance tracking.

- [x] Supports `workflow_dispatch` for targeted benchmark runs (customizable via inputs).
- [x] Runs automatically on pull requests to `master`. (We can remove this after merging because most of the times run will be done manually to avoid unnecessary full runs)

- [x] configurable inputs for `workflow_dispatch`
  - `target_ref`: commit SHA to benchmark against.
  - `benchmark_type`: choose between full and simple benchmark modes.
  - `filter / function`: allow filtering tests by name or function pattern.
  - `save_results`: optionally store benchmark results for later reference.
  - `fail_on_regression`: control whether regressions cause CI failure.
  - `regression_threshold`: define acceptable performance deviation.
 
- [x] Compares new benchmark results against a baseline (`benchmarks/baseline.json`).
- [x] 🔴 Regressions (significant slowdown > threshold + noise).
- [x] 🟡 Large changes (big relative difference).
- [x] 🟠 Significant changes (beyond statistical noise).
- [x] ✅ Stable results. 