### PR TITLE
Fixing minor typos and inconsistencies in the hadamard function

### DIFF
--- a/toqito/matrices/hadamard.py
+++ b/toqito/matrices/hadamard.py
@@ -24,7 +24,7 @@ def hadamard(n_param: int = 1) -> np.ndarray:
 
     Examples
     ==========
-    The standard 1-qubit Hadamard matrix can be generated in :code:`|toqito⟩` as
+    The standard 1-qubit Hadamard matrix can be generated in :code:`toqito` as
 
     .. jupyter-execute::
 


### PR DESCRIPTION
## Description
This PR corrects minor typos and inconsistencies in the hadamard function and its related docstrings. These changes improve clarity and consistency of documentation without altering the underlying functionality of the code.
Fixes #1316 

## Changes
  - [x] Fixed LaTeX math notation in the Hadamard matrix definition (i \dot j → i \cdot j).
 -  [x] Corrected terminology in the example section (2-qubit → 1-qubit) to align with the actual behavior of hadamard(1).
 -  [x] Capitalized "Hamming" in docstrings to properly reference the Hamming distance



## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
