### PR TITLE
fix(abs-ppt): ensure renum_su_tri is reshaped to 2D

### DIFF
--- a/toqito/state_props/abs_ppt_constraints.py
+++ b/toqito/state_props/abs_ppt_constraints.py
@@ -163,7 +163,7 @@ def abs_ppt_constraints(
     def _create_constraint(eigs: np.ndarray, order_matrix: np.ndarray, p: int) -> np.ndarray:
         r"""Return constraint matrix from order matrix."""
         add_index = -np.where(order_matrix, order_matrix, order_matrix.T)
-        renum_su_tri = np.unique(order_matrix - np.diag(np.diag(order_matrix)), return_inverse=True)[1]
+        renum_su_tri = np.unique(order_matrix - np.diag(np.diag(order_matrix)), return_inverse=True)[1].reshape(p, p)
         sub_index = renum_su_tri + renum_su_tri.T - 1 + np.diag(np.diag(add_index) + 1)
         diag = np.diag if isinstance(eigs, np.ndarray) else cp.diag
         return eigs[add_index] - eigs[sub_index] + 2 * diag(eigs[np.diag(add_index)])


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->

`renum_su_tri` was returning as 1D while `add_index` was returning as 2D. This was causing the example in the docs to fail and a handful of tests as NumPy couldn't distinguish between the different shapes of the arrays. 

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [x] reshape `renum_su_tri` to 2D

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
