### PR TITLE
fix(cyclic-perm-matrix): Add validation for 'int'

### DIFF
--- a/toqito/matrices/cyclic_permutation_matrix.py
+++ b/toqito/matrices/cyclic_permutation_matrix.py
@@ -46,6 +46,13 @@ def cyclic_permutation_matrix(n: int, k: int = 1) -> np.ndarray:
         of the cyclic permutation.
 
     """
+    if not isinstance(n, int):
+        raise TypeError("'n' must be an integer.")
+    if n <= 0:
+        raise ValueError("'n' must be a positive integer.")
+    if not isinstance(k, int):
+        raise TypeError("'k' must be an integer.")
+
     p_mat = np.zeros((n, n), dtype=int)
     np.fill_diagonal(p_mat[1:], 1)
     p_mat[0, -1] = 1

--- a/toqito/matrices/tests/test_cyclic_permutation_matrix.py
+++ b/toqito/matrices/tests/test_cyclic_permutation_matrix.py
@@ -1,35 +1,69 @@
 """Test cyclic_permutation_matrix."""
 
 import numpy as np
+import pytest
 
 from toqito.matrices import cyclic_permutation_matrix
 
 
-def test_cyclic_permutation_matrix_fixed():
+@pytest.mark.parametrize("n", [10])
+def test_cyclic_permutation_matrix_fixed(n):
     """Test cyclic permuation matrix."""
-    n = 10
     res = cyclic_permutation_matrix(n)
     assert np.allclose(np.linalg.matrix_power(res, n), np.eye(n))
 
 
-def test_cyclic_permutation_matrix_successive():
+@pytest.mark.parametrize(
+    "n,k",
+    [
+        (4, 1),
+        (4, 2),
+        (4, 3),
+    ],
+)
+def test_cyclic_permutation_matrix_successive(n, k):
     """Test a successive cyclic permuation matrix."""
-    n = 4
-    # Test for k from 1 to n - 1
-    for k in range(1, n):
-        res = cyclic_permutation_matrix(n, k)
-        assert np.allclose(np.linalg.matrix_power(res, n), np.eye(n))
+    res = cyclic_permutation_matrix(n, k)
+    assert np.allclose(np.linalg.matrix_power(res, n), np.eye(n))
 
 
-def test_cyclic_permutation_matrix_checks():
-    """Run checks to confrim a proper cyclic permutation."""
-    for n in (2, 4, 6, 8, 10):
-        res = cyclic_permutation_matrix(n)
-        # Check the size of the matrix
-        np.testing.assert_equal(res.shape, (n, n))
-        # Check that the matrix is equal to the calculated matirx
-        expected_matrix = np.zeros((n, n), dtype=int)
-        np.fill_diagonal(expected_matrix[1:], 1)
-        expected_matrix[0, -1] = 1
+@pytest.mark.parametrize("n", [2, 4, 6, 8, 10])
+def test_cyclic_permutation_matrix_checks(n):
+    """Test to confrim a proper cyclic permutation."""
+    res = cyclic_permutation_matrix(n)
 
-        np.testing.assert_array_equal(res, expected_matrix)
+    # Shape check
+    np.testing.assert_equal(res.shape, (n, n))
+
+    # Expected cyclic permutation matrix
+    expected_matrix = np.zeros((n, n), dtype=int)
+    np.fill_diagonal(expected_matrix[1:], 1)
+    expected_matrix[0, -1] = 1
+
+    np.testing.assert_array_equal(res, expected_matrix)
+
+
+@pytest.mark.parametrize("n", [1.0])
+def test_cyclic_permutation_matrix_n_invalid(n):
+    """Test function raises TypeError for invalid input 'n'."""
+    with pytest.raises(TypeError, match="'n' must be an integer."):
+        cyclic_permutation_matrix(n=n)
+
+
+@pytest.mark.parametrize("n", [-2])
+def test_cyclic_permutation_matrix_positive_int(n):
+    """Test function raises ValueError for invalid input."""
+    with pytest.raises(ValueError, match="'n' must be a positive integer."):
+        cyclic_permutation_matrix(n=n)
+
+
+@pytest.mark.parametrize(
+    "n, k",
+    [
+        (4, 2.0),
+    ],
+)
+def test_cyclic_permutation_matrix_k_invalid(n, k):
+    """Test function raises TypeError for invalid input 'k'."""
+    with pytest.raises(TypeError, match="'k' must be an integer."):
+        cyclic_permutation_matrix(n=n, k=k)


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->

Parent: https://github.com/vprusso/toqito/issues/1327

Added validation for `cyclic_permuation_matrix`and refactored tests in`test_cyclic_permutation_matrix`.

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [x] Check `n` is an integer.
  -  [x] Check `n` is a positive integer.
  -  [x] Check `k` is an integer.

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
