### PR TITLE
fix: added Dimension Check in choi_to_kraus.py

### DIFF
--- a/toqito/channel_ops/choi_to_kraus.py
+++ b/toqito/channel_ops/choi_to_kraus.py
@@ -89,6 +89,15 @@ def choi_to_kraus(
     :return: List of Kraus operators
 
     """
+    if dim is not None:
+        if isinstance(dim, int):
+            dim_check = np.array([dim])
+        else:
+            dim_check = np.array(dim)
+
+        if np.any(dim_check <= 0):
+            raise ValueError("Dimension must be greater than 0.")
+
     d_in, d_out, _ = channel_dim(choi_mat, dim=dim, compute_env_dim=False)
     if is_hermitian(choi_mat):
         eigvals, v_mat = np.linalg.eigh(choi_mat)

--- a/toqito/channel_ops/tests/test_choi_to_kraus.py
+++ b/toqito/channel_ops/tests/test_choi_to_kraus.py
@@ -131,3 +131,13 @@ def test_choi_to_kraus_general_map():
     res_kraus_ops = choi_to_kraus(choi_mat)
 
     assert np.isclose(kraus_ops, res_kraus_ops).all()
+
+
+def test_choi_to_kraus_invalid_dim():
+    """Choi to kraus output for invalid dimensions."""
+    choi_mat = np.identity(4)
+    with pytest.raises(ValueError, match="Dimension must be greater than 0."):
+        choi_to_kraus(choi_mat, dim=0)
+
+    with pytest.raises(ValueError, match="Dimension must be greater than 0."):
+        choi_to_kraus(choi_mat, dim=[-2, 2])


### PR DESCRIPTION
## Description
Closes #1325 by checking `dim` variable

## Changes

  - [x] Added check for `dim` variable for all valid Error (`dim<=0` raises `valueError`).
  - [x] Added test case for validating `dim<=0` error.

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
