### PR TITLE
fix: added dimension validation to realignment

### DIFF
--- a/toqito/channels/realignment.py
+++ b/toqito/channels/realignment.py
@@ -49,6 +49,14 @@ def realignment(input_mat: np.ndarray, dim: int | list[int] = None) -> np.ndarra
     :return: The realignment map matrix.
 
     """
+    if dim is not None:
+        if isinstance(dim, int):
+            dim_check = np.array([dim])
+        else:
+            dim_check = np.array(dim)
+
+        if np.any(dim_check <= 0):
+            raise ValueError("Dimension must be greater than 0.")
     dim_mat = input_mat.shape
     round_dim = np.round(np.sqrt(dim_mat))
     if dim is None:

--- a/toqito/channels/tests/test_realignment.py
+++ b/toqito/channels/tests/test_realignment.py
@@ -1,6 +1,7 @@
 """Test realignment."""
 
 import numpy as np
+import pytest
 
 from toqito.channels import realignment
 
@@ -70,3 +71,12 @@ def test_realignment_int_dim():
 
     res = realignment(test_input_mat, 1)
     np.testing.assert_array_equal(res, expected_res)
+
+
+def test_realignment_invalid_dim():
+    """Pass in invalid dimension argument."""
+    test_input_mat = np.arange(1, 17).reshape(4, 4)
+    with pytest.raises(ValueError, match="Dimension must be greater than 0."):
+        realignment(test_input_mat, dim=0)
+    with pytest.raises(ValueError, match="Dimension must be greater than 0."):
+        realignment(test_input_mat, dim=[2, -2])


### PR DESCRIPTION
## Description
Closes #1329 by checking dim variable

## Changes

  - [x] Added check for `dim` variable for all valid Error (`dim<=0` raises `valueError`).
  - [x] Added test case for validating `dim<=0` error.


## Checklist

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
