### PR TITLE
fix hilbert–schmidt and bures implementations and update tests

### DIFF
--- a/toqito/rand/tests/test_random_density_matrix.py
+++ b/toqito/rand/tests/test_random_density_matrix.py
@@ -54,29 +54,63 @@ def test_random_density_matrix(dim, is_real, distance_metric):
 @pytest.mark.parametrize(
     "dim, is_real, k_param, distance_metric, expected",
     [
-        # Generate random non-real density matrix.
         (
             2,
             False,
             None,
             "haar",
-            np.array([[0.37758384 + 0.0j, 0.19597419 + 0.19965911j], [0.19597419 - 0.19965911j, 0.62241616 + 0.0j]]),
+            np.array(
+                [
+                    [0.22986343 + 0.0j, 0.13365203 - 0.20624294j],
+                    [0.13365203 + 0.20624294j, 0.77013657 + 0.0j],
+                ]
+            ),
         ),
-        # Generate random real density matrix.
-        (2, True, None, "haar", np.array([[0.45158815, 0.49355259], [0.49355259, 0.54841185]])),
-        # Random non-real density matrix according to Bures metric.
+        (
+            2,
+            True,
+            None,
+            "haar",
+            np.array(
+                [
+                    [0.13871939, 0.33280544],
+                    [0.33280544, 0.86128061],
+                ]
+            ),
+        ),
         (
             2,
             False,
             None,
             "bures",
-            np.array([[0.31466466 + 0.0j, -0.09170064 + 0.24517065j], [-0.09170064 - 0.24517065j, 0.68533534 + 0.0j]]),
+            np.array(
+                [
+                    [0.38769156 + 0.0j, -0.3872277 + 0.26396657j],
+                    [-0.3872277 - 0.26396657j, 0.61230844 + 0.0j],
+                ]
+            ),
         ),
-        # Generate random non-real density matrix all params.
-        (2, True, 2, "haar", np.array([[0.45158815, 0.49355259], [0.49355259, 0.54841185]])),
+        (
+            2,
+            True,
+            2,
+            "haar",
+            np.array(
+                [
+                    [0.13871939, 0.33280544],
+                    [0.33280544, 0.86128061],
+                ]
+            ),
+        ),
     ],
 )
+
 def test_seed(dim, is_real, k_param, distance_metric, expected):
     """Test that the function produces the expected output using a seed."""
     dm = random_density_matrix(dim, is_real, k_param=k_param, distance_metric=distance_metric, seed=124)
     assert_allclose(dm, expected)
+
+def test_invalid_distance_metric():
+    """Ensure invalid distance_metric raises ValueError."""
+    with pytest.raises(ValueError):
+        random_density_matrix(2, distance_metric="invalid")


### PR DESCRIPTION
## Description

closes #1392
this PR corrects the implementation of the Hilbert–Schmidt (Haar) and Bures measures in `random_density_matrix`
the Ginibre matrix is now generated using Gaussian sampling (as required for the Hilbert–Schmidt measure), and the Bures construction has been corrected to use left-multiplication by `(I + U)` instead of computing `U + G`
a test for invalid `distance_metric` was also added

## Changes

replaced Uniform sampling with Gaussian sampling for Ginibre matrix generation
corrected Bures construction to `(I + U) @ G`
updated seed-based expected values in tests
added test to ensure invalid `distance_metric` raises `ValueError`

## Checklist

- [x] Use `ruff` for errors related to code style and formatting
- [x] Verify all previous and newly added unit tests pass in `pytest`
- [x] Check the documentation build does not lead to any failures