### PR TITLE
Add edge-case tests for invalid input in is_ppt

### DIFF
--- a/toqito/state_props/tests/test_is_ppt.py
+++ b/toqito/state_props/tests/test_is_ppt.py
@@ -10,18 +10,44 @@ from toqito.states import bell, horodecki
 @pytest.mark.parametrize(
     "mat, sys, dim, tol, expected_result",
     [
-        # Check that PPT matrix returns True.
         (np.identity(9), 2, None, None, True),
-        # Check that PPT matrix returns True with dim and sys specified.
         (np.identity(9), 2, [3], None, True),
-        # Check that PPT matrix returns True.
         (np.identity(9), 2, [3], 1e-10, True),
-        # Entangled state of dimension 2 will violate PPT criterion.
         (bell(2) @ bell(2).conj().T, 2, None, None, False),
-        # Horodecki state is an example of an entangled PPT state.
         (horodecki(0.5, [3, 3]), 2, None, None, True),
     ],
 )
 def test_is_ppt(mat, sys, dim, tol, expected_result):
     """Test function works as expected for a valid input."""
     np.testing.assert_equal(is_ppt(mat=mat, sys=sys, dim=dim, tol=tol), expected_result)
+
+
+def test_is_ppt_non_square_matrix():
+    """Test is_ppt raises ValueError for non-square input."""
+    mat = np.array([[1, 0, 0],
+                    [0, 1, 0]])
+
+    with pytest.raises(ValueError):
+        is_ppt(mat=mat, sys=2)
+
+
+def test_is_ppt_one_dimensional_input():
+    """Test is_ppt raises ValueError for 1D input."""
+    mat = np.array([1, 2, 3, 4])
+
+    with pytest.raises(ValueError):
+        is_ppt(mat=mat, sys=2)
+
+
+def test_is_ppt_invalid_dim():
+    """Test is_ppt raises ValueError for invalid dim."""
+    mat = np.eye(4)
+
+    with pytest.raises(ValueError):
+        is_ppt(mat=mat, sys=2, dim=[2, 3])
+
+
+def test_is_ppt_non_numeric_input():
+    """Test is_ppt raises TypeError for non-numeric input."""
+    with pytest.raises((TypeError, ValueError)):
+        is_ppt(mat="not a matrix", sys=2)


### PR DESCRIPTION
This PR improves the robustness of the `is_ppt` function by adding
unit tests that cover invalid and edge-case inputs.

### Changes
- Added tests to verify `is_ppt` raises an exception for non-square matrices.
- Added tests for one-dimensional inputs that do not represent valid matrices.
- Added tests to ensure invalid `dim` parameters are rejected.
- Added tests to confirm non-numeric inputs raise appropriate errors.
- Ensured existing valid-input behavior remains unchanged.

Fixes #1395.
