### PR TITLE
Fix typo in bell.py docstring: 'teh' -> 'the'

### DIFF
--- a/toqito/states/bell.py
+++ b/toqito/states/bell.py
@@ -1,4 +1,4 @@
-"""Bell states represent teh simplest examples of quantum entanglement of two qubits.
+"""Bell states represent the simplest examples of quantum entanglement of two qubits.
 
 Also known as EPR pairs, Bell states comprise of four quantum states in a superposition of 0 and 1.
 """


### PR DESCRIPTION
## Description
Fixes a typo in the `bell.py` module docstring where "teh" was incorrectly spelled instead of "the".
## Changes
  - [x] Changed "teh" to "the" in `toqito/states/bell.py` module docstring (line 1)
## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 
Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).
  - [x] Use `ruff` for errors related to code style and formatting.
  - [x] Verify all previous and newly added unit tests pass in `pytest`.
  - [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
---
## Type of Change
- [x] Documentation fix (typo correction)
- [ ] Bug fix
- [ ] New feature
## Additional Notes
This is a simple typo fix in documentation that does not affect code functionality. No tests are affected by this change.