### PR TITLE
Fix duplicate word in mutual_coherence.py comment: 'the the' -> 'the'

### DIFF
--- a/toqito/matrix_props/mutual_coherence.py
+++ b/toqito/matrix_props/mutual_coherence.py
@@ -43,7 +43,7 @@ def mutual_coherence(vectors: list[np.ndarray]) -> float:
     # Convert input into a 2D numpy array.
     vectors = np.column_stack(vectors).astype(float)
 
-    # Normalize the the vectors.
+    # Normalize the vectors.
     vectors /= np.linalg.norm(vectors, axis=0)
 
     # Calculate the inner product between all pairs of columns.


### PR DESCRIPTION
## Description
Fixes a duplicate word in a comment in `mutual_coherence.py` where "the the" should be just "the".
## Changes
  - [x] Changed "the the" to "the" in `toqito/matrix_props/mutual_coherence.py` comment (line 46)
## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 
Additional information is available in the [documentation](https://toqito.readthedocs.io/en/latest/contributing.html#testing).
  - [x] Use `ruff` for errors related to code style and formatting.
  - [x] Verify all previous and newly added unit tests pass in `pytest`.
  - [x] Check the documentation build does not lead to any failures. `Sphinx` build can be checked locally for any failures related to your PR
---
## Type of Change
- [x] Documentation fix (comment correction)
- [ ] Bug fix
- [ ] New feature
## Additional Notes
This is a simple fix of a duplicate word in a code comment. No functionality is affected by this change.