### PR TITLE
docs: add quantum projector example to is_projection

### DIFF
--- a/toqito/matrix_props/is_projection.py
+++ b/toqito/matrix_props/is_projection.py
@@ -39,6 +39,28 @@ def is_projection(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> 
 
      is_projection(A)
 
+    A common use case in quantum mechanics is checking if a matrix represents a valid quantum measurement
+    projector. For example, the projector onto the :math:`|0\rangle` state is defined as:
+
+    .. math::
+        P_0 = |0\rangle\langle 0| = \begin{pmatrix}
+                1 & 0 \\
+                0 & 0
+              \end{pmatrix}
+
+    This projector satisfies :math:`P_0^2 = P_0` and is positive semidefinite.
+
+    .. jupyter-execute::
+
+     import numpy as np
+     from toqito.matrix_props import is_projection
+
+     # Projector onto |0⟩ state
+     ket_0 = np.array([[1], [0]])
+     proj_0 = ket_0 @ ket_0.conj().T
+
+     is_projection(proj_0)
+
     Alternatively, the following example matrix :math:`B` defined as
 
     .. math::


### PR DESCRIPTION
## Summary
Adds a practical quantum computing example to [is_projection.py](cci:7://file:///c:/Users/abhay/toquito/toqito/toqito/matrix_props/is_projection.py:0:0-0:0) demonstrating projection onto the |0⟩ state.

## Changes
- Added example showing `|0⟩⟨0|` projector construction from state vectors
- Demonstrates practical quantum measurement context
- Includes mathematical notation and explanation of the projector property P₀² = P₀

## Example Added
```python
# Projector onto |0⟩ state
ket_0 = np.array([[1], [0]])
proj_0 = ket_0 @ ket_0.conj().T

is_projection(proj_0)  # Returns True