### PR TITLE
Add generator for random linearly independent vectors

### DIFF
--- a/toqito/rand/__init__.py
+++ b/toqito/rand/__init__.py
@@ -9,4 +9,4 @@ from toqito.rand.random_states import random_states
 from toqito.rand.random_circulant_gram_matrix import random_circulant_gram_matrix
 from toqito.rand.random_orthonormal_basis import random_orthonormal_basis
 from toqito.rand.random_psd_operator import random_psd_operator
-from toqito.rand.random_linearly_independent_vectors import generate_random_independent_vectors
+from toqito.rand.random_linearly_independent_vectors import random_linearly_independent_vectors

--- a/toqito/rand/random_linearly_independent_vectors.py
+++ b/toqito/rand/random_linearly_independent_vectors.py
@@ -1,30 +1,33 @@
-"""Utilities for generating random linearly independent vectors."""
+"""Generate a random set of linearly independent vectors."""
 
 import numpy as np
 
 from toqito.matrix_props import is_linearly_independent
 
-max_tries = 1000
-def generate_random_independent_vectors(
+
+def random_linearly_independent_vectors(
     num_vectors: int,
     dim: int,
     is_real: bool = True,
     seed: int | None = None,
+    max_tries: int = 1_000,
 ) -> np.ndarray:
     r"""Generate random linearly independent vectors.
 
-    Generates a collection of random vectors that are guaranteed to be linearly independent.
+    This function repeatedly samples random vectors (real or complex) and checks
+    their linear independence until a valid set is found or a maximum number of
+    attempts is reached.
 
-    Examples
-    ==========
-    >>> from toqito.rand import generate_random_independent_vectors
-    >>> vecs = generate_random_independent_vectors(num_vectors=2, dim=3, seed=42)
-    >>> vecs.shape
-    (3, 2)
+    Random vectors are drawn from a standard normal distribution. Independence is
+    verified using :func:`toqito.matrix_props.is_linearly_independent`. If a valid
+    set of vectors cannot be generated within ``max_tries`` attempts, a
+    ``RuntimeError`` is raised.
 
     References
     ==========
     .. footbibliography::
+
+
     :param num_vectors: Number of independent vectors to generate.
     :param dim: Dimension of the vector space.
     :param is_real: Whether vectors are real-valued (default is True).
@@ -35,7 +38,7 @@ def generate_random_independent_vectors(
 
     """
     if num_vectors > dim:
-        raise ValueError("Cannot have more independent vectors than the dimension of the space.")
+        raise ValueError(f"Number of vectors {num_vectors} cannot be greater than dimension {dim}")
 
     rng = np.random.default_rng(seed)
 
@@ -50,4 +53,4 @@ def generate_random_independent_vectors(
         if is_linearly_independent(vectors):
             return mat
 
-    raise RuntimeError("Failed to generate linearly independent vectors after multiple attempts.")
+    raise RuntimeError(f"Failed to generate linearly independent vectors after {max_tries} attempts.")

--- a/toqito/rand/tests/__init__.py
+++ b/toqito/rand/tests/__init__.py
@@ -1,2 +1,2 @@
 """Tests for random."""
-from toqito.rand.random_linearly_independent_vectors import generate_random_independent_vectors
+from toqito.rand.random_linearly_independent_vectors import random_linearly_independent_vectors

--- a/toqito/rand/tests/test_random_linearly_independent_vectors.py
+++ b/toqito/rand/tests/test_random_linearly_independent_vectors.py
@@ -1,16 +1,19 @@
 """Unit tests for generate_random_independent_vectors."""
 
+import importlib
+
 import numpy as np
 import pytest
 
 from toqito.matrix_props import is_linearly_independent
-from toqito.rand.random_linearly_independent_vectors import generate_random_independent_vectors
+from toqito.rand.random_linearly_independent_vectors import random_linearly_independent_vectors
 
+rliv = importlib.import_module("toqito.rand.random_linearly_independent_vectors")
 
 @pytest.mark.parametrize("is_real", [True, False])
-def test_generate_random_independent_vectors_valid(is_real):
+def test_random_linearly_independent_vectors_valid(is_real):
     """Generated vectors should be linearly independent."""
-    vecs = generate_random_independent_vectors(
+    vecs = random_linearly_independent_vectors(
         num_vectors=3,
         dim=5,
         is_real=is_real,
@@ -23,29 +26,30 @@ def test_generate_random_independent_vectors_valid(is_real):
     assert is_linearly_independent(vectors)
 
 
-def test_generate_random_independent_vectors_reproducible():
+def test_random_linearly_independent_vectors_reproducible():
     """Generator should be reproducible when a seed is provided."""
-    vecs1 = generate_random_independent_vectors(2, 4, seed=42)
-    vecs2 = generate_random_independent_vectors(2, 4, seed=42)
+    vecs1 = random_linearly_independent_vectors(2, 4, seed=42)
+    vecs2 = random_linearly_independent_vectors(2, 4, seed=42)
 
     assert np.allclose(vecs1, vecs2)
 
 
-def test_generate_random_independent_vectors_invalid():
+def test_random_linearly_independent_vectors_invalid():
     """Requesting too many vectors should raise a ValueError."""
     with pytest.raises(ValueError):
-        generate_random_independent_vectors(num_vectors=5, dim=3)
+        random_linearly_independent_vectors(num_vectors=5, dim=3)
 
-def test_generate_random_independent_vectors_failure(monkeypatch):
+def test_random_linearly_independent_vectors_failure(monkeypatch):
     """Raises RuntimeError if independent vectors cannot be generated."""
 
     def always_dependent(*args, **kwargs):
         return np.zeros((3, 2))
 
     monkeypatch.setattr(
-        "toqito.rand.random_linearly_independent_vectors.is_linearly_independent",
+        rliv,
+        "is_linearly_independent",
         lambda _: False,
     )
 
     with pytest.raises(RuntimeError):
-        generate_random_independent_vectors(num_vectors=2, dim=3, seed=0)
+        random_linearly_independent_vectors(num_vectors=2, dim=3, seed=0)


### PR DESCRIPTION
This PR implements a utility for generating random linearly independent vectors, as proposed in #1182.

It adds:
- generate_random_independent_vectors in toqito/rand/
- unit tests with full coverage
- docstring examples

The implementation uses toqito.matrix_props.is_linearly_independent as requested.