### PR TITLE
move sympy to main dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "numba>=0.62.0,<0.64.0",
     "jupyter-sphinx>=0.5.3,<0.6.0",
     "matplotlib==3.10.1",
+    "sympy==1.14.0",
 ]
 
 [project.urls]
@@ -46,7 +47,6 @@ dev = [
     "pytest==9.0.0",
     "pytest-cov==6.3.0",
     "coverage==7.13.0",
-    "sympy==1.14.0",
     "distlib==0.4.0",
     "ipython==8.38.0",
     "setuptools>65.5.1",


### PR DESCRIPTION
## Description

SymPy is actually a required dependency since it is used in [`mutually_unbiased_basis.py`](https://github.com/vprusso/toqito/blob/74f29df6f948ed6f3886f1878da4cbb4fea1ca93/toqito/states/mutually_unbiased_basis.py#L8).

Not sure if the version range should be broadened, but happy to do that if suggested.
