### PR TITLE
docs: fix code style reference anchor

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -82,7 +82,7 @@ If you add a new feature to :code:`|toqito⟩`, make sure
 - The docstring of a new feature should contain a theoretical description of the feature, one or more examples in an :code:`Examples`
   subsection and a :code:`References` subsection. The docstring code examples should utilize `jupyter-sphinx <https://jupyter-sphinx.readthedocs.io/en/latest/>`_. 
 - Added lines should show up as covered in the :code:`pytest` code coverage report. See `Testing`_.
-- Code and unit tests for the new feature should follow the style guidelines as discussed in `Code Style`_.
+- Code and unit tests for the new feature should follow the style guidelines as discussed in :ref:`Code Style <code_style_reference-label>`.
 - The new feature must be added to the :code:`init` file of its module to avoid import issues. 
 - Finally, if the new feature is a new module, it has to be listed in :code:`docs/autoapi_members.rst` such that the new module appears
   in the :code:`API Reference` page due to :code:`sphinx-autoapi`.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -119,6 +119,8 @@ A beginner introduction to adding unit tests is available `here <https://third-b
     timings or regression checks.
 
 
+.. _code_style_reference-label:
+
 ----------
 Code Style
 ----------
@@ -162,7 +164,7 @@ References in Docstrings
 
 
 If you are adding a new function, make sure the docstring of your function follows the formatting specifications
-in `Code Style`_. A standard format for :code:`|toqito⟩` docstring is provided below:
+in :ref:`Code Style <code_style_reference-label>`. A standard format for :code:`|toqito⟩` docstring is provided below:
 
 .. code-block:: python
     

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -134,7 +134,7 @@ Do not use an autoformatter like :code:`black` as the configuration settings for
 might be incompatible with the changes made by :code:`black`. This is discussed in detail at
 `this link <https://docs.astral.sh/ruff/formatter/black/>`_.
 
-Static typing is enforced with :code:`mypy <https://mypy.readthedocs.io/en/stable/>`_. Before submitting a pull request, run the
+Static typing is enforced with :code:`mypy` (see `mypy documentation <https://mypy.readthedocs.io/en/stable/>`_). Before submitting a pull request, run the
 type checker against the source tree (the type checker lives in the ``lint`` dependency group):
 
 .. code-block:: bash


### PR DESCRIPTION
## Summary
- Fix the broken mypy hyperlink that uses invalid RST syntax
- Separate code formatting from hyperlink to comply with RST standards
- Also improve Code Style cross-references with explicit labels (bonus fix)

## Rationale
- Fixes #1406 - the mypy link was using invalid syntax: `:code:`mypy <URL>``
- RST does not allow nesting hyperlinks inside code roles
- Separating them makes the documentation render correctly

## Changes

### Primary Fix (Line 137):
**Before (Broken RST syntax):**
```rst
Static typing is enforced with :code:`mypy <https://mypy.readthedocs.io/en/stable/>`_.
```

**After (Valid RST syntax):**
```rst
Static typing is enforced with :code:`mypy` (see `mypy documentation <https://mypy.readthedocs.io/en/stable/>`_).
```

### Secondary Improvements (Lines 85, 122-124, 167):
- Add explicit label `code_style_reference-label` for Code Style section
- Update two Code Style references to use `:ref:` directive
- Makes cross-references more robust and explicit

## Why This Matters

**The Issue:**
The original syntax ``:code:`mypy <URL>``` attempts to nest a hyperlink inside a code role, which is **invalid RST syntax** and causes the link to break in rendered documentation.

**The Fix:**
- `:code:`mypy`` - Preserves code formatting
- `(see `mypy documentation <URL>`_)` - Provides working hyperlink
- Both elements work correctly in rendered docs

## Test Plan
- RST syntax verified to be valid
- Code style checks passing
- Documentation will render correctly with working hyperlink
- ReadTheDocs build in progress

Fixes #1406