### PR TITLE
fix: local env setup fix

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -125,15 +125,15 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     
-    - name: Install Poetry
-      run: pip install poetry
-    
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
     - name: Setup toqito environment
       run: |
         cd toqito
         echo "Setting up toqito development environment..."
-        poetry install --with dev
-        poetry add pytest-benchmark --group dev pytest-memray sympy pygal
+        uv sync --group dev
+        uv pip install pytest-benchmark pytest-memray pygal
         echo "Environment setup complete"
     
     - name: Verify baseline benchmark exists
@@ -187,7 +187,7 @@ jobs:
 
         cd ../toqito
 
-        PYTEST_CMD="poetry run pytest ../toqito-bench/scripts/benchmark_toqito.py"
+        PYTEST_CMD="uv run pytest ../toqito-bench/scripts/benchmark_toqito.py"
         if [ -n "$FILTER" ]; then
           PYTEST_CMD="$PYTEST_CMD -k \"$FILTER\""
         fi
@@ -240,7 +240,7 @@ jobs:
 
         cd ../toqito
 
-        PYTEST_CMD="poetry run pytest ../toqito-bench/scripts/benchmark_toqito.py"
+        PYTEST_CMD="uv run pytest ../toqito-bench/scripts/benchmark_toqito.py"
         if [ -n "$FILTER" ]; then
           PYTEST_CMD="$PYTEST_CMD -k \"$FILTER\""
         fi

--- a/.github/workflows/build-test-actions.yml
+++ b/.github/workflows/build-test-actions.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
           # Add versions here to expand support matrix
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
@@ -39,11 +39,15 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get install -y libblas-dev liblapack-dev
+      - name: Install suite-sparse for macOS
+        if: runner.os == 'macOS'
+        run: |
+          brew install suite-sparse
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Install toqito + dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install poetry
-          poetry install --without docs --no-interaction
+          uv sync --group dev --no-group docs --no-group lint
 
 
   toqito-pytest:
@@ -51,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         # Add versions here to expand support matrix
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#using-a-matrix-strategy
@@ -67,17 +71,17 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get install -y libblas-dev liblapack-dev
-      - name: Install blas, lapack for macOS
+      - name: Install blas, lapack, suite-sparse for macOS
         if: runner.os == 'macOS'
         run: |
-          brew install openblas lapack
+          brew install openblas lapack suite-sparse
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Install toqito + dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install poetry
-          poetry install --with dev --without docs,lint --no-interaction
+          uv sync --group dev --no-group docs --no-group lint
       - name: Run tests
-        run: poetry run pytest -v --cov-config=.coveragerc --cov-report=xml --cov-report term-missing:skip-covered --cov=toqito
+        run: uv run pytest -v --cov-config=.coveragerc --cov-report=xml --cov-report term-missing:skip-covered --cov=toqito
       - name: Upload coverage information
         uses: codecov/codecov-action@v5
         with:
@@ -87,5 +91,5 @@ jobs:
           files: ./coverage.xml
           verbose: true
       - name: Build artifacts
-        run: poetry build
+        run: uv build
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,15 +22,13 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          make install requirements
-          pip install setuptools wheel twine
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Build and publish
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          python setup.py sdist bdist_wheel
+          uv build
+          pip install twine
           twine upload dist/*  

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -17,7 +17,7 @@ We welcome contributions from external contributors, and this document describes
 .. warning::
      Avoid ad-hoc :code:`pip install -e .` workflows; the project standardizes on :code:`uv` for syncing dependencies.
 
-4. As stated in :ref:`getting_started_reference-label`, ensure you have Python 3.10 to 3.12 installed on your machine or in 
+4. As stated in :ref:`getting_started_reference-label`, ensure you have Python 3.10 or greater installed on your machine or in
    a virtual environment (`pyenv <https://github.com/pyenv/pyenv>`_, `pyenv tutorial <https://realpython.com/intro-to-pyenv/>`_).
    Consider using a `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_.
    You can also use :code:`pyenv` with :code:`virtualenv` `to manage different Python

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -11,11 +11,17 @@ Getting started
 Installing
 ----------
 
-1. Ensure you have Python 3.10 or greater installed on your machine or in 
-a virtual environment (`pyenv <https://github.com/pyenv/pyenv>`_, `pyenv tutorial <https://realpython.com/intro-to-pyenv/>`_). 
+1. Ensure you have Python 3.10 or greater installed on your machine or in
+a virtual environment (`pyenv <https://github.com/pyenv/pyenv>`_, `pyenv tutorial <https://realpython.com/intro-to-pyenv/>`_).
 
-.. warning::
-    Python 3.13 is not yet supported due to incompatibilities with some dependencies (e.g., :code:`cvxopt`).
+.. note::
+    On macOS, the :code:`cvxopt` dependency (pulled in by :code:`picos`) may need to be built from source
+    if a pre-built wheel is not available for your Python version and macOS version. If you encounter a
+    build error mentioning :code:`umfpack.h`, install the required system library with:
+
+    .. code-block:: bash
+
+        brew install suite-sparse
 
 2. Consider using a `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_.
 You can also use :code:`pyenv` with :code:`virtualenv` `to manage different Python versions <https://github.com/pyenv/pyenv-virtualenv>`_. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -715,7 +715,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -2789,6 +2789,7 @@ dependencies = [
     { name = "picos" },
     { name = "scipy" },
     { name = "scs" },
+    { name = "sympy" },
 ]
 
 [package.dev-dependencies]
@@ -2801,7 +2802,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "setuptools" },
-    { name = "sympy" },
 ]
 docs = [
     { name = "furo" },
@@ -2836,6 +2836,7 @@ requires-dist = [
     { name = "picos", specifier = ">=2.6.2" },
     { name = "scipy", specifier = "==1.15.3" },
     { name = "scs", specifier = "==3.2.7.post2" },
+    { name = "sympy", specifier = "==1.14.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2848,7 +2849,6 @@ dev = [
     { name = "pytest", specifier = "==9.0.0" },
     { name = "pytest-cov", specifier = "==6.3.0" },
     { name = "setuptools", specifier = ">65.5.1" },
-    { name = "sympy", specifier = "==1.14.0" },
 ]
 docs = [
     { name = "furo", specifier = "==2025.12.19" },


### PR DESCRIPTION
Closes: #1404

The only cvxopt wheel for Python 3.13 ARM64 requires macOS 15.0+ (macosx_15_0_arm64), so `uv` falls back to building from source, which fails because SuiteSparse (umfpack.h) isn't installed.

Updated python versions / uv.lock / docs to clarify this. 