### PR TITLE
Fix block hermitian K

### DIFF
--- a/toqito/nonlocal_games/extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/extended_nonlocal_game.py
@@ -537,7 +537,11 @@ class ExtendedNonlocalGame:
         K = {}
         for x in range(A_in):
             for y in range(B_in):
-                K[(x, y)] = cvxpy.Variable((A_out * dR, B_out * dR), hermitian=True, name=f"K({x},{y})")
+                blocks = [[None for _ in range(B_out)] for _ in range(A_out)]
+                for a in range(A_out):
+                    for b in range(B_out):
+                        blocks[a][b] = cvxpy.Variable((dR, dR), hermitian=True, name=f"K({x},{y})_{a}{b}")
+                K[(x, y)] = cvxpy.bmat(blocks)
         total_win = cvxpy.Constant(0)
         for x in range(A_in):
             for y in range(B_in):

--- a/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
@@ -239,7 +239,7 @@ class TestExtendedNonlocalGame(unittest.TestCase):
             tol=1e-7,
             seed=42,
         )
-        # NPA k=2 is known to give a loose classical bound for this game
+        # NPA k=1 upper bound (loose for this game)
         ent_ub = game.commuting_measurement_value_upper_bound(k=1)
 
         expected_classical_value = 2 / 3.0
@@ -256,15 +256,12 @@ class TestExtendedNonlocalGame(unittest.TestCase):
             delta=1e-4,
         )
 
-        # 3. Verify the NPA k=2 upper bound is classical
-        self.assertAlmostEqual(
-            ent_ub,
-            expected_classical_value,
-            delta=1e-4,
-        )
+        # 3. Verify the NPA k=1 upper bound.
+        # With block-hermitian K (correct formulation), the NPA k=1 bound is
+        # loose for this game (~0.873), not the classical value.
+        self.assertAlmostEqual(ent_ub, 0.8727, delta=5e-3)
 
         # 4. Verify universal ordering that MUST hold for valid bounds
-        # All these should pass as unent, ent_lb, ent_ub are all ~0.666
         self.assertLessEqual(unent, ent_lb + 1e-5)
         self.assertLessEqual(ent_lb, ent_ub + 1e-5)
         self.assertLessEqual(ent_ub, ns + 1e-5)
@@ -505,7 +502,9 @@ class TestExtendedNonlocalGame(unittest.TestCase):
         pi, pred_mat = self.four_mub_game()
         game = ExtendedNonlocalGame(pi, pred_mat)
         ub = game.commuting_measurement_value_upper_bound(k=1, no_signaling=False)
-        self.assertAlmostEqual(ub, 0.760573, delta=5e-3)
+        # With block-hermitian K (correct formulation), the bound is looser than
+        # the old globally-hermitian formulation which gave ~0.761.
+        self.assertAlmostEqual(ub, 0.8067, delta=5e-3)
 
     def test_four_mub_nonsignaling_value(self):
         """No-signaling value of the 4-MUB game."""

--- a/toqito/state_opt/npa_hierarchy.py
+++ b/toqito/state_opt/npa_hierarchy.py
@@ -282,8 +282,8 @@ def npa_constraints(
     # Ensure rho_R_referee is a valid quantum state
     constraints = [
         cvxpy.trace(rho_R_referee) == 1,
-        rho_R_referee >> 0,
         moment_matrix_R >> 0,
+        # rho_R_referee >> 0 holds since it is a minor of moment_matrix_R
     ]
 
     # Store relations for (S_i^dagger S_j) -> block_index in moment_matrix_R


### PR DESCRIPTION
## Description

This PR fixes #1257.
The problem was that the variables `K[(x, y)]` were taken to be hermitian while they should only contain hermitian blocks. This was leading to an overly constrained problem, hence lower maximal values.

## Changes

`K[(x, y)]` is now defined blockwise through the command `cvxpy.bmat`, after having defined each (hermitian) block manually.
In `npa_constraints`, I also removed a redundant constraint: the state of the referee is simply a minor of the moment matrix, so enforcing its positivity is not required.