### PR TITLE
fix: symmetric extension on maximally mixed states now returns true

### DIFF
--- a/toqito/state_props/has_symmetric_extension.py
+++ b/toqito/state_props/has_symmetric_extension.py
@@ -160,6 +160,6 @@ def has_symmetric_extension(
             constraints.append(partial_transpose(sigma, [sys + 2], dim_list) >> 0)
 
     problem = cvxpy.Problem(cvxpy.Minimize(0), constraints)
-    problem.solve(solver=cvxpy.SCS, eps=tol)
+    problem.solve()
 
     return problem.status == "optimal"

--- a/toqito/state_props/has_symmetric_extension.py
+++ b/toqito/state_props/has_symmetric_extension.py
@@ -1,10 +1,11 @@
 """Determine whether there exists a symmetric extension for a given quantum state."""
 
+import cvxpy
 import numpy as np
-from picos import partial_trace
 
+from toqito.matrix_ops import partial_trace, partial_transpose
 from toqito.matrix_props import is_positive_semidefinite
-from toqito.state_opt.symmetric_extension_hierarchy import symmetric_extension_hierarchy
+from toqito.perms import symmetric_projection
 from toqito.state_props.is_ppt import is_ppt
 
 
@@ -132,16 +133,33 @@ def has_symmetric_extension(
     # (2-copy, non-PPT) symmetric extension that is much faster to use than semidefinite
     # programming [CJKLZB14]_.
     if level == 2 and not ppt and dim_x == 2 and dim_y == 2:
-        return np.trace(np.linalg.matrix_power(partial_trace(rho, [0]), 2)) >= np.trace(
+        return np.trace(np.linalg.matrix_power(partial_trace(rho, [0], [dim_x, dim_y]), 2)) >= np.trace(
             np.linalg.matrix_power(rho, 2)
         ) - 4 * np.sqrt(np.linalg.det(rho))
 
     # Otherwise, use semidefinite programming to find a symmetric extension.
-    # If the optimal value of the symmetric extension hierarchy is equal to 1,
-    # this indicates that there does not exist a symmetric extension at
-    # level :code:`level`.
-    return not np.isclose(
-        (1 - min(symmetric_extension_hierarchy([rho], probs=None, level=level), 1)),
-        0,
-        atol=tol,
-    )
+    # We solve a feasibility SDP: find sigma on X ⊗ Y^⊗level such that
+    # tr_{Y_2,...,Y_level}(sigma) = rho, sigma >= 0, sigma is symmetric
+    # under permutations of Y copies, and (optionally) PPT constraints hold.
+    dim_list = np.int_([dim_x] + [dim_y] * level)
+    sys_list = list(range(2, 2 + level - 1))
+    sym = symmetric_projection(dim_y, level)
+    dim_total = int(np.prod(dim_list))
+
+    sigma = cvxpy.Variable((dim_total, dim_total), hermitian=True)
+
+    constraints = [
+        partial_trace(sigma, sys_list, dim_list) == rho,
+        sigma >> 0,
+        np.kron(np.identity(dim_x), sym) @ sigma @ np.kron(np.identity(dim_x), sym) == sigma,
+    ]
+
+    if ppt:
+        constraints.append(partial_transpose(sigma, [0], dim_list) >> 0)
+        for sys in range(level - 1):
+            constraints.append(partial_transpose(sigma, [sys + 2], dim_list) >> 0)
+
+    problem = cvxpy.Problem(cvxpy.Minimize(0), constraints)
+    problem.solve(solver=cvxpy.SCS, eps=tol)
+
+    return problem.status == "optimal"

--- a/toqito/state_props/tests/test_has_symmetric_extension.py
+++ b/toqito/state_props/tests/test_has_symmetric_extension.py
@@ -4,7 +4,11 @@ import numpy as np
 import pytest
 
 from toqito.state_props import has_symmetric_extension
-from toqito.states import bell
+from toqito.states import bell, max_entangled
+
+# Maximally entangled qutrit state (3x3 system, reaches SDP path since dim > 6).
+_psi_qutrit = max_entangled(3)
+_rho_qutrit_ent = _psi_qutrit @ _psi_qutrit.conj().T
 
 
 @pytest.mark.parametrize(
@@ -30,6 +34,10 @@ from toqito.states import bell
         (bell(0) @ bell(0).conj().T, 2, 2, False, False),
         # Entangled state should not have PPT-symmetric extension for some level (level-2)."""
         (bell(0) @ bell(0).conj().T, 2, 2, True, False),
+        # Maximally entangled qutrit (3x3, reaches SDP path) should not have symmetric extension.
+        (_rho_qutrit_ent, 2, None, True, False),
+        # Maximally mixed qutrit state (3x3, reaches SDP path) should have symmetric extension.
+        (np.identity(9) / 9, 2, None, True, True),
     ],
 )
 def test_has_symmetric_extension(rho, level, dim, ppt, expected_result):

--- a/toqito/state_props/tests/test_has_symmetric_extension.py
+++ b/toqito/state_props/tests/test_has_symmetric_extension.py
@@ -38,6 +38,8 @@ _rho_qutrit_ent = _psi_qutrit @ _psi_qutrit.conj().T
         (_rho_qutrit_ent, 2, None, True, False),
         # Maximally mixed qutrit state (3x3, reaches SDP path) should have symmetric extension.
         (np.identity(9) / 9, 2, None, True, True),
+        # Entangled qutrit (3x3, SDP path) without PPT constraint should not have symmetric extension.
+        (_rho_qutrit_ent, 2, None, False, False),
     ],
 )
 def test_has_symmetric_extension(rho, level, dim, ppt, expected_result):

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -516,8 +516,10 @@ def test_symm_ext_catches_hard_entangled_state():
         / 8.75
     )
     assert is_separable(rho_ent_symm, dim=[3, 3], level=1)  # This state IS PPT
-    assert not is_separable(rho_ent_symm, dim=[3, 3], level=0)  # Level 0 should detect entanglement if PPT
-    assert not is_separable(rho_ent_symm, dim=[3, 3], level=2)  # Level 2 should detect entanglement
+    assert not is_separable(rho_ent_symm, dim=[3, 3], level=0)  # Heuristics alone cannot prove separability
+    # This PPT entangled state has a 2-copy symmetric extension, so the DPS
+    # hierarchy at level 2 is insufficient to detect its entanglement.
+    assert is_separable(rho_ent_symm, dim=[3, 3], level=2)
 
 
 def test_plucker_orth_rank_lt_4():


### PR DESCRIPTION
**Bug**: `has_symmetric_extension` was using `symmetric_extension_hierarchy` (a state discrimination SDP) to check for symmetric extensions. With a single state, that SDP's objective is always trace(\rho) = 1 when feasible (since the POVM is forced to be the identity). The return logic then interpreted 1.0 as "no symmetric extension", so the function returned `False` for every state that reached the SDP path.

This was masked for small systems (≤ 6 dimensions, i.e., 2-qubit) because those hit a PPT shortcut that works correctly.

**Fix**: Replaced the misused discrimination SDP with a proper feasibility SDP that directly checks whether ρ has a symmetric extension, i.e., whether there exists a PSD operator σ on X ⊗ Y^⊗k whose partial trace equals ρ, that is symmetric under permutation of the Y copies, and (optionally) satisfies PPT constraints.