### PR TITLE
Implementing Iterated product state subtraction

### DIFF
--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -155,18 +155,18 @@ def is_separable(
 
     14. **Iterative `S_k` decomposition**:
 
-        - The test is only activated when `search_depth>=2` as this is an computationaly expensive check.
+        - The test is only activated when `search_depth>=2` as this is a computationally expensive check.
         - We use `search_depth` to control the level of the `S_k` decomposition and the maximum
           allowed random product states to start the test.
         - Finds the maximal product state overlap using see-saw method(i.e. fix one party and optimize over the other
           and repeat until convergence). Then subtracts the optimal product state. If the resulting state is negligible
-          or the resulting state falls in the seperable ball then the state is separable. Else, we return the original
+          or the resulting state falls in the separable ball then the state is separable. Else, we return the original
           state and try to repeat the optimization starting with another random product state. How long this process
           continues is controlled by `search_depth`.
 
         !!! Note
-            QETLAB's[@qetlablink] `sk_iterate` routined for testing seperability. Though the original test has
-            capabilites to split the state for any schmidt rank,this implimentation  is restricted to Schimdt rank 1
+            QETLAB's[@qetlablink] `sk_iterate` routined for testing separability. Though the original test has
+            capabilities to split the state for any Schmidt rank, this implementation is restricted to Schmidt rank 1
             decomposition.
 
     Examples:
@@ -537,7 +537,7 @@ def is_separable(
         return True
 
     rho_pt_A = partial_transpose(current_state, sys=0, dim=dims_list)  # Partial transpose on system A
-    rank_pt_A = np.linalg.matrix_rank(np.asarray(rho_pt_A), tol=tol)
+    rank_pt_A = np.linalg.matrix_rank(rho_pt_A, tol=tol)
     threshold_horodecki = 2 * prod_dim_val - dA - dB + 2  # Threshold for sum of ranks
 
     if state_rank + rank_pt_A <= threshold_horodecki:  # rank(rho) + rank(rho^T_A) <= threshold
@@ -549,8 +549,8 @@ def is_separable(
     # Its main use is for NPT states. Included for completeness of listed criteria.
     rho_A_marginal = partial_trace(current_state, sys=[1], dim=dims_list)
     rho_B_marginal = partial_trace(current_state, sys=[0], dim=dims_list)
-    op_reduct1 = np.kron(np.eye(dA), np.asarray(rho_B_marginal)) - current_state
-    op_reduct2 = np.kron(np.asarray(rho_A_marginal), np.eye(dB)) - current_state
+    op_reduct1 = np.kron(np.eye(dA), rho_B_marginal) - current_state
+    op_reduct2 = np.kron(rho_A_marginal, np.eye(dB)) - current_state
     if not (
         is_positive_semidefinite(op_reduct1, atol=tol, rtol=tol)
         and is_positive_semidefinite(op_reduct2, atol=tol, rtol=tol)
@@ -569,12 +569,7 @@ def is_separable(
     val_A = max(0, 1 - tr_rho_A_sq)  # Ensure non-negativity from (1 - purity)
     val_B = max(0, 1 - tr_rho_B_sq)
     bound_zhang = np.sqrt(val_A * val_B) if (val_A * val_B >= 0) else 0
-    if (
-        trace_norm(
-            realignment(current_state - np.kron(np.asarray(rho_A_marginal), np.asarray(rho_B_marginal)), dims_list)
-        )
-        > bound_zhang + tol
-    ):
+    if trace_norm(realignment(current_state - np.kron(rho_A_marginal, rho_B_marginal), dims_list)) > bound_zhang + tol:
         return False
     # TODO: #1246 Consider adding Filter CMC criterion from Gittsovich et al. 2008, which is stronger.
 
@@ -741,9 +736,7 @@ def is_separable(
         # for k=2 (and level >=2), it declares separable.
         for k_actual_level_check in range(2, int(level) + 1):  # Ensure level is int for range
             try:
-                if has_symmetric_extension(
-                    rho=current_state, level=k_actual_level_check, dim=np.asarray(dims_list), tol=tol
-                ):
+                if has_symmetric_extension(rho=current_state, level=k_actual_level_check, dim=dims_list, tol=tol):
                     # State has a k-symmetric extension, considered separable by this test level.
                     return True
                 # If it does NOT have a k-symmetric extension, it is entangled.
@@ -767,11 +760,14 @@ def is_separable(
     if search_depth >= 2:
         # As this test is computationally expensive it only gets activated when the search_depth parameter is larger
         # than 2.
+        def is_same(state1: np.ndarray, state2: np.ndarray, tol: float = 1e-9) -> bool:
+            return np.allclose(state1, state2, atol=tol, rtol=tol)
+
         seed = 100
         max_iter = search_depth * 100
         max_see_saw_iters = 1000
         sep_factor = search_depth * 10
-        rho_sub = np.asarray(state.copy())
+        rho_sub = state.copy()
         max_depth = sep_factor * min(dA, dB)  # mainly to bound the depth of the loop
         for dep in range(max_depth):
             count_rand_starts = 0
@@ -786,30 +782,30 @@ def is_separable(
                     delta > min(dA, dB) * tol and max_see_saw_iters > 0
                 ):  # loop for see-saw attempting to find max overlap product state.
                     rho_part = partial_trace(
-                        rho_sub @ np.kron(np.outer(v0, v0.conj().T), np.identity(dB)), sys=1, dim=[dA, dB]
+                        rho_sub @ np.kron(np.outer(v0, v0.conj()), np.identity(dB)), sys=1, dim=[dA, dB]
                     )
-                    _, dv1_new = np.linalg.eigh(np.asarray(rho_part))
+                    _, dv1_new = np.linalg.eigh(rho_part)
                     v1_new = dv1_new[:, -1]
                     rho_part = partial_trace(
-                        rho_sub @ np.kron(np.identity(dA), np.outer(v1_new, v1_new.conj().T)), sys=0, dim=[dA, dB]
+                        rho_sub @ np.kron(np.identity(dA), np.outer(v1_new, v1_new.conj())), sys=0, dim=[dA, dB]
                     )
-                    dev0, dv0_new = np.linalg.eigh(np.asarray(rho_part))
+                    dev0, dv0_new = np.linalg.eigh(rho_part)
                     v0_new = dv0_new[:, -1]
                     ev0 = dev0[-1]
                     delta = np.linalg.norm(v1_new - v1) + np.linalg.norm(v0_new - v0)
                     v0 = v0_new
                     v1 = v1_new
                     max_see_saw_iters -= 1
-                max_product_state = ev0 * np.kron(np.outer(v0, v0.conj().T), np.outer(v1, v1.conj().T))
+                max_product_state = ev0 * np.kron(np.outer(v0, v0.conj()), np.outer(v1, v1.conj()))
                 rho_sub = rho_sub - max_product_state
-                if np.allclose(rho_sub, np.zeros(np.shape(rho_sub)), atol=tol, rtol=tol):
+                if is_same(rho_sub, np.zeros(np.shape(rho_sub))):
                     return True
                 elif is_positive_semidefinite(rho_sub):  # making sure that the residue can be a valid state
                     residue = trace_norm(rho_sub)
                     rho_sub = rho_sub / residue  # normalizing only if the residue can be a state.
                     if in_separable_ball(
                         rho_sub
-                    ):  # return if the residual state is in the seperable ball or the residue is neglegible
+                    ):  # return if the residual state is in the separable ball or the residue is negligible
                         return True
                     else:  # use the rho_sub to continue the algorithm to another iteration
                         break

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -820,8 +820,8 @@ def test_rank1_pert_eigvalsh_fails_eigvals_fallback():
 
 # ---  testing the iterative product state subtraction ---
 def test_is_separable_iterative_pass_with_nearly_zero_residue_state():
-    """Test the STR >= 2 iterative product state subtraction finds the residue is nearly zero."""
-    # genenrating a random rank-1 perturbative product state
+    """Test the search_depth >= 2 iterative product state subtraction finds the residue is nearly zero."""
+    # generating a random rank-1 product state
     np.random.seed(42)
     vec1 = np.random.rand(3) + 1j * np.random.rand(3)
     vec1 = vec1 / np.linalg.norm(vec1)
@@ -839,25 +839,25 @@ def test_is_separable_iterative_pass_with_nearly_zero_residue_state():
         if call_count["count_sep_ball"] <= 2:
             # using a small number to make it pass the first 3 iterations to keep the loop testing.
             return False  # Bypass initial check
-        return True  # Succeed inside STR >= 2 block
+        return True  # Succeed inside search_depth >= 2 block
 
-    def mock_all_close(state, *args, **kwargs):
+    def mock_all_close(state1, state2, *args, **kwargs):
         call_count["count_all_close"] += 1
         if call_count["count_all_close"] >= 2 and call_count["count_all_close"] <= 5:
             # letting the first one pass to skip the test of being PSD and using a small
             # number to make it pass the next 4 iterations to keep the loop testing.
             return False  # Bypass initial check
-        return True  # Succeed inside STR >= 2 block
+        return True  # Succeed inside search_depth >= 2 block
 
     with mock.patch("toqito.state_props.in_separable_ball.in_separable_ball", side_effect=mock_in_sep_ball):
         with mock.patch("toqito.state_props.is_ppt.is_ppt", return_value=True):
             with mock.patch("numpy.allclose", side_effect=mock_all_close):
-                assert is_separable(rho, dim=dim, level=0, STR=2)
+                assert is_separable(rho, dim=dim, level=0, search_depth=2)
 
 
 def test_is_separable_iterative_pass_with_falling_to_sep_ball():
-    """Test the STR >= 2 iterative product state subtraction finds result is in the separable ball."""
-    # genenrating a random rank-1 perturbative product state
+    """Test the search_depth >= 2 iterative product state subtraction finds result is in the separable ball."""
+    # generating a random rank-1 perturbative product state
 
     np.random.seed(42)
     vec1 = np.random.rand(3) + 1j * np.random.rand(3)
@@ -877,7 +877,7 @@ def test_is_separable_iterative_pass_with_falling_to_sep_ball():
             call_count["count_sep_ball"] <= 4
         ):  # using a small number to make it pass the first 3 iterations to keep the loop testing.
             return False  # Bypass initial check
-        return True  # Succeed inside STR >= 2 block
+        return True  # Succeed inside search_depth >= 2 block
 
     def mock_all_close(state, *args, **kwargs):
         call_count["count_all_close"] += 1
@@ -885,12 +885,12 @@ def test_is_separable_iterative_pass_with_falling_to_sep_ball():
             # letting the first one pass to skip the test of being PSD and using a small
             # making sure that the residue never small enough
             return False  # Bypass initial check
-        return True  # Succeed inside STR >= 2 block
+        return True  # Succeed inside search_depth >= 2 block
 
     with mock.patch("toqito.state_props.in_separable_ball.in_separable_ball", side_effect=mock_in_sep_ball):
         with mock.patch("toqito.state_props.is_ppt.is_ppt", return_value=True):
             with mock.patch("numpy.allclose", side_effect=mock_all_close):
-                assert is_separable(rho, dim=dim, level=0, STR=5)
+                assert is_separable(rho, dim=dim, level=0, search_depth=5)
 
 
 # --- attempt to Targeted Tests for Coverage ---


### PR DESCRIPTION
## Description
Fixing #1244. 

## Changes
Core functionality has been implemented. 
  - [x] Iterative product state subtraction has been implemented as described in #1244. 
  - [x] some older linting/type errors in is_seperable has been fixed. 
  - [x] STR parameter added to allow for variable compute complexity of is_seperable. STR<2 checks for all the easy tests till 13. Then, take increasingly complex tests with larger STR(expected Quadratic scaling in STR).     
  - [x] New tests need to be implemented to check the functionality when STR>=2

## Checklist

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [?] Verify all previous and newly added unit tests pass in `pytest`.(verified using with hard-coded STR=2 to make sure there are no conflicts. )
  -  [x] Check the documentation build does not lead to any failures. 
