### PR TITLE
fix: replace sphinx references with mkdocs in contributing guide

### DIFF
--- a/docs/content/contributing-guide.md
+++ b/docs/content/contributing-guide.md
@@ -175,26 +175,22 @@ function follows the formatting specifications in [Code Style](#code-style). A s
 def my_new_function(some_parameter: parameter_type) -> return_type:
     r"""One liner description of the new function.
 
-        Detailed description of the function.
+    Detailed description of the function [@some_citation_key].
 
-        Examples
-        ==========
+    Examples:
         Demonstrate how the function works with expected output.
 
-        .. jupyter-execute::
+        ```python exec="1" source="above"
+        import numpy as np
+        x = np.array([[1, 2], [3, 4]])
+        print(x)
+        ```
 
-            import numpy as np
-            x = np.array([[1, 2], [3, 4]])
-            print(x)
+    Raises:
+        SomeError: Description for when the function raises an error.
 
-        References
-        ==========
-        .. footbibliography::
-
-
-        :param name_of_parameter: Description of the parameter.
-        :raises SomeError: Description for when the function raises an error.
-        :return: Description of what the function returns.
+    Returns:
+        Description of what the function returns.
 
     """
 ```
@@ -208,26 +204,29 @@ To add an attribution to a paper or a book, add your reference with
 last name. Take a look at the [existing
 entries](https://github.com/vprusso/toqito/blob/master/docs/content/refs.bib) to
 get an idea of how to format the `bib` keys.
-## Documentation 
+## Documentation
 
-We use `sphinx` to build the documentation. Sync the docs dependency
-group first (`uv sync --group docs`), then run:
+We use [MkDocs](https://www.mkdocs.org/) with
+[Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) to
+build the documentation. Sync the docs dependency group first, then
+serve locally:
 
 ``` bash
-uv run make clean html
+uv sync --group docs
+uv run mkdocs serve -f docs/mkdocs.yml
 ```
 
-If you would prefer to decrease the amount of time taken by `sphinx` to
-build the documentation locally, use `make html` instead after the
-documentation has been built once.
+This starts a live-reloading server at `http://127.0.0.1:8000`.
 
-A standard document has to follow the `.rst` format. For more
-information on `sphinx`, `rst` fromat and the documentation theme
-`furo`, visit [sphinx
-documentation](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html)
-, [rst
-primer](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html)
-& [furo documentation](https://sphinx-themes.org/sample-sites/furo/) .
+To produce a static build instead:
+
+``` bash
+uv run mkdocs build -f docs/mkdocs.yml
+```
+
+For more information, visit the
+[MkDocs documentation](https://www.mkdocs.org/getting-started/) and the
+[Material for MkDocs reference](https://squidfunk.github.io/mkdocs-material/getting-started/).
 
 ## Additional Resources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "picos>=2.6.2",
     "networkx>=3.4,<4.0",
     "numba>=0.63.0",
-    "jupyter-sphinx>=0.5.3,<0.6.0",
     "matplotlib==3.10.8",
 ]
 
@@ -51,7 +50,6 @@ dev = [
     "ipython==9.10.0",
     "setuptools>65.5.1",
     "pre-commit>=3.0.0",
-    "jupyter-sphinx>=0.5.3,<0.6.0",
 ]
 lint = [
     "flake8==7.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -851,11 +851,12 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "8.38.0"
+version = "9.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
     { name = "jedi" },
     { name = "matplotlib-inline" },
     { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
@@ -865,34 +866,30 @@ dependencies = [
     { name = "traitlets" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/61/1810830e8b93c72dcd3c0f150c80a00c3deb229562d9423807ec92c3a539/ipython-8.38.0.tar.gz", hash = "sha256:9cfea8c903ce0867cc2f23199ed8545eb741f3a69420bfcf3743ad1cec856d39", size = 5513996, upload-time = "2026-01-05T10:59:06.901Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/df/db59624f4c71b39717c423409950ac3f2c8b2ce4b0aac843112c7fb3f721/ipython-8.38.0-py3-none-any.whl", hash = "sha256:750162629d800ac65bb3b543a14e7a74b0e88063eac9b92124d4b2aa3f6d8e86", size = 831813, upload-time = "2026-01-05T10:59:04.239Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/aa/898dec789a05731cd5a9f50605b7b44a72bd198fd0d4528e11fc610177cc/ipython-9.10.0-py3-none-any.whl", hash = "sha256:c6ab68cc23bba8c7e18e9b932797014cc61ea7fd6f19de180ab9ba73e65ee58d", size = 622774, upload-time = "2026-02-02T10:00:31.503Z" },
 ]
 
 [[package]]
-name = "ipywidgets"
-version = "8.1.7"
+name = "ipython-pygments-lexers"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "comm" },
-    { name = "ipython" },
-    { name = "jupyterlab-widgets" },
-    { name = "traitlets" },
-    { name = "widgetsnbextension" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/48/d3dbac45c2814cb73812f98dd6b38bbcc957a4e7bb31d6ea9c03bf94ed87/ipywidgets-8.1.7.tar.gz", hash = "sha256:15f1ac050b9ccbefd45dccfbb2ef6bed0029d8278682d569d71b8dd96bee0376", size = 116721, upload-time = "2025-05-05T12:42:03.489Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/6a/9166369a2f092bd286d24e6307de555d63616e8ddb373ebad2b5635ca4cd/ipywidgets-8.1.7-py3-none-any.whl", hash = "sha256:764f2602d25471c213919b8a1997df04bef869251db4ca8efba1b76b1bd9f7bb", size = 139806, upload-time = "2025-05-05T12:41:56.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
 ]
 
 [[package]]
 name = "isort"
-version = "7.0.0"
+version = "8.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/53/4f3c058e3bace40282876f9b553343376ee687f3c35a525dc79dbd450f88/isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187", size = 805049, upload-time = "2025-10-11T13:30:59.107Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/ed/e3705d6d02b4f7aea715a353c8ce193efd0b5db13e204df895d38734c244/isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1", size = 94672, upload-time = "2025-10-11T13:30:57.665Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
 ]
 
 [[package]]
@@ -986,38 +983,12 @@ wheels = [
 ]
 
 [[package]]
-name = "jupyter-sphinx"
-version = "0.5.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ipykernel" },
-    { name = "ipython" },
-    { name = "ipywidgets" },
-    { name = "nbconvert" },
-    { name = "nbformat" },
-    { name = "sphinx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/b5/40f540cc9e54ee829f79daac43456a8d5ab4b70c8d26f0b9eca0dfcb4ad5/jupyter_sphinx-0.5.3.tar.gz", hash = "sha256:2e23699a3a1cf5db31b10981da5aa32606ee730f6b73a844d1e76d800756af56", size = 17532, upload-time = "2023-12-28T12:19:41.047Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/1c/45251d4b9624e42b9e4f369dae2a64f5ea19b9387ba492ceb7be65343dda/jupyter_sphinx-0.5.3-py3-none-any.whl", hash = "sha256:a67b3208d4da5b3508dbb8260d3b359ae476c36c6c642747b78a2520e5be0b05", size = 21918, upload-time = "2023-12-28T12:19:39.38Z" },
-]
-
-[[package]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
-]
-
-[[package]]
-name = "jupyterlab-widgets"
-version = "3.0.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/7d/160595ca88ee87ac6ba95d82177d29ec60aaa63821d3077babb22ce031a5/jupyterlab_widgets-3.0.15.tar.gz", hash = "sha256:2920888a0c2922351a9202817957a68c07d99673504d6cd37345299e971bb08b", size = 213149, upload-time = "2025-05-05T12:32:31.004Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/6a/ca128561b22b60bd5a0c4ea26649e68c8556b82bc70a0c396eebc977fe86/jupyterlab_widgets-3.0.15-py3-none-any.whl", hash = "sha256:d59023d7d7ef71400d51e6fee9a88867f6e65e10a4201605d2d7f3e8f012a31c", size = 216571, upload-time = "2025-05-05T12:32:29.534Z" },
 ]
 
 [[package]]
@@ -2825,7 +2796,6 @@ version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "cvxpy" },
-    { name = "jupyter-sphinx" },
     { name = "matplotlib" },
     { name = "more-itertools" },
     { name = "networkx" },
@@ -2841,7 +2811,6 @@ dev = [
     { name = "coverage" },
     { name = "distlib" },
     { name = "ipython" },
-    { name = "jupyter-sphinx" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -2874,7 +2843,6 @@ lint = [
 [package.metadata]
 requires-dist = [
     { name = "cvxpy", specifier = "==1.8.1" },
-    { name = "jupyter-sphinx", specifier = ">=0.5.3,<0.6.0" },
     { name = "matplotlib", specifier = "==3.10.8" },
     { name = "more-itertools", specifier = "==10.8.0" },
     { name = "networkx", specifier = ">=3.4,<4.0" },
@@ -2889,8 +2857,7 @@ requires-dist = [
 dev = [
     { name = "coverage", specifier = "==7.13.0" },
     { name = "distlib", specifier = "==0.4.0" },
-    { name = "ipython", specifier = "==8.38.0" },
-    { name = "jupyter-sphinx", specifier = ">=0.5.3,<0.6.0" },
+    { name = "ipython", specifier = "==9.10.0" },
     { name = "pre-commit", specifier = ">=3.0.0" },
     { name = "pytest", specifier = "==9.0.0" },
     { name = "pytest-cov", specifier = "==6.3.0" },
@@ -2913,7 +2880,7 @@ docs = [
 lint = [
     { name = "flake8", specifier = "==7.3.0" },
     { name = "flake8-docstrings", specifier = "==1.7.0" },
-    { name = "isort", specifier = "==7.0.0" },
+    { name = "isort", specifier = "==8.0.1" },
     { name = "myst-parser", specifier = "==4.0.1" },
     { name = "pep8", specifier = "==1.7.1" },
     { name = "ruff", specifier = "==0.15.0" },
@@ -3069,13 +3036,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
-]
-
-[[package]]
-name = "widgetsnbextension"
-version = "4.0.14"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/53/2e0253c5efd69c9656b1843892052a31c36d37ad42812b5da45c62191f7e/widgetsnbextension-4.0.14.tar.gz", hash = "sha256:a3629b04e3edb893212df862038c7232f62973373869db5084aed739b437b5af", size = 1097428, upload-time = "2025-04-10T13:01:25.628Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl", hash = "sha256:4875a9eaf72fbf5079dc372a51a9f268fc38d46f767cbf85c43a36da5cb9b575", size = 2196503, upload-time = "2025-04-10T13:01:23.086Z" },
 ]


### PR DESCRIPTION
Closes: #1448 

- removes outdated Sphinx-based docs mentions.