### PR TITLE
feat: parameterize random_psd_operator with wishart option

### DIFF
--- a/toqito/rand/random_psd_operator.py
+++ b/toqito/rand/random_psd_operator.py
@@ -1,18 +1,26 @@
 """Generates a random positive semidefinite operator."""
 
+import warnings
+
 import numpy as np
+
+from toqito.matrix_props import is_positive_semidefinite
 
 
 def random_psd_operator(
     dim: int,
     is_real: bool = False,
     seed: int | None = None,
+    distribution: str = "uniform",
+    scale: np.ndarray | None = None,
+    num_degrees: int | None = None,
 ) -> np.ndarray:
     r"""Generate a random positive semidefinite operator.
 
     A positive semidefinite operator is a Hermitian operator that has only real and non-negative eigenvalues.
-    This function generates a random positive semidefinite operator by constructing a Hermitian matrix,
-    based on the fact that a Hermitian matrix can have real eigenvalues.
+    This function generates a random PSD operator using one of two sampling strategies: `"uniform"`
+    constructs a Hermitian matrix via random sampling and eigendecomposition, while `"wishart"` samples
+    from the Wishart distribution parameterized by a scale matrix and degrees of freedom.
 
     Examples:
         Using `|toqito⟩`, we may generate a random positive semidefinite matrix.
@@ -39,8 +47,6 @@ def random_psd_operator(
         We can also generate random positive semidefinite matrices that are real-valued as follows.
 
         ```python exec="1" source="above" session="psd_operator"
-        from toqito.rand import random_psd_operator
-
         real_psd_mat = random_psd_operator(2, is_real=True)
 
         print(real_psd_mat)
@@ -50,7 +56,6 @@ def random_psd_operator(
         Again, verifying that this is a valid positive semidefinite matrix can be done as follows.
 
         ```python exec="1" source="above" session="psd_operator"
-        from toqito.matrix_props import is_positive_semidefinite
         print(is_positive_semidefinite(real_psd_mat))
         ```
 
@@ -58,34 +63,95 @@ def random_psd_operator(
         It is also possible to add a seed for reproducibility.
 
         ```python exec="1" source="above" session="psd_operator"
-        from toqito.rand import random_psd_operator
-
         seeded = random_psd_operator(2, is_real=True, seed=42)
 
         print(seeded)
         ```
 
+        To generate a random PSD operator using the Wishart distribution, pass
+        `distribution="wishart"`. Optional parameters `scale` (a PSD scale matrix) and
+        `num_degrees` (degrees of freedom) can be provided to fully parameterize the distribution.
+
+        ```python exec="1" source="above" session="psd_operator"
+        wishart_mat = random_psd_operator(3, distribution="wishart", num_degrees=5)
+
+        print(wishart_mat)
+        ```
+
     Args:
         dim: The dimension of the operator.
-        is_real: Boolean denoting whether the returned matrix will have all real entries or not. Default is `False`.
+        is_real: Boolean denoting whether the returned matrix will have all real entries or not.
+            Default is `False`.
         seed: A seed used to instantiate numpy's random number generator.
+        distribution: The sampling strategy to use. Either `"uniform"` (default) or
+            `"wishart"`. The `"uniform"` strategy constructs a Hermitian matrix via
+            random sampling and eigendecomposition. The `"wishart"` strategy samples from
+            the Wishart distribution, which guarantees a PSD matrix by construction.
+        scale: Scale matrix for the Wishart distribution. Must be a positive semidefinite matrix of
+            shape `(dim, dim)`. Defaults to the identity matrix if not provided.
+            Only used when `distribution="wishart"`.
+        num_degrees: Degrees of freedom for the Wishart distribution. Must be a positive integer.
+            Defaults to `dim` if not provided. Only used when `distribution="wishart"`.
+            When `num_degrees < dim`, the resulting matrix is guaranteed to be rank-deficient
+            (singular), which may be unintentional.
 
     Returns:
         A `dim` x `dim` random positive semidefinite matrix.
 
     """
-    # Generate a random matrix of dimension dim x dim.
-    gen = np.random.default_rng(seed=seed)
-    rand_mat = gen.random((dim, dim))
+    if not isinstance(dim, int) or dim < 1:
+        raise ValueError("dim must be a positive integer.")
 
-    # If is_real is False, add an imaginary component to the matrix.
-    if not is_real:
-        rand_mat = rand_mat + 1j * gen.random((dim, dim))
+    if distribution == "uniform":
+        if scale is not None or num_degrees is not None:
+            warnings.warn(
+                "scale and num_degrees are ignored when distribution='uniform'.",
+                UserWarning,
+                stacklevel=2,
+            )
+        gen = np.random.default_rng(seed=seed)
+        rand_mat = gen.random((dim, dim))
+        if not is_real:
+            rand_mat = rand_mat + 1j * gen.random((dim, dim))
+        rand_mat = (rand_mat.conj().T + rand_mat) / 2
+        eigenvals, eigenvecs = np.linalg.eigh(rand_mat)
+        q_mat, _ = np.linalg.qr(eigenvecs)
+        return q_mat @ np.diag(np.abs(eigenvals)) @ q_mat.conj().T
 
-    # Constructing a Hermitian matrix.
-    rand_mat = (rand_mat.conj().T + rand_mat) / 2
-    eigenvals, eigenvecs = np.linalg.eigh(rand_mat)
+    if distribution == "wishart":
+        if scale is None:
+            scale = np.eye(dim)
+        else:
+            if scale.shape != (dim, dim):
+                raise ValueError(f"scale must be a {dim}x{dim} matrix, got {scale.shape}.")
+            if not is_positive_semidefinite(scale):
+                raise ValueError("scale must be a positive semidefinite matrix.")
 
-    Q, R = np.linalg.qr(eigenvecs)
+        if num_degrees is None:
+            num_degrees = dim
+        if num_degrees < 1:
+            raise ValueError("num_degrees must be a positive integer.")
 
-    return Q @ np.diag(np.abs(eigenvals)) @ Q.conj().T
+        if num_degrees < dim:
+            warnings.warn(
+                f"num_degrees ({num_degrees}) < dim ({dim}): the resulting Wishart matrix "
+                "will be rank-deficient (singular).",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        gen = np.random.default_rng(seed=seed)
+        if is_real:
+            x_mat = gen.multivariate_normal(np.zeros(dim), scale, size=num_degrees).T
+        else:
+            # Each component is drawn independently with covariance `scale`.
+            # Dividing by sqrt(2) ensures the resulting complex Wishart matrix
+            # x_mat @ x_mat.conj().T has the expected scale matrix `scale`
+            # rather than 2 * scale.
+            x_mat = (
+                gen.multivariate_normal(np.zeros(dim), scale, size=num_degrees).T
+                + 1j * gen.multivariate_normal(np.zeros(dim), scale, size=num_degrees).T
+            ) / np.sqrt(2)
+        return x_mat @ x_mat.conj().T
+
+    raise ValueError("Invalid distribution. Supported options are 'uniform' and 'wishart'.")

--- a/toqito/rand/tests/test_random_psd_operator.py
+++ b/toqito/rand/tests/test_random_psd_operator.py
@@ -9,37 +9,37 @@ from toqito.rand import random_psd_operator
 
 
 @pytest.mark.parametrize(
-    "dim, is_real",
+    "dim, is_real, distribution",
     [
-        # Test with a matrix of dimension 2.
-        (2, True),
-        # Test with a matrix of dimension 4.
-        (4, False),
-        # Test with a matrix of dimension 5.
-        (5, False),
-        # Test with a matrix of dimension 10.
-        (10, True),
+        # Test with a matrix of dimension 2, real, uniform.
+        (2, True, "uniform"),
+        # Test with a matrix of dimension 4, complex, uniform.
+        (4, False, "uniform"),
+        # Test with a matrix of dimension 5, complex, uniform.
+        (5, False, "uniform"),
+        # Test with a matrix of dimension 10, real, uniform.
+        (10, True, "uniform"),
+        # Test with a matrix of dimension 4, complex, wishart.
+        (4, False, "wishart"),
+        # Test with a matrix of dimension 4, real, wishart.
+        (4, True, "wishart"),
     ],
 )
-def test_random_psd_operator(dim, is_real):
+def test_random_psd_operator(dim, is_real, distribution):
     """Test for random_psd_operator function."""
-    # Generate a random positive semidefinite operator.
-    rand_psd_operator = random_psd_operator(dim, is_real)
-
-    # Ensure the matrix has the correct shape.
+    rand_psd_operator = random_psd_operator(dim, is_real, distribution=distribution)
     assert_equal(rand_psd_operator.shape, (dim, dim))
-
-    # Check if the matrix is positive semidefinite.
     assert is_positive_semidefinite(rand_psd_operator)
 
 
 @pytest.mark.parametrize(
-    "dim, is_real, seed, expected_mat",
+    "dim, is_real, seed, distribution, expected_mat",
     [
         (
             2,
             True,
             13,
+            "uniform",
             np.array(
                 [
                     [1.0778147, 0.52948168],
@@ -51,6 +51,7 @@ def test_random_psd_operator(dim, is_real):
             3,
             False,
             42,
+            "uniform",
             np.array(
                 [
                     [0.95967267 + 1.23259516e-32j, 0.64147554 + 2.12105374e-01j, 0.58409076 - 4.68163042e-03j],
@@ -63,6 +64,7 @@ def test_random_psd_operator(dim, is_real):
             5,
             True,
             13,
+            "uniform",
             np.array(
                 [
                     [1.10423147, 0.58541728, 0.23882546, 0.38725184, 0.47981462],
@@ -73,9 +75,100 @@ def test_random_psd_operator(dim, is_real):
                 ]
             ),
         ),
+        # Wishart, real, dim=3, seed=7.
+        (
+            3,
+            True,
+            7,
+            "wishart",
+            np.array(
+                [
+                    [0.79677259, 0.48589897, 0.85321202],
+                    [0.48589897, 2.09215132, -0.29068742],
+                    [0.85321202, -0.29068742, 1.30078171],
+                ]
+            ),
+        ),
+        # Wishart, complex, dim=3, seed=7.
+        (
+            3,
+            False,
+            7,
+            "wishart",
+            np.array(
+                [
+                    [0.83816019 + 0.0j, -0.42537849 - 0.02493043j, 0.15525367 - 0.13781929j],
+                    [-0.42537849 + 0.02493043j, 2.50239004 + 0.0j, 0.26324124 + 0.97171381j],
+                    [0.15525367 + 0.13781929j, 0.26324124 - 0.97171381j, 0.81920895 + 0.0j],
+                ]
+            ),
+        ),
     ],
 )
-def test_random_psd_operator_with_seed(dim, is_real, seed, expected_mat):
+def test_random_psd_operator_with_seed(dim, is_real, seed, distribution, expected_mat):
     """Test that random_psd_operator function returns the expected output when seeded."""
-    matrix = random_psd_operator(dim, is_real, seed)
+    matrix = random_psd_operator(dim, is_real, seed, distribution=distribution)
     assert_allclose(matrix, expected_mat)
+
+
+@pytest.mark.parametrize(
+    "dim, distribution",
+    [
+        # Invalid dim type.
+        ("4", "uniform"),
+        # Negative dim.
+        (-2, "uniform"),
+        # Zero dim.
+        (0, "uniform"),
+    ],
+)
+def test_random_psd_operator_invalid_dim(dim, distribution):
+    """Test that invalid dim raises ValueError."""
+    with pytest.raises(ValueError):
+        random_psd_operator(dim, distribution=distribution)
+
+
+def test_random_psd_operator_invalid_distribution():
+    """Test that invalid distribution raises ValueError."""
+    with pytest.raises(ValueError):
+        random_psd_operator(4, distribution="invalid")
+
+
+@pytest.mark.parametrize(
+    "scale, num_degrees, match",
+    [
+        # Scale shape mismatch.
+        (np.eye(3), None, "scale must be a 4x4 matrix"),
+        # Non-PSD scale matrix.
+        (
+            np.array([
+                [1.0, 2.0, 0.0, 0.0],
+                [2.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]) * -1,
+            None,
+            "positive semidefinite",
+        ),
+        # num_degrees zero.
+        (None, 0, "num_degrees must be a positive integer"),
+        # num_degrees negative.
+        (None, -3, "num_degrees must be a positive integer"),
+    ],
+)
+def test_random_psd_operator_wishart_invalid_params(scale, num_degrees, match):
+    """Test that invalid Wishart parameters raise ValueError."""
+    with pytest.raises(ValueError, match=match):
+        random_psd_operator(4, distribution="wishart", scale=scale, num_degrees=num_degrees)
+
+
+def test_random_psd_operator_uniform_ignores_wishart_params():
+    """Test that passing scale or num_degrees with distribution='uniform' raises a warning."""
+    with pytest.warns(UserWarning, match="scale and num_degrees are ignored"):
+        random_psd_operator(4, distribution="uniform", scale=np.eye(4), num_degrees=5)
+
+
+def test_random_psd_operator_wishart_rank_deficient_warning():
+    """Test that num_degrees < dim emits a warning about rank-deficient matrices."""
+    with pytest.warns(UserWarning, match="rank-deficient"):
+        random_psd_operator(4, distribution="wishart", num_degrees=2)


### PR DESCRIPTION
## Description

closes #1275

This PR parameterizes the distribution used in `random_psd_operator` by introducing a new `distribution` argument. This allows users to select alternative sampling strategies when generating random positive semidefinite (PSD) operators.
The default behavior remains unchanged to preserve backward compatibility.

## Changes

- [x] Added `distribution: str = "uniform"` parameter to `random_psd_operator`
- [x] Preserved existing behavior as the default (`"uniform"`) for full backward compatibility
- [x] Added `"wishart"` option with full parameterization (`scale` matrix, `num_degrees` degrees of freedom)
- [x] Added input validation for `dim`, `scale`, `num_degrees`, and invalid distribution values
- [x] Added warning when `num_degrees < dim` (rank-deficient matrices)
- [x] Fixed complex Wishart scaling (`/ sqrt(2)`) so covariance matches `scale` rather than `2 * scale`
- [x] Rewrote docstring to Google-style markdown format (matching `random_density_matrix.py`)
- [x] Added docstring example for Wishart distribution usage
- [x] Removed Sphinx-specific `References` section
- [x] Consolidated tests using `pytest.mark.parametrize`
- [x] Added hardcoded expected matrices for Wishart seeded tests
- [x] Added comprehensive validation and warning tests (21 total tests)

## Checklist

- [x] Use `ruff` for errors related to code style and formatting
- [x] Verify all previous and newly added unit tests pass in `pytest` (21/21 pass)
- [x] Check the documentation build does not lead to any failures
