### PR TITLE
fix: sync ruff version to 0.15.0 across pre-commit and CI

### DIFF
--- a/.github/workflows/build-test-actions.yml
+++ b/.github/workflows/build-test-actions.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.15.0"
       - run: ruff check --fix
       - run: ruff format
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version (keep in sync with the version in pyproject.toml)
-  rev: v0.11.0
+  rev: v0.15.0
   hooks:
     # Run the linter.
     - id: ruff


### PR DESCRIPTION
## Summary
- Sync `.pre-commit-config.yaml` ruff version from `v0.11.0` to `v0.15.0` to match `pyproject.toml`
- Pin ruff version in CI workflow to `0.15.0` instead of using unpinned `@v3` latest

## Motivation
The ruff version was inconsistent across three locations:
- `pyproject.toml`: `ruff==0.15.0`
- `.pre-commit-config.yaml`: `v0.11.0` (comment says "keep in sync" but wasn't)
- CI: unpinned via `ruff-action@v3`

This could cause lint results to differ between local pre-commit and CI.