### PR TITLE
Fix: Replace print statements with warnings in vectors_from_gram_matrix

### DIFF
--- a/toqito/matrix_ops/vectors_from_gram_matrix.py
+++ b/toqito/matrix_ops/vectors_from_gram_matrix.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import scipy
+import warnings
 
 
 def vectors_from_gram_matrix(gram: np.ndarray) -> list[np.ndarray]:
@@ -32,7 +33,6 @@ def vectors_from_gram_matrix(gram: np.ndarray) -> list[np.ndarray]:
         gram_matrix = np.array([[0, 1], [1, 0]])
         vectors = vectors_from_gram_matrix(gram_matrix)
 
-        print(vectors)  # Matrix is not positive semidefinite. Using eigendecomposition as alternative.
         ```
 
     Raises:
@@ -55,6 +55,6 @@ def vectors_from_gram_matrix(gram: np.ndarray) -> list[np.ndarray]:
         return [decomp[i][:] for i in range(dim)]
     # Otherwise, need to do eigendecomposition:
     except np.linalg.LinAlgError:
-        print("Matrix is not positive semidefinite. Using eigendecomposition as alternative.")
+        warnings.warn("Matrix is not positive semidefinite. Using eigendecomposition as alternative.")
         d, v = np.linalg.eig(gram)
         return [scipy.linalg.sqrtm(np.diag(d)) @ v[i].conj().T for i in range(dim)]


### PR DESCRIPTION
## Fix: Remove unexpected warning line from docs build

Fixes #1462

### Root Cause
Found two `print()` statements in `toqito/matrix_ops/vectors_from_gram_matrix.py`:
- A leftover debug `print(vectors)` statement
- A `print()` message for the non-positive semidefinite fallback path

These were printing to stdout during the docs build, causing the unexpected line:
```
Matrix is not positive semidefinite. Using eigendecomposition as alternative.
```

### Fix
- Removed the debug `print(vectors)` statement
- Replaced `print(...)` with `warnings.warn(...)` for the eigendecomposition fallback
- Added `import warnings` at the top of the file