### PR TITLE
Deploy docs previews to GitHub Pages (fixes #1498)

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -2,87 +2,57 @@ name: Docs Preview
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, closed]
     paths:
       - "docs/**"
       - "toqito/**"
       - ".github/workflows/docs-preview.yml"
 
+concurrency: preview-${{ github.ref }}
+
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:
   preview:
     runs-on: ubuntu-latest
+    # Fork PRs cannot push to gh-pages; they must build docs locally.
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - uses: actions/checkout@v6
 
       - name: Set up Python
+        if: github.event.action != 'closed'
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Install system dependencies for BLAS/LAPACK
+        if: github.event.action != 'closed'
         run: |
           sudo apt-get update
           sudo apt-get install -y libblas-dev liblapack-dev gfortran libatlas-base-dev
 
       - name: Install uv
+        if: github.event.action != 'closed'
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies with uv
+        if: github.event.action != 'closed'
         run: uv sync --group docs
 
       - name: Build docs
+        if: github.event.action != 'closed'
         run: |
           cd docs
-          uv run mkdocs build --strict 2>&1 | tee build.log || true
+          uv run mkdocs build --strict
 
-      - name: Upload docs artifact
-        uses: actions/upload-artifact@v7
+      - name: Deploy PR preview
+        uses: rossjrw/pr-preview-action@v1
         with:
-          name: docs-preview
-          path: docs/site/
-          retention-days: 14
-
-      - name: Comment on PR
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = [
-              '### 📖 Docs Preview',
-              '',
-              `The docs have been built for this PR. Download the preview artifact from the [workflow run](${runUrl}).`,
-              '',
-              'To view locally, download and extract the `docs-preview` artifact, then open `index.html` in your browser.',
-              '',
-              '*This comment is automatically updated on each push.*'
-            ].join('\n');
-
-            // Find existing comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const botComment = comments.find(c =>
-              c.user.type === 'Bot' && c.body.includes('Docs Preview')
-            );
-
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+          source-dir: docs/site/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/docs/content/examples/quantum_states/state_distinguishability.py
+++ b/docs/content/examples/quantum_states/state_distinguishability.py
@@ -191,7 +191,7 @@ print(np.around(state_distinguishability(states, probs)[0], decimals=2))
 #
 import numpy as np
 
-from toqito.state_opt import ppt_distinguishability
+from toqito.state_opt import state_distinguishability
 from toqito.states import bell
 
 # mkdocs_gallery_thumbnail_path = 'figures/quantum_state_distinguish.svg'
@@ -211,7 +211,13 @@ states = [x_1, x_2, x_3, x_4]
 
 probs = [1 / 4, 1 / 4, 1 / 4, 1 / 4]
 # Calculate the PPT distinguishability value.
-ppt_val, _ = ppt_distinguishability(vectors=states, probs=probs, dimensions=[2, 2, 2, 2], subsystems=[0, 2])
+ppt_val, _ = state_distinguishability(
+    vectors=states,
+    probs=probs,
+    measurement="ppt",
+    subsystems=[0, 2],
+    dimensions=[2, 2, 2, 2],
+)
 
 # Print the rounded result.
 print(f"Optimal probability with PPT measurements: {np.around(ppt_val, decimals=2)}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,10 @@ docs = [
     "mkdocs-jupyter>=0.24",
     "mkdocs-gallery>=0.10.0",
     "pymdown-extensions>=10.0",
+    # pymdown-extensions 10.20.1 passes `filename=None` to pygments'
+    # HtmlFormatter, which pygments 2.20.0 no longer accepts (crashes in
+    # html.escape). Cap until an upstream fix ships.
+    "pygments<2.20",
     "mkdocs-api-autonav>=0.4.0",
     "markdown-exec[ansi]>=1.7",
     "pybtex>=0.24",

--- a/uv.lock
+++ b/uv.lock
@@ -2053,11 +2053,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]
@@ -2792,6 +2792,7 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pybtex" },
+    { name = "pygments" },
     { name = "pymdown-extensions" },
     { name = "pypandoc" },
     { name = "ruff" },
@@ -2840,6 +2841,7 @@ docs = [
     { name = "mkdocs-material", specifier = ">=9.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.24" },
     { name = "pybtex", specifier = ">=0.24" },
+    { name = "pygments", specifier = "<2.20" },
     { name = "pymdown-extensions", specifier = ">=10.0" },
     { name = "pypandoc", specifier = ">=1.13" },
     { name = "ruff", specifier = ">=0.1.0" },


### PR DESCRIPTION
## Summary
- Replaces the downloadable `docs-preview` artifact with an in-browser preview deployed to `gh-pages` under `pr-preview/pr-N/`.
- Uses `rossjrw/pr-preview-action` to build, deploy, comment the preview URL on the PR, and clean up on close.
- Coexists with `mike`'s versioned deploys (`dev/`, `versions.json`, release dirs) on the same branch — the action only touches `pr-preview/pr-N/`.

## Notes
- Preview URL pattern: `https://vprusso.github.io/toqito/pr-preview/pr-<number>/`
- Fork PRs are skipped (cannot push to `gh-pages`); contributors from forks still need a local build.
- Closes #1498.

## Test plan
- [ ] Open a same-repo PR touching `docs/**` and confirm the bot comment links to a rendered preview.
- [ ] Push a follow-up commit and confirm the preview updates in place.
- [ ] Close the PR and confirm `pr-preview/pr-N/` is removed from `gh-pages`.
- [ ] Confirm `mike deploy --push dev` on master still works (dev docs unaffected).