### PR TITLE
Serialize gh-pages writers to prevent push races

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -8,7 +8,12 @@ on:
       - "toqito/**"
       - ".github/workflows/docs-preview.yml"
 
-concurrency: preview-${{ github.ref }}
+# Shared with .github/workflows/docs.yml — mike deploys and preview cleanups
+# both write to gh-pages, so they must not run concurrently or one push will
+# be rejected as non-fast-forward.
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,13 @@ on:
 permissions:
   contents: write
 
+# Serialize all writers of the gh-pages branch (this workflow + Docs Preview)
+# so mike's deploy and rossjrw/pr-preview-action cleanup don't race each other
+# and lose one of the pushes to a non-fast-forward rejection.
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `docs.yml` (`mike deploy --push dev`) and `docs-preview.yml` (`rossjrw/pr-preview-action` cleanup) both write to `gh-pages`, and PR merges fire them at the same time.
- On the #1502 merge this actually happened: preview cleanup finished and pushed at 16:44:14, mike's ~10-minute build tried to push at 16:54:18, and git rejected with `! [rejected] gh-pages -> gh-pages (fetch first)`. Failed deploy: https://github.com/vprusso/toqito/actions/runs/24253724456
- Put both workflows in a shared `gh-pages-deploy` concurrency group with `cancel-in-progress: false` so they queue instead of racing.

## Trade-off
The previous per-ref preview group (`preview-${{ github.ref }}`) allowed multiple open-PR preview builds to run in parallel. With the shared group they'll now queue. For a repo with normal PR volume that's a minor feedback-latency cost and worth it to stop silently failing release deploys.

## Test plan
- [ ] Merge and let the next docs-touching PR exercise both workflows on close — confirm the two runs queue rather than race.
- [ ] Confirm a `workflow_dispatch` of `Deploy Documentation` still works while no preview is running.