### PR TITLE
is_separable: add strength parameter for quick-check mode (closes #1247)

### DIFF
--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -22,6 +22,7 @@ def is_separable(
     dim: None | int | list[int] = None,
     level: int = 2,
     tol: float = 1e-8,
+    strength: int = 1,
 ) -> tuple[bool, str]:
     r"""Determine if a given state (given as a density matrix) is a separable state [@wikipediaseparable].
 
@@ -162,11 +163,36 @@ def is_separable(
         state: The density matrix to check.
         dim: The dimension of the input state, e.g., [dim_A, dim_B]. Optional; inferred if None.
         level:
-            - The level for symmetric extension (DPS) hierarchy (default: 2)
+            - The level for symmetric extension (DPS) hierarchy (default: 2).
             - If 1, only PPT is checked.
             - If >=2, checks for k-symmetric extension up to this level.
-            - If -1, attempts all implemented checks exhaustively (not all possible checks are implemented).
+            - `level` only controls how deep the DPS check runs; whether DPS runs
+              at all is gated by `strength` (see below).
         tol: Numerical tolerance (default: 1e-8).
+        strength:
+            Controls how thoroughly the function checks for separability. `strength`
+            picks *which* families of checks run; `level` continues to pick *how
+            deep* the DPS hierarchy goes once DPS is running.
+
+            - `strength = 0` — quick-check mode. Runs only the fast
+              pre-checks (trivial cases, pure-state Schmidt rank,
+              Gurvits-Barnum separable ball, PPT, and the PPT <= 6 dimension
+              sufficiency), then returns an inconclusive verdict. All later
+              checks (3x3 rank-4 Plucker, Horodecki rank bounds, reduction,
+              realignment/CCNR, Vidal-Tarrach, 2xN Johnston/Hildebrand,
+              Ha-Kye and Breuer-Hall witnesses, DPS hierarchy) are skipped.
+              Useful when you want a cheap answer or are batch-processing
+              many states and only care about the easy cases.
+            - `strength = 1` (default) — runs everything implemented today,
+              matching the function's behavior prior to the `strength`
+              parameter existing.
+            - `strength >= 2` — reserved for future expensive criteria
+              (Filter CMC, iterative product-state subtraction, additional
+              positive maps, refined Breuer/Horodecki conditions); currently
+              equivalent to `strength = 1`.
+            - `strength = -1` — alias for "run every implemented check".
+              Currently equivalent to `strength = 1`, will grow with future
+              additions.
 
     Returns:
         A 2-tuple `(separable, reason)` where `separable` is `True` if a sufficient
@@ -407,6 +433,16 @@ def is_separable(
         # For dA * dB <= 6, PPT is necessary and sufficient for separability
         # [@horodecki1996separability].
         return True, "PPT with d_A * d_B <= 6 (Horodecki 1996)"
+
+    # ----- Strength cutoff -----
+    # At `strength == 0`, only the fast pre-checks above (trivial, pure state,
+    # separable ball, PPT, PPT <= 6) run. Everything below this point — the
+    # 3x3 rank-4 Plucker determinant, Horodecki rank bounds, reduction,
+    # realignment/CCNR, Vidal-Tarrach, 2xN conditions, Ha-Kye/Breuer-Hall
+    # witnesses, and the DPS hierarchy — is skipped, and the function returns
+    # an inconclusive verdict. This is the "quick check" mode.
+    if strength == 0:
+        return False, "inconclusive: strength=0 capped after PPT pre-checks"
 
     # --- 6. 3x3 Rank-4 PPT N&S Check (Plucker/Breuer/Chen&Djokovic) ---
     # This checks if a 3x3 PPT state of rank 4 is separable.

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -163,11 +163,16 @@ def is_separable(
         state: The density matrix to check.
         dim: The dimension of the input state, e.g., [dim_A, dim_B]. Optional; inferred if None.
         level:
-            - The level for symmetric extension (DPS) hierarchy (default: 2).
-            - If 1, only PPT is checked.
-            - If >=2, checks for k-symmetric extension up to this level.
-            - `level` only controls how deep the DPS check runs; whether DPS runs
-              at all is gated by `strength` (see below).
+            - Controls only the depth of the DPS symmetric-extension hierarchy
+              (default: 2). All other post-PPT checks run regardless of
+              `level` (provided `strength` does not cut them off early).
+            - If `level == 1` and the state is PPT, the function accepts the
+              state at the DPS stage via the "1-extendible" branch.
+            - If `level >= 2`, the function checks for a k-symmetric extension
+              for every k from 2 up to `level`.
+            - `strength == 0` triggers an early inconclusive return before the
+              DPS block is reached, so `level` is effectively ignored in that
+              mode (see `strength` below).
         tol: Numerical tolerance (default: 1e-8).
         strength:
             Controls how thoroughly the function checks for separability. `strength`
@@ -296,6 +301,19 @@ def is_separable(
         raise TypeError("Input state must be a NumPy array.")
     if state.ndim != 2 or state.shape[0] != state.shape[1]:
         raise ValueError("Input state must be a square matrix.")
+
+    # Validate and normalize `strength`. Documented values are -1, 0, and any
+    # integer >= 1; anything else (including bools, floats, and other negatives)
+    # is rejected so typos don't silently behave like the full run.
+    if isinstance(strength, bool) or not isinstance(strength, (int, np.integer)):
+        raise ValueError(f"`strength` must be an int; got {type(strength).__name__}.")
+    if strength < -1:
+        raise ValueError(f"`strength` must be -1, 0, or a positive integer; got {strength}.")
+    # Normalize: -1 and any value >= 1 all mean "run every implemented check",
+    # which today is identical behavior. Collapse them to 1 so downstream logic
+    # only has to distinguish 0 vs non-0.
+    if strength != 0:
+        strength = 1
 
     # Define the smallest number computer can represent to avoid numerical issues.
     # This is used to determine the machine epsilon for numerical significance checks.

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -954,6 +954,19 @@ def test_return_reason_tracks_npt_branch():
 # --- Tests for the `strength` parameter ---
 
 
+def _upb_tile_state() -> np.ndarray:
+    """3x3 rank-4 PPT-entangled state built from the tile UPB (I - sum of tile projectors) / 4.
+
+    Used by the strength-parameter tests to exercise the Plucker branch at
+    strength=1 vs. the early-cutoff at strength=0. Not a fixture so a couple
+    of small tests can call it directly without indirection.
+    """
+    rho = np.identity(9)
+    for i in range(5):
+        rho = rho - tile(i) @ tile(i).conj().T
+    return rho / 4
+
+
 def test_strength_zero_caps_after_ppt_prechecks_on_upb_tile():
     """strength=0 stops early on a UPB tile PPT-entangled state.
 
@@ -961,10 +974,7 @@ def test_strength_zero_caps_after_ppt_prechecks_on_upb_tile():
     strength=0 everything after PPT <= 6 is skipped, so the function returns
     the 'strength=0 capped' inconclusive fallback.
     """
-    rho = np.identity(9)
-    for i in range(5):
-        rho = rho - tile(i) @ tile(i).conj().T
-    rho = rho / 4  # UPB tile state — PPT but entangled
+    rho = _upb_tile_state()
 
     sep_default, reason_default = is_separable(rho, dim=[3, 3])
     assert sep_default is False
@@ -979,7 +989,7 @@ def test_strength_zero_still_catches_tier_zero_criteria():
     """strength=0 must still catch the fast sufficient/necessary conditions.
 
     The maximally mixed 2x2 state is separable and hits one of the tier-0
-    branches (Gurvits-Barnum ball or PPT<=6); an NPT Bell state is entangled
+    branches (Gurvits-Barnum ball or PPT<=6); a mixed NPT state is entangled
     and hits the PPT criterion — both must fire regardless of strength.
     """
     sep_mixed, reason_mixed = is_separable(np.eye(4) / 4, dim=[2, 2], strength=0)
@@ -996,10 +1006,22 @@ def test_strength_zero_still_catches_tier_zero_criteria():
 
 def test_strength_minus_one_matches_default():
     """strength=-1 ('everything') is equivalent to strength=1 today."""
-    rho = np.identity(9)
-    for i in range(5):
-        rho = rho - tile(i) @ tile(i).conj().T
-    rho = rho / 4
-    sep_default, reason_default = is_separable(rho, dim=[3, 3], strength=1)
-    sep_all, reason_all = is_separable(rho, dim=[3, 3], strength=-1)
-    assert (sep_default, reason_default) == (sep_all, reason_all)
+    rho = _upb_tile_state()
+    assert is_separable(rho, dim=[3, 3], strength=1) == is_separable(rho, dim=[3, 3], strength=-1)
+
+
+@pytest.mark.parametrize(
+    "bad_strength, match",
+    [
+        (1.5, "must be an int"),
+        ("fast", "must be an int"),
+        (None, "must be an int"),
+        (True, "must be an int"),
+        (-2, "must be -1, 0, or a positive integer"),
+        (-10, "must be -1, 0, or a positive integer"),
+    ],
+)
+def test_strength_validation_rejects_invalid(bad_strength, match):
+    """Invalid `strength` values are rejected rather than silently treated as the full run."""
+    with pytest.raises(ValueError, match=match):
+        is_separable(np.eye(4) / 4, dim=[2, 2], strength=bad_strength)

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -949,3 +949,57 @@ def test_return_reason_tracks_npt_branch():
     # Match on "NPT" / "Peres-Horodecki" specifically — "PPT" alone would also
     # match the inconclusive fallback reason and wouldn't catch a regression.
     assert "NPT" in reason and "Peres-Horodecki" in reason
+
+
+# --- Tests for the `strength` parameter ---
+
+
+def test_strength_zero_caps_after_ppt_prechecks_on_upb_tile():
+    """strength=0 stops early on a UPB tile PPT-entangled state.
+
+    At strength=1 the 3x3 rank-4 Plucker check catches it as entangled; at
+    strength=0 everything after PPT <= 6 is skipped, so the function returns
+    the 'strength=0 capped' inconclusive fallback.
+    """
+    rho = np.identity(9)
+    for i in range(5):
+        rho = rho - tile(i) @ tile(i).conj().T
+    rho = rho / 4  # UPB tile state — PPT but entangled
+
+    sep_default, reason_default = is_separable(rho, dim=[3, 3])
+    assert sep_default is False
+    assert "Plucker" in reason_default
+
+    sep_fast, reason_fast = is_separable(rho, dim=[3, 3], strength=0)
+    assert sep_fast is False
+    assert "strength=0 capped" in reason_fast
+
+
+def test_strength_zero_still_catches_tier_zero_criteria():
+    """strength=0 must still catch the fast sufficient/necessary conditions.
+
+    The maximally mixed 2x2 state is separable and hits one of the tier-0
+    branches (Gurvits-Barnum ball or PPT<=6); an NPT Bell state is entangled
+    and hits the PPT criterion — both must fire regardless of strength.
+    """
+    sep_mixed, reason_mixed = is_separable(np.eye(4) / 4, dim=[2, 2], strength=0)
+    assert sep_mixed is True
+    assert "strength=0 capped" not in reason_mixed  # should NOT be the fallback
+
+    # Use a mixed NPT state (not a pure Bell) so PPT fires, not Schmidt rank.
+    rho_bell = bell(0) @ bell(0).conj().T
+    rho_npt_mixed = 0.9 * rho_bell + 0.1 * np.eye(4) / 4
+    sep_bell, reason_bell = is_separable(rho_npt_mixed, strength=0)
+    assert sep_bell is False
+    assert "NPT" in reason_bell
+
+
+def test_strength_minus_one_matches_default():
+    """strength=-1 ('everything') is equivalent to strength=1 today."""
+    rho = np.identity(9)
+    for i in range(5):
+        rho = rho - tile(i) @ tile(i).conj().T
+    rho = rho / 4
+    sep_default, reason_default = is_separable(rho, dim=[3, 3], strength=1)
+    sep_all, reason_all = is_separable(rho, dim=[3, 3], strength=-1)
+    assert (sep_default, reason_default) == (sep_all, reason_all)


### PR DESCRIPTION
## Summary
- Adds `strength: int = 1` to `is_separable`. `strength` controls *which* families of checks run; `level` continues to control *how deep* the DPS hierarchy goes.
- `strength = 0` — quick-check mode: runs only trivial cases, pure-state Schmidt rank, Gurvits-Barnum separable ball, PPT, and the PPT ≤ 6 sufficiency, then returns an inconclusive verdict. Everything after that point is skipped.
- `strength = 1` (default) — runs everything implemented today. Exactly matches the function's prior behavior, so no existing test needed adjusting.
- `strength >= 2` — placeholder for future expensive criteria (Filter CMC #1246, iterative product-state subtraction #1244, new PnCP maps #1249, refined Breuer/Horodecki #1251). Currently aliased to `strength = 1`.
- `strength = -1` — alias for \"run everything implemented\"; currently equivalent to `strength = 1`.

Closes #1247.

## Why an early-return instead of per-section gates
I initially tried gating individual blocks (3×3 Plücker at tier 2, Horodecki rank-bounds at tier 0, etc.) to give users finer-grained control. That exposed a pre-existing gotcha: the Horodecki rank-sum sufficient condition at section 7 wrongly classifies UPB tile states as separable, and the Plücker check at section 6 was silently acting as a guard by running first and catching those states as entangled. Splitting them across tiers meant `strength=0` produced a **false positive** on UPB tiles. I backed out the per-section gating and replaced it with a single early-return after the PPT ≤ 6 block — cleaner, no correctness hazards, and obviously-correct to review. The Horodecki rank-sum issue itself is out of scope for this PR; I'll flag it as a separate issue so it isn't lost.

## Test plan
- [x] Three new tests:
  - UPB tile state returns an entanglement verdict at `strength=1` (Plücker) and the `strength=0 capped` inconclusive fallback at `strength=0`.
  - Tier-0 paths still fire: `np.eye(4)/4` at `strength=0` is separable, a mixed NPT state at `strength=0` is entangled via PPT.
  - `strength=-1` is equivalent to `strength=1` on the tile state.
- [x] `pytest toqito/state_metrics toqito/state_props` → 314 passed, 6 skipped, 4 xfailed (up from 311).
- [x] `ruff check` clean.

## Next
This is the second and final infrastructure PR in the is_separable enhancement arc. The criterion-work PRs (C: #1251 + #1245 cheap sufficient conditions, D: #1246 Filter CMC, E: #1249 new PnCP maps, F: #1244 iterative subtraction) can now hook into the `strength` parameter for gating once they land.