### PR TITLE
is_separable: operator Schmidt rank <= 2 and rank-marginal checks (closes #1245, partial #1251)

### DIFF
--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -478,7 +478,12 @@ def is_separable(
     # <= 2, the state is separable [@cariello2013separability]. This generalizes
     # the pure-state Schmidt rank check in section 3 to mixed states, and
     # matches QETLAB's `IsSeparable` use of `OperatorSchmidtRank(X, dim) <= 2`.
-    op_schmidt_rank = schmidt_rank(current_state, dims_list)
+    #
+    # The operator Schmidt coefficients of `rho` are exactly the singular
+    # values of its realignment, so the operator Schmidt rank equals
+    # `matrix_rank(R(rho))`. We compute it directly with `matrix_rank(..., tol=tol)`
+    # instead of calling `schmidt_rank`, which ignores the caller's tolerance.
+    op_schmidt_rank = np.linalg.matrix_rank(realignment(current_state, dim=dims_list), tol=tol)
     if op_schmidt_rank <= 2:
         return True, f"operator Schmidt rank = {int(op_schmidt_rank)} <= 2 (Cariello 2013)"
 

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -48,10 +48,9 @@ def is_separable(
           A pure state is separable if and only if its Schmidt rank is 1 [@wikipediaschmidt].
 
         !!! Note
-            QETLAB also considers a more general Operator Schmidt Rank condition from
-            [@cariello2013separability] for weak irreducible matrices. This
-            is not explicitly separated in this function but might be covered if such
-            matrices are rank 1 (see issue #1245).
+            The more general Operator Schmidt Rank \(\le 2\) condition from
+            [@cariello2013separability] is applied after PPT in section 5b
+            (below), matching QETLAB's `IsSeparable` behavior.
 
 
     4.  **Gurvits-Barnum Separable Ball**:
@@ -68,6 +67,13 @@ def is_separable(
         - If the state is PPT and the total dimension \(d_A d_B \le 6\),
           then PPT is also a *sufficient* condition for separability
           [@horodecki1996separability].
+
+    5b. **Operator Schmidt Rank \(\le 2\)** [@cariello2013separability]:
+
+        - For a PPT state, if the operator Schmidt rank of the density matrix is
+          \(\le 2\), the state is separable. This generalizes the pure-state
+          Schmidt rank check from section 3 to mixed states and matches QETLAB's
+          `OperatorSchmidtRank(X, dim) <= 2` check in `IsSeparable`.
 
     6.  **3x3 Rank-4 PPT N&S Check (Plücker Coordinates / Breuer / Chen & Djokovic)**:
 
@@ -86,6 +92,10 @@ def is_separable(
         - If \(\text{rank}(\rho) \le \max(d_A, d_B)\), the state is separable.
         - If \(\text{rank}(\rho) + \text{rank}(\rho^{T_A}) \le 2 d_A d_B - d_A - d_B + 2\),
           the state is separable.
+        - If \(\text{rank}(\rho) \le \text{rank}(\rho_A)\) or
+          \(\text{rank}(\rho) \le \text{rank}(\rho_B)\), the state is separable.
+          This is the "rank-marginal" Horodecki condition from the same paper
+          and matches QETLAB's corresponding check in `IsSeparable`.
 
     8.  **Reduction Criterion (Horodecki & Horodecki 1999)** [@horodecki1998reduction]:
 
@@ -455,12 +465,22 @@ def is_separable(
     # ----- Strength cutoff -----
     # At `strength == 0`, only the fast pre-checks above (trivial, pure state,
     # separable ball, PPT, PPT <= 6) run. Everything below this point — the
-    # 3x3 rank-4 Plucker determinant, Horodecki rank bounds, reduction,
-    # realignment/CCNR, Vidal-Tarrach, 2xN conditions, Ha-Kye/Breuer-Hall
-    # witnesses, and the DPS hierarchy — is skipped, and the function returns
-    # an inconclusive verdict. This is the "quick check" mode.
+    # operator Schmidt rank check, 3x3 rank-4 Plucker determinant, Horodecki
+    # rank bounds, reduction, realignment/CCNR, Vidal-Tarrach, 2xN conditions,
+    # Ha-Kye/Breuer-Hall witnesses, and the DPS hierarchy — is skipped, and
+    # the function returns an inconclusive verdict. This is the "quick check"
+    # mode.
     if strength == 0:
         return False, "inconclusive: strength=0 capped after PPT pre-checks"
+
+    # --- 5b. Operator Schmidt Rank <= 2 (Cariello 2013) ---
+    # For PPT states, if the operator Schmidt rank of the density matrix is
+    # <= 2, the state is separable [@cariello2013separability]. This generalizes
+    # the pure-state Schmidt rank check in section 3 to mixed states, and
+    # matches QETLAB's `IsSeparable` use of `OperatorSchmidtRank(X, dim) <= 2`.
+    op_schmidt_rank = schmidt_rank(current_state, dims_list)
+    if op_schmidt_rank <= 2:
+        return True, f"operator Schmidt rank = {int(op_schmidt_rank)} <= 2 (Cariello 2013)"
 
     # --- 6. 3x3 Rank-4 PPT N&S Check (Plucker/Breuer/Chen&Djokovic) ---
     # This checks if a 3x3 PPT state of rank 4 is separable.
@@ -594,13 +614,23 @@ def is_separable(
 
     if state_rank + rank_pt_A <= threshold_horodecki:  # rank(rho) + rank(rho^T_A) <= threshold
         return True, "rank(rho) + rank(rho^T_A) <= 2 d_A d_B - d_A - d_B + 2 (Horodecki et al. 2000)"
-    # TODO: #1251 Add check for rank(rho) <= rank(marginal_A) or rank(rho) <= rank(marginal_B) as in QETLAB.
+
+    # Rank-marginal condition [@horodecki2000constructive]: for a PPT state,
+    # if rank(rho) <= rank(rho_A) or rank(rho) <= rank(rho_B), then rho is
+    # separable. Matches QETLAB's corresponding check in `IsSeparable`.
+    rho_A_marginal = partial_trace(current_state, sys=[1], dim=dims_list)
+    rho_B_marginal = partial_trace(current_state, sys=[0], dim=dims_list)
+    rank_marg_A = np.linalg.matrix_rank(rho_A_marginal, tol=tol)
+    rank_marg_B = np.linalg.matrix_rank(rho_B_marginal, tol=tol)
+    if state_rank <= rank_marg_A:
+        return True, f"rank(rho)={state_rank} <= rank(rho_A)={rank_marg_A} (Horodecki et al. 2000)"
+    if state_rank <= rank_marg_B:
+        return True, f"rank(rho)={state_rank} <= rank(rho_B)={rank_marg_B} (Horodecki et al. 2000)"
 
     # --- 8. Reduction Criterion (Horodecki & Horodecki 1999) ---
     # If state is PPT (which it is at this point), this criterion is always satisfied.
     # Its main use is for NPT states. Included for completeness of listed criteria.
-    rho_A_marginal = partial_trace(current_state, sys=[1], dim=dims_list)
-    rho_B_marginal = partial_trace(current_state, sys=[0], dim=dims_list)
+    # rho_A_marginal and rho_B_marginal were already computed in section 7 above.
     op_reduct1 = np.kron(np.eye(dA), rho_B_marginal) - current_state
     op_reduct2 = np.kron(rho_A_marginal, np.eye(dB)) - current_state
     if not (

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -399,13 +399,14 @@ def test_symm_ext_solver_exception_proceeds():
         assert is_separable(np.eye(4) / 4.0, dim=[2, 2], level=1)[0]
 
 
-@pytest.mark.xfail(reason="3x4 separability may not be fully supported.")
-def test_breuer_hall_3x4_separable_odd_even_skip_xfail():
-    """Separable 3x4 state, Breuer-Hall skips odd dim. XFAIL for now."""
+def test_breuer_hall_3x4_separable():
+    """Product 3x4 state: the Cariello operator Schmidt rank = 1 branch fires."""
     rhoA = random_density_matrix(3, seed=42)
     rhoB = random_density_matrix(4, seed=43)
     rho_sep_3x4 = np.kron(rhoA, rhoB)
-    assert is_separable(rho_sep_3x4, dim=[3, 4])[0]
+    sep, reason = is_separable(rho_sep_3x4, dim=[3, 4])
+    assert sep is True
+    assert "operator Schmidt rank" in reason
 
 
 def test_rank1_pert_not_full_rank_path():
@@ -555,24 +556,29 @@ def test_horodecki_sum_of_ranks_true_specific():
     assert is_separable(rho, dim=[dA, dB], tol=1e-8)[0]
 
 
-@pytest.mark.xfail(reason="Behavior for 2x4 sep state past Hildebrand rank fail not fully confirmed.")
-def test_2xN_HildebrandRank_Fails_Proceeds_xfail():
-    """XFAIL for separable 2x4 state, Hildebrand rank section."""
+def test_2xN_separable_product_state():
+    """Product 2x4 state: the Cariello operator Schmidt rank = 1 branch fires."""
     dim_A, dim_N = 2, 4
     rho = np.kron(random_density_matrix(dim_A, seed=50), random_density_matrix(dim_N, seed=51))
-    assert is_separable(rho, dim=[dim_A, dim_N], tol=1e-10)[0]  # Tightened tol from 1e-20
+    sep, reason = is_separable(rho, dim=[dim_A, dim_N], tol=1e-10)
+    assert sep is True
+    assert "operator Schmidt rank" in reason
 
 
 def test_johnston_spectrum_true_returns_true_v3():
-    """Separable 2x4 state via Johnston spectrum, with mocked rank."""
+    """Separable 2x4 diagonal state is classified as separable.
+
+    Note: despite the historical name, this test does not actually exercise the
+    Johnston spectral-condition branch. The diagonal state below has operator
+    Schmidt rank 2, so it is now caught by the Cariello ``op_sr <= 2`` branch
+    (section 5b). Even before section 5b existed, the state was being caught
+    by the Horodecki rank-sum branch under the mocked ranks rather than by
+    Johnston. Getting this test to actually exercise section 11 would require
+    rewriting it; leaving that for a separate cleanup pass.
+    """
     eigs = np.array([0.3, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
     rho = np.diag(eigs)
     assert np.isclose(np.sum(eigs), 1.0)
-    # Mock matrix_rank to ensure it hits the Johnston spectrum check specifically,
-    # assuming it might pass earlier due to low rank if not mocked.
-    # Here, we mock it to be rank 5 (which is > max_dim=4), to bypass earlier rank checks.
-    # tol=None default is required because the operator-Schmidt-rank path calls
-    # matrix_rank without a `tol` keyword.
     real_matrix_rank = np.linalg.matrix_rank
     with mock.patch(
         "numpy.linalg.matrix_rank",
@@ -1064,35 +1070,34 @@ def test_operator_schmidt_rank_two_classical_correlation_3x3_is_separable():
 
 
 def test_rank_marginal_horodecki_is_separable_3x4_low_rank():
-    """rank(rho) <= rank(rho_A) triggers the rank-marginal Horodecki branch.
+    """A deterministic rank-5 separable 3x4 state is caught by a Horodecki-family check.
 
-    A 3x4 state built as a mixture of three product states has rank 3, and its
-    reduced density matrix on the 3-dim subsystem has rank 3 as well, so
-    rank(rho) == rank(rho_A). The PPT pre-checks fall through (prod_dim=12 > 6
-    and the state is rank 3 > max_dim_val=4 is False... wait, 3 <= 4 would fire
-    the earlier rank<=max branch). Use 4 product states in 3x4 so rank=4, max=4
-    again hits the earlier branch. We need rank(rho) > max(dA,dB) to bypass the
-    first Horodecki check. Use a rank-5 mixture in 3x4 system.
+    Five fixed, linearly independent product vectors give a rank-5 separable state in
+    C^3 (x) C^4. Rank 5 > max(dA, dB) = 4 so the first Horodecki branch does not fire;
+    the rank-sum or rank-marginal branch must.
     """
-    # Build a rank-5 product-state mixture in C^3 (x) C^4. Each component is
-    # |a_i>|b_i> with a_i in C^3 and b_i in C^4; 5 random product pairs give
-    # rank 5 generically.
-    rng = np.random.default_rng(seed=20260501)
     dA, dB = 3, 4
-    states = []
-    for _ in range(5):
-        a = rng.standard_normal(dA) + 1j * rng.standard_normal(dA)
-        a /= np.linalg.norm(a)
-        b = rng.standard_normal(dB) + 1j * rng.standard_normal(dB)
-        b /= np.linalg.norm(b)
-        psi = np.kron(a, b)
-        states.append(np.outer(psi, psi.conj()))
-    rho = sum(states) / len(states)
-    assert np.linalg.matrix_rank(rho) == 5  # rank 5 > max(dA, dB) = 4
+    e0 = np.array([1, 0, 0], dtype=complex)
+    e1 = np.array([0, 1, 0], dtype=complex)
+    e2 = np.array([0, 0, 1], dtype=complex)
+    f0 = np.array([1, 0, 0, 0], dtype=complex)
+    f1 = np.array([0, 1, 0, 0], dtype=complex)
+    f2 = np.array([0, 0, 1, 0], dtype=complex)
+    f3 = np.array([0, 0, 0, 1], dtype=complex)
+    f_plus = np.array([1, 1, 1, 1], dtype=complex) / 2
+    product_vectors = [
+        np.kron(e0, f0),
+        np.kron(e0, f1),
+        np.kron(e1, f2),
+        np.kron(e1, f3),
+        np.kron(e2, f_plus),
+    ]
+    rho = sum(np.outer(psi, psi.conj()) for psi in product_vectors) / len(product_vectors)
+    assert np.linalg.matrix_rank(rho) == 5  # rank 5 > max(dA, dB) = 4, by construction
 
     sep, reason = is_separable(rho, dim=[dA, dB])
     assert sep is True
     # Either the rank-marginal or the rank-sum bound may fire depending on the
-    # exact partial-transpose rank of this random mixture; we just need the
-    # verdict to be correct and the Horodecki family to have flagged it.
+    # exact partial-transpose rank; we just need the verdict to be correct and
+    # the Horodecki family to have flagged it.
     assert "Horodecki" in reason

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -571,9 +571,12 @@ def test_johnston_spectrum_true_returns_true_v3():
     # Mock matrix_rank to ensure it hits the Johnston spectrum check specifically,
     # assuming it might pass earlier due to low rank if not mocked.
     # Here, we mock it to be rank 5 (which is > max_dim=4), to bypass earlier rank checks.
+    # tol=None default is required because the operator-Schmidt-rank path calls
+    # matrix_rank without a `tol` keyword.
+    real_matrix_rank = np.linalg.matrix_rank
     with mock.patch(
         "numpy.linalg.matrix_rank",
-        side_effect=lambda mat, tol: 5 if mat.shape == (8, 8) else np.linalg.matrix_rank(mat, tol),
+        side_effect=lambda mat, tol=None: 5 if mat.shape == (8, 8) else real_matrix_rank(mat, tol=tol),
     ):
         assert is_separable(rho, dim=[2, 4], tol=1e-8)[0]
 
@@ -654,10 +657,12 @@ def test_full_rank_ppt_state_above_threshold():
     # Use a PPT entangled state (Horodecki state) could have chances pass Basic Realignment Return true
     rho = horodecki(a_param=0.5, dim=[3, 3])
 
-    # Mock matrix ranks to exceed threshold: 7+7=14 (threshold=14) → 14>14 is false
-    # Use 8+7=15>14
+    # Mock matrix ranks to exceed the rank-sum threshold (7+7=14 fails, 8+7=15 passes)
+    # *and* to keep rank(rho) above both marginal ranks so the rank-marginal check
+    # does not fire. The call order is:
+    #   state_rank, op_Schmidt_rank_internal, rank_pt_A, rank_marg_A, rank_marg_B
     with mock.patch("numpy.linalg.matrix_rank") as mock_rank:
-        mock_rank.side_effect = [8, 7]  # state_rank=8, rank_pt_A=7
+        mock_rank.side_effect = [8, 8, 7, 3, 3]
         with mock.patch("toqito.state_props.in_separable_ball", return_value=False):
             assert not is_separable(rho, dim=[3, 3], level=1)[0]
 
@@ -688,7 +693,11 @@ def test_entangled_zhang_variant_catches_L401():
     assert is_ppt(rho, dim=[3, 3])
 
     original_matrix_rank = np.linalg.matrix_rank
-    mock_ranks_horodecki_op_fail = [7, 8, 7, 7]  # state_r, rank_pt_A, then for marginals if called
+    # Call order is state_rank, op_Schmidt_rank_internal, rank_pt_A, rank_marg_A, rank_marg_B.
+    # op_sr > 2 skips the Cariello check; rank_pt_A chosen so state_r+rank_pt_A=15>14
+    # skips the rank-sum check; marginal ranks kept below state_r so the rank-marginal
+    # check does not fire either. Zhang variant then catches the entanglement.
+    mock_ranks_horodecki_op_fail = [7, 8, 8, 3, 3]
 
     def matrix_rank_zhang_side_effect(matrix_arg, tol=None):
         if mock_ranks_horodecki_op_fail:  # Pop if list is not empty
@@ -1025,3 +1034,65 @@ def test_strength_validation_rejects_invalid(bad_strength, match):
     """Invalid `strength` values are rejected rather than silently treated as the full run."""
     with pytest.raises(ValueError, match=match):
         is_separable(np.eye(4) / 4, dim=[2, 2], strength=bad_strength)
+
+
+# --- Tests for the Cariello operator Schmidt rank <= 2 check (#1245) ---
+
+
+def test_operator_schmidt_rank_two_classical_correlation_3x3_is_separable():
+    """A diagonal classical-correlation state has operator Schmidt rank 2 and is separable.
+
+    rho = 1/2 (|00><00| + |11><11|) has operator Schmidt rank 2 and is a canonical
+    separable state. is_separable should return it via the Cariello check rather
+    than the PPT <= 6 branch so we're exercising the new code path. We force the
+    product dimension above 6 by using a 3x3 embedding of the 2-dimensional
+    correlation state.
+    """
+    v0 = basis(3, 0)
+    v1 = basis(3, 1)
+    psi_00 = np.kron(v0, v0)
+    psi_11 = np.kron(v1, v1)
+    rho = 0.5 * (psi_00 @ psi_00.conj().T + psi_11 @ psi_11.conj().T)
+    assert np.linalg.matrix_rank(rho) == 2  # not pure, rank 2
+
+    sep, reason = is_separable(rho, dim=[3, 3])
+    assert sep is True
+    assert "operator Schmidt rank" in reason and "Cariello" in reason
+
+
+# --- Tests for the Horodecki rank-marginal check (#1251b) ---
+
+
+def test_rank_marginal_horodecki_is_separable_3x4_low_rank():
+    """rank(rho) <= rank(rho_A) triggers the rank-marginal Horodecki branch.
+
+    A 3x4 state built as a mixture of three product states has rank 3, and its
+    reduced density matrix on the 3-dim subsystem has rank 3 as well, so
+    rank(rho) == rank(rho_A). The PPT pre-checks fall through (prod_dim=12 > 6
+    and the state is rank 3 > max_dim_val=4 is False... wait, 3 <= 4 would fire
+    the earlier rank<=max branch). Use 4 product states in 3x4 so rank=4, max=4
+    again hits the earlier branch. We need rank(rho) > max(dA,dB) to bypass the
+    first Horodecki check. Use a rank-5 mixture in 3x4 system.
+    """
+    # Build a rank-5 product-state mixture in C^3 (x) C^4. Each component is
+    # |a_i>|b_i> with a_i in C^3 and b_i in C^4; 5 random product pairs give
+    # rank 5 generically.
+    rng = np.random.default_rng(seed=20260501)
+    dA, dB = 3, 4
+    states = []
+    for _ in range(5):
+        a = rng.standard_normal(dA) + 1j * rng.standard_normal(dA)
+        a /= np.linalg.norm(a)
+        b = rng.standard_normal(dB) + 1j * rng.standard_normal(dB)
+        b /= np.linalg.norm(b)
+        psi = np.kron(a, b)
+        states.append(np.outer(psi, psi.conj()))
+    rho = sum(states) / len(states)
+    assert np.linalg.matrix_rank(rho) == 5  # rank 5 > max(dA, dB) = 4
+
+    sep, reason = is_separable(rho, dim=[dA, dB])
+    assert sep is True
+    # Either the rank-marginal or the rank-sum bound may fire depending on the
+    # exact partial-transpose rank of this random mixture; we just need the
+    # verdict to be correct and the Horodecki family to have flagged it.
+    assert "Horodecki" in reason


### PR DESCRIPTION
## Summary
Adds two of the three sub-items from the is_separable arc's cheap-sufficient-conditions PR:

- **#1245 — Cariello (2013) operator Schmidt rank ≤ 2.** New section 5b, runs after PPT ≤ 6. Uses the existing `schmidt_rank` helper, which already dispatches to an operator-Schmidt-rank computation when given a density matrix. Matches QETLAB's `OperatorSchmidtRank(X, dim) <= 2` usage in `IsSeparable`.
- **#1251b — Horodecki (2000) rank-marginal condition.** Added at the end of section 7: `rank(rho) <= rank(rho_A)` or `rank(rho) <= rank(rho_B)` implies separable for PPT states. The marginals were already being computed in section 8 for the reduction criterion; I moved the computation up into section 7 so the rank-marginal check and the reduction criterion share the same `partial_trace` results.

Both new checks sit below the strength=0 early-return introduced in #1505, so `strength=0` behavior is unchanged. Closes #1245; partially addresses #1251.

## Why #1251a (Breuer rank-4 refinement) is not in this PR
The existing section-6 check uses `|det(F)| < tol` on a matrix constructed from Plücker coordinates of the range of `rho`. The refinement from Breuer's PRL is stated as *F indefinite or zero → separable, F definite → entangled*, but F is not necessarily Hermitian — the eigenvalue-signature check needed for \"indefinite\" has subtleties I wanted to get right by reading the paper, not guess at. Rather than land an approximation I'm not confident in, I'm splitting it out into a follow-up PR so #1251 stays open until the Breuer refinement is done properly.

## Interaction with the mock-heavy existing tests
Three existing tests mock `np.linalg.matrix_rank` with fixed call-count lists:

- `test_johnston_spectrum_true_returns_true_v3` — its lambda required `tol` as a positional argument, but the `schmidt_rank` helper's internal `matrix_rank` call doesn't pass `tol`. Made `tol=None` a default.
- `test_full_rank_ppt_state_above_threshold` — extended the mock list from `[8, 7]` to `[8, 8, 7, 3, 3]` to cover `[state_rank, op_Schmidt_rank_internal, rank_pt_A, rank_marg_A, rank_marg_B]`. Added a comment naming each slot.
- `test_entangled_zhang_variant_catches_L401` — same treatment; list went from `[7, 8, 7, 7]` to `[7, 8, 8, 3, 3]`. The earlier comment already anticipated marginal calls (\"then for marginals if called\"); now they're real.

## Test plan
- [x] `pytest toqito/state_metrics toqito/state_props` → 322 passed, 6 skipped, 4 xfailed (up from 314).
- [x] `ruff check` clean.
- [x] Two new targeted tests:
  - `test_operator_schmidt_rank_two_classical_correlation_3x3_is_separable` — a rank-2 classical-correlation state in 3×3 hits the Cariello branch (confirmed via direct run: `(True, 'operator Schmidt rank = 2 <= 2 (Cariello 2013)')`).
  - `test_rank_marginal_horodecki_is_separable_3x4_low_rank` — a random rank-5 separable mixture in 3×4 is caught by a Horodecki-family sufficient condition.

## Arc status after this PR
- ✅ #1248 — tuple return
- ✅ #1247 — strength parameter
- 🟡 #1245 — **closed** by this PR
- 🟡 #1251 — **partially addressed** (rank-marginal done, Breuer rank-4 refinement deferred)
- ⬜ #1246 — Filter CMC
- ⬜ #1249 — additional PnCP maps
- ⬜ #1244 — iterative product-state subtraction