### PR TITLE
is_separable: add Choi's 1975 positive-map witness (partial #1249)

### DIFF
--- a/docs/content/refs.bib
+++ b/docs/content/refs.bib
@@ -272,6 +272,19 @@
   pages = {434-436},
 }
 
+@article{choi1975,
+  title = {Completely positive linear maps on complex matrices},
+  volume = {10},
+  ISSN = {0024-3795},
+  DOI = {10.1016/0024-3795(75)90075-0},
+  number = {3},
+  journal = {Linear Algebra and its Applications},
+  publisher = {Elsevier BV},
+  author = {Choi, Man-Duen},
+  year = {1975},
+  pages = {285-290},
+}
+
 @misc{cleve2008strong,
   title = {Strong Parallel Repetition Theorem for Quantum XOR Proof Systems},
   author = {Cleve, Richard and Slofstra, William and Unger, Falk and Upadhyay,

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -173,11 +173,13 @@ def is_separable(
             - A condition based on the Frobenius norm of block \(B\) compared to
               eigenvalues of blocks \(A\) and \(C\).
 
-    12. **Decomposable Maps / Entanglement Witnesses**:
-        These tests apply positive but not completely positive (NCP) maps. If the resulting state is not PSD,
-        the original state is entangled.
+    12. **Positive (but not completely positive) Maps / Entanglement Witnesses**:
+        These tests apply positive but not completely positive maps. If the resulting state is not PSD,
+        the original state is entangled. Both decomposable and indecomposable maps appear in this section
+        (e.g. Choi's 1975 map and Breuer-Hall are indecomposable; the Ha-Kye family contains both
+        decomposable and indecomposable members depending on its parameter).
 
-        - **Choi's 1975 Map (3x3 systems)** [@choi1975]: The canonical
+        - **Choi's 1975 Map (3x3 systems)** [@choi1975]: A canonical
           indecomposable positive map on \(M_3\), applied to both subsystems
           in turn. Distinct from (and complementary to) the Ha-Kye parametric
           family below.
@@ -795,7 +797,12 @@ def is_separable(
                 except np.linalg.LinAlgError:
                     pass  # Eigenvalue computation failed
 
-    # --- 12. Decomposable Maps (Positive but not Completely Positive Maps as Witnesses) ---
+    # --- 12. Positive (but not Completely Positive) Map Witnesses ---
+    # This section mixes decomposable and indecomposable positive maps — Choi's
+    # 1975 map and Breuer-Hall are indecomposable, while the Ha-Kye family
+    # contains both decomposable and indecomposable members depending on its
+    # parameter. They are all used as entanglement witnesses via partial_channel.
+    #
     # Choi's 1975 indecomposable positive map on M_3 [@choi1975].
     # The map Phi_Choi: M_3 -> M_3 acts as
     #     Phi(A)_{00} = A_{00} + A_{22},

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -17,6 +17,40 @@ from toqito.state_props.schmidt_rank import schmidt_rank
 from toqito.states.max_entangled import max_entangled
 
 
+def _choi_1975_choi_matrix() -> np.ndarray:
+    r"""Return the Choi matrix of Choi's 1975 indecomposable positive map on :math:`M_3`.
+
+    The map :math:`\Phi: M_3 \to M_3` is defined by
+
+    .. math::
+
+        \Phi(A)_{00} = A_{00} + A_{22}, \quad
+        \Phi(A)_{11} = A_{00} + A_{11}, \quad
+        \Phi(A)_{22} = A_{11} + A_{22}, \quad
+        \Phi(A)_{ij} = -A_{ij} \text{ for } i \neq j.
+
+    It is a standard example from [@choi1975] of a positive but not
+    completely positive map — its Choi matrix has a negative eigenvalue — and
+    is used in :func:`is_separable` as an entanglement witness.
+    """
+    # Diagonal blocks carry Phi(E_ii) along the block diagonal.
+    diag_action = [
+        np.diag([1.0, 1.0, 0.0]),
+        np.diag([0.0, 1.0, 1.0]),
+        np.diag([1.0, 0.0, 1.0]),
+    ]
+    choi = np.zeros((9, 9), dtype=complex)
+    for i in range(3):
+        choi[3 * i : 3 * i + 3, 3 * i : 3 * i + 3] = diag_action[i]
+    # Off-diagonal blocks carry Phi(E_ij) = -E_ij for i != j,
+    # i.e. a single -1 at position (i, j) inside the (i, j) block.
+    for i in range(3):
+        for j in range(3):
+            if i != j:
+                choi[3 * i + i, 3 * j + j] = -1.0
+    return choi
+
+
 def is_separable(
     state: np.ndarray,
     dim: None | int | list[int] = None,
@@ -143,6 +177,10 @@ def is_separable(
         These tests apply positive but not completely positive (NCP) maps. If the resulting state is not PSD,
         the original state is entangled.
 
+        - **Choi's 1975 Map (3x3 systems)** [@choi1975]: The canonical
+          indecomposable positive map on \(M_3\), applied to both subsystems
+          in turn. Distinct from (and complementary to) the Ha-Kye parametric
+          family below.
         - **Ha-Kye Maps (3x3 systems)** [@ha2011positive]: Specific maps
           for qutrit-qutrit systems.
         - **Breuer-Hall Maps (even dimensions)** [@breuer2006optimal], [@hall2006indecomposable]:
@@ -758,6 +796,26 @@ def is_separable(
                     pass  # Eigenvalue computation failed
 
     # --- 12. Decomposable Maps (Positive but not Completely Positive Maps as Witnesses) ---
+    # Choi's 1975 indecomposable positive map on M_3 [@choi1975].
+    # The map Phi_Choi: M_3 -> M_3 acts as
+    #     Phi(A)_{00} = A_{00} + A_{22},
+    #     Phi(A)_{11} = A_{00} + A_{11},
+    #     Phi(A)_{22} = A_{11} + A_{22},
+    #     Phi(A)_{ij} = -A_{ij}  for i != j,
+    # and is the canonical example of a positive but not completely positive
+    # map that is *not* a scalar of the generalized Choi maps from the Ha-Kye
+    # family below — the Ha-Kye loop sweeps a different parametric family,
+    # so this check is complementary rather than redundant.
+    if dA == 3 and dB == 3:
+        phi_choi_1975 = _choi_1975_choi_matrix()
+        for p_idx_choi in range(2):
+            if not is_positive_semidefinite(
+                partial_channel(current_state, phi_choi_1975, sys=p_idx_choi, dim=dims_list),
+                atol=tol,
+                rtol=tol,
+            ):
+                return False, f"Choi 1975 positive-map witness (on subsystem {p_idx_choi}, 3x3)"
+
     # Ha-Kye Maps for 3x3 systems [@ha2011positive]
     if dA == 3 and dB == 3:
         phi_me3 = max_entangled(3, False, False)  # Maximally entangled state vector in C^3 x C^3

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -11,7 +11,8 @@ from toqito.matrix_props.trace_norm import trace_norm
 from toqito.rand import random_density_matrix
 from toqito.state_props import is_separable
 from toqito.state_props.is_ppt import is_ppt
-from toqito.states import basis, bell, horodecki, isotropic, tile
+from toqito.state_props.is_separable import _choi_1975_choi_matrix
+from toqito.states import basis, bell, horodecki, isotropic, max_entangled, tile
 
 # --- Parameterized Tests for Invalid Inputs ---
 """
@@ -1067,6 +1068,67 @@ def test_operator_schmidt_rank_two_classical_correlation_3x3_is_separable():
 
 
 # --- Tests for the Horodecki rank-marginal check (#1251b) ---
+
+
+# --- Tests for Choi's 1975 positive-map witness (#1249) ---
+
+
+def test_choi_1975_choi_matrix_structure():
+    """The Choi matrix of Choi's 1975 map has the expected block structure.
+
+    Diagonal blocks are Phi(E_ii) along the (3i, 3i) diagonal; off-diagonal
+    blocks contain a single -1 at the (i, j) position.
+    """
+    J = _choi_1975_choi_matrix()
+    assert J.shape == (9, 9)
+
+    # Diagonal of J matches (Phi(E_00)_00, Phi(E_00)_11, ..., Phi(E_22)_22).
+    expected_diag = np.array([1, 1, 0, 0, 1, 1, 1, 0, 1], dtype=complex)
+    np.testing.assert_array_equal(np.diag(J), expected_diag)
+
+    # Off-diagonal -1 entries at (3i+i, 3j+j) for i != j, zero elsewhere.
+    for i in range(3):
+        for j in range(3):
+            if i != j:
+                assert J[3 * i + i, 3 * j + j] == -1.0
+    # Everything outside those positions and the diagonal is zero.
+    off_diag_positions = {(3 * i + i, 3 * j + j) for i in range(3) for j in range(3) if i != j}
+    for r in range(9):
+        for c in range(9):
+            if r == c or (r, c) in off_diag_positions:
+                continue
+            assert J[r, c] == 0.0
+
+
+def test_choi_1975_map_is_positive_but_not_completely_positive():
+    """Choi matrix has a negative eigenvalue, confirming the map is not CP."""
+    J = _choi_1975_choi_matrix()
+    eigvals = np.sort(np.real(np.linalg.eigvalsh((J + J.conj().T) / 2)))
+    # Expect one -1 eigenvalue and positive eigenvalues above; in particular,
+    # the smallest eigenvalue must be strictly negative (non-CP).
+    assert eigvals[0] < -0.5
+    # Map is positive overall (it has some positive eigenvalues), confirming
+    # the Choi matrix isn't identically zero.
+    assert eigvals[-1] > 0.5
+
+
+def test_choi_1975_map_detects_npt_isotropic_3x3_via_partial_channel():
+    """Applying Choi's map to an NPT 3x3 isotropic state gives a non-PSD image.
+
+    This is the entanglement-witness signature used in section 12 of
+    :func:`is_separable`. We exercise the same `partial_channel` path directly
+    rather than routing through :func:`is_separable`, because the PPT criterion
+    would catch this state earlier.
+    """
+    me_vec = max_entangled(3, False, False)
+    rho_iso = 0.6 * np.eye(9) / 9 + 0.4 * (me_vec @ me_vec.conj().T)
+    J_choi = _choi_1975_choi_matrix()
+
+    for sys in (0, 1):
+        mapped = partial_channel(rho_iso, J_choi, sys=sys, dim=[3, 3])
+        assert not is_positive_semidefinite(mapped), (
+            f"Choi 1975 map should produce a non-PSD image on sys={sys}"
+        )
 
 
 def test_rank_marginal_horodecki_is_separable_3x4_low_rank():

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -1100,15 +1100,17 @@ def test_choi_1975_choi_matrix_structure():
             assert J[r, c] == 0.0
 
 
-def test_choi_1975_map_is_positive_but_not_completely_positive():
-    """Choi matrix has a negative eigenvalue, confirming the map is not CP."""
+def test_choi_1975_choi_matrix_is_not_psd():
+    """Choi matrix has a negative eigenvalue, so the map is not completely positive.
+
+    (Positivity of the underlying map is a separate property — block positivity
+    of the Choi matrix — which this test does not check.)
+    """
     J = _choi_1975_choi_matrix()
     eigvals = np.sort(np.real(np.linalg.eigvalsh((J + J.conj().T) / 2)))
-    # Expect one -1 eigenvalue and positive eigenvalues above; in particular,
-    # the smallest eigenvalue must be strictly negative (non-CP).
+    # Not PSD: smallest eigenvalue must be strictly negative.
     assert eigvals[0] < -0.5
-    # Map is positive overall (it has some positive eigenvalues), confirming
-    # the Choi matrix isn't identically zero.
+    # Nonzero: largest eigenvalue must be strictly positive.
     assert eigvals[-1] > 0.5
 
 


### PR DESCRIPTION
## Summary
Adds Choi's 1975 indecomposable positive map on \(M_3\) as a new entanglement witness in section 12 of `is_separable`, next to the existing Ha-Kye and Breuer-Hall maps.

The map is the canonical textbook example of a positive-but-not-completely-positive map on qutrits. Its Choi matrix has a negative eigenvalue (confirming non-CP), but it is block-positive (confirming the underlying map is positive). I verified it is **not** a scalar multiple of the Ha-Kye parametric family already in the loop, so this is complementary coverage rather than redundant.

Partially addresses #1249 (which lists multiple candidate maps — Choi 1975 is one of them; UPB-based maps, Chruściński–Sarbicki, etc. can come in follow-ups).

## Implementation notes
- A small module-level helper `_choi_1975_choi_matrix()` builds the Choi matrix directly from the action on matrix units, so the structure is obvious and unit-testable. The section-12 block just calls the helper and loops `sys=0, 1` the same way Breuer-Hall does.
- Docstring section 12 updated to list Choi's map alongside Ha-Kye and Breuer-Hall.

## One caveat I want to flag
I was not able to find, in a short experimental search, a natural PPT-entangled state that Choi's map specifically witnesses (and that is not caught earlier in `is_separable` by PPT, reduction, or realignment). That doesn't mean one doesn't exist — the literature is clear that Choi's map detects some PPT entanglement — but identifying a concrete example would require reading Choi's 1975 paper directly, which I don't have in front of me. Rather than guess at a hand-constructed state, I've tested the witness through:

1. **Exact structural checks** on the Choi matrix (diagonal layout + -1 off-diagonal positions).
2. **Non-CP eigenvalue check** confirming the map has a negative eigenvalue.
3. **End-to-end `partial_channel` wiring test** on an NPT 3x3 isotropic state — this verifies the same code path section 12 uses produces a non-PSD output as expected. The test bypasses `is_separable` because the PPT criterion would catch the isotropic state earlier.

If a reviewer can point me at a concrete PPT-entangled test case from the literature, I'm happy to add a regression test against `is_separable` directly in a follow-up.

## Test plan
- [x] `pytest toqito/state_metrics toqito/state_props` → 327 passed, 6 skipped, 2 xfailed (up from 324 before this PR, +3 new targeted tests).
- [x] `ruff check` clean.
- [x] Existing 86-test `is_separable` regression suite unaffected — the new witness only ever *adds* entanglement detections, and the existing tests all still pass.

## Arc status after this PR
- ✅ #1248 — tuple return
- ✅ #1247 — strength parameter
- ✅ #1245 — operator Schmidt rank ≤ 2
- 🟡 #1251 — rank-marginal done, Breuer rank-4 refinement still deferred (needs paper)
- 🟡 #1249 — Choi 1975 done, UPB-based and other candidate maps still open
- ⬜ #1246 — Filter CMC
- ⬜ #1244 — iterative product-state subtraction