### PR TITLE
is_separable: iterative product-state subtraction witness (closes #1244)

### DIFF
--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -51,6 +51,106 @@ def _choi_1975_choi_matrix() -> np.ndarray:
     return choi
 
 
+def _iterative_product_state_subtraction(
+    state: np.ndarray,
+    dims: list[int],
+    tol: float,
+    max_outer_iter: int = 50,
+    n_restarts: int = 5,
+    max_inner_iter: int = 25,
+) -> bool:
+    r"""Try to prove separability by iteratively subtracting product states.
+
+    Loosely modelled on QETLAB's ``sk_iterate`` (with ``s = 1``) and the
+    Gühne method [@guhne2009entanglement]. At each outer iteration, run
+    alternating rank-1 maximization (with a handful of random restarts) to
+    find a product state :math:`|\psi\rangle|\phi\rangle` with high overlap
+    on the residual state, then subtract as much of
+    :math:`|\psi\rangle\langle\psi| \otimes |\phi\rangle\langle\phi|` as
+    positivity allows (via a geometric backoff search). Returns ``True`` if
+    the residual eventually enters the Gurvits-Barnum separable ball or
+    shrinks to numerical zero. Returns ``False`` if the loop stalls
+    (no product state with non-trivial overlap, or subtraction driven to
+    zero) or the iteration budget is exhausted — callers should treat
+    ``False`` as inconclusive rather than as an entanglement verdict.
+
+    This is a *one-sided* witness: the algorithm can prove separability
+    constructively, but cannot disprove it.
+    """
+    dA, dB = dims[0], dims[1]
+    residual = state.astype(complex, copy=True)
+    rng = np.random.default_rng(seed=0)
+
+    for _outer in range(max_outer_iter):
+        residual_trace = float(np.real(np.trace(residual)))
+        if residual_trace < tol:
+            return True  # Fully decomposed into product states.
+        if in_separable_ball(residual / residual_trace):
+            return True  # Residual fell into the Gurvits-Barnum ball.
+
+        tensor = residual.reshape(dA, dB, dA, dB)
+        best_overlap = 0.0
+        best_prod_vec: np.ndarray | None = None
+        for _ in range(n_restarts):
+            psi = rng.standard_normal(dA) + 1j * rng.standard_normal(dA)
+            psi /= np.linalg.norm(psi)
+            phi = rng.standard_normal(dB) + 1j * rng.standard_normal(dB)
+            phi /= np.linalg.norm(phi)
+
+            prev_overlap = -np.inf
+            overlap = 0.0
+            for _inner in range(max_inner_iter):
+                # Fix phi, maximize over psi: top eigenvector of
+                # M_psi[i, k] = sum_{j, l} conj(phi_j) T[i, j, k, l] phi_l.
+                m_psi = np.einsum("j,ijkl,l->ik", np.conj(phi), tensor, phi)
+                m_psi = (m_psi + m_psi.conj().T) / 2.0
+                _, vecs = np.linalg.eigh(m_psi)
+                psi = vecs[:, -1]
+
+                # Fix psi, maximize over phi: top eigenvector of
+                # M_phi[j, l] = sum_{i, k} conj(psi_i) T[i, j, k, l] psi_k.
+                m_phi = np.einsum("i,ijkl,k->jl", np.conj(psi), tensor, psi)
+                m_phi = (m_phi + m_phi.conj().T) / 2.0
+                _, vecs = np.linalg.eigh(m_phi)
+                phi = vecs[:, -1]
+
+                prod_vec = np.kron(psi, phi)
+                overlap = float(np.real(prod_vec.conj() @ residual @ prod_vec))
+                if abs(overlap - prev_overlap) < tol:
+                    break
+                prev_overlap = overlap
+
+            if overlap > best_overlap:
+                best_overlap = overlap
+                best_prod_vec = prod_vec
+
+        if best_prod_vec is None or best_overlap < tol:
+            return False  # Stuck: no product state with non-trivial overlap.
+
+        # Subtract as much of |prod><prod| as keeps the residual PSD.
+        # Start with the full overlap and back off geometrically on PSD failure.
+        # If the product state has a component in the null space of the residual,
+        # no positive subtraction is possible and the backoff drives s below tol.
+        prod_proj = np.outer(best_prod_vec, best_prod_vec.conj())
+        s_subtract = best_overlap
+        accepted = False
+        for _backoff in range(40):
+            candidate = residual - s_subtract * prod_proj
+            candidate = (candidate + candidate.conj().T) / 2.0
+            min_eig = float(np.linalg.eigvalsh(candidate)[0])
+            if min_eig >= -tol:
+                residual = candidate
+                accepted = True
+                break
+            s_subtract *= 0.5
+            if s_subtract < tol:
+                break
+        if not accepted:
+            return False  # Backoff exhausted; algorithm is stuck.
+
+    return False  # Iteration budget exhausted.
+
+
 def is_separable(
     state: np.ndarray,
     dim: None | int | list[int] = None,
@@ -188,6 +288,19 @@ def is_separable(
         - **Breuer-Hall Maps (even dimensions)** [@breuer2006optimal], [@hall2006indecomposable]:
           Maps based on antisymmetric unitary matrices, applicable when a subsystem
           has even dimension.
+
+    12b. **Iterative Product-State Subtraction (Gühne / sk_iterate)**:
+
+        A constructive sufficient test for separability. Uses alternating
+        rank-1 maximization (with a handful of random restarts) to find a
+        product state \(|\psi\rangle|\phi\rangle\) with high overlap on
+        the residual density matrix, then subtracts as much of
+        \(|\psi\rangle\langle\psi| \otimes |\phi\rangle\langle\phi|\) as
+        positivity allows and repeats. If the residual shrinks into the
+        Gurvits-Barnum separable ball or to numerical zero, the state is
+        declared separable. Otherwise the algorithm falls through silently
+        to the DPS hierarchy below — this is a *one-sided* witness and
+        never returns an entanglement verdict.
 
     13. **Symmetric Extension Hierarchy (DPS)** [@doherty2004complete]:
 
@@ -871,6 +984,16 @@ def is_separable(
             mapped_state_bh = partial_channel(current_state, Phi_bh_map_choi, sys=p_idx_bh, dim=dims_list)
             if not is_positive_semidefinite(mapped_state_bh, atol=tol, rtol=tol):
                 return False, f"Breuer-Hall positive-map witness (on subsystem {p_idx_bh}, dim={current_dim_bh})"
+
+    # --- 12b. Iterative Product-State Subtraction (Guhne / sk_iterate) ---
+    # Try to constructively prove separability by iteratively finding and
+    # subtracting product states from the residual. This is a one-sided
+    # witness: if it succeeds, the state is separable; if it stalls, the
+    # caller falls through to DPS. We run it before DPS because a successful
+    # constructive proof is cheaper than a full SDP solve, and because DPS
+    # gives only a hierarchy-level verdict rather than a decomposition.
+    if _iterative_product_state_subtraction(current_state, dims_list, tol):
+        return True, "iterative product-state subtraction decomposed the state (Guhne / sk_iterate)"
 
     # --- 13. Symmetric Extension Hierarchy (DPS) ---
     # A state is separable iff it has a k-symmetric extension for all k [@doherty2004complete].

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -58,6 +58,7 @@ def _iterative_product_state_subtraction(
     max_outer_iter: int = 50,
     n_restarts: int = 5,
     max_inner_iter: int = 25,
+    rng: np.random.Generator | None = None,
 ) -> bool:
     r"""Try to prove separability by iteratively subtracting product states.
 
@@ -74,12 +75,18 @@ def _iterative_product_state_subtraction(
     zero) or the iteration budget is exhausted — callers should treat
     ``False`` as inconclusive rather than as an entanglement verdict.
 
+    The `rng` parameter accepts a `numpy.random.Generator` for reproducible
+    restarts in tests. Callers that don't supply one get a fresh
+    non-deterministic generator, so production calls genuinely randomize
+    across restarts.
+
     This is a *one-sided* witness: the algorithm can prove separability
     constructively, but cannot disprove it.
     """
     dA, dB = dims[0], dims[1]
     residual = state.astype(complex, copy=True)
-    rng = np.random.default_rng(seed=0)
+    if rng is None:
+        rng = np.random.default_rng()
 
     for _outer in range(max_outer_iter):
         residual_trace = float(np.real(np.trace(residual)))
@@ -91,6 +98,12 @@ def _iterative_product_state_subtraction(
         tensor = residual.reshape(dA, dB, dA, dB)
         best_overlap = 0.0
         best_prod_vec: np.ndarray | None = None
+        # Both the inner-loop convergence threshold and the outer "stuck"
+        # threshold scale with the current residual trace, so a small
+        # residual (or a high-dimension diffuse residual) doesn't get
+        # spuriously declared stuck when the best achievable overlap is
+        # naturally below an absolute `tol`.
+        scaled_tol = tol * max(1.0, residual_trace)
         for _ in range(n_restarts):
             psi = rng.standard_normal(dA) + 1j * rng.standard_normal(dA)
             psi /= np.linalg.norm(psi)
@@ -116,7 +129,7 @@ def _iterative_product_state_subtraction(
 
                 prod_vec = np.kron(psi, phi)
                 overlap = float(np.real(prod_vec.conj() @ residual @ prod_vec))
-                if abs(overlap - prev_overlap) < tol:
+                if abs(overlap - prev_overlap) < scaled_tol:
                     break
                 prev_overlap = overlap
 
@@ -124,7 +137,7 @@ def _iterative_product_state_subtraction(
                 best_overlap = overlap
                 best_prod_vec = prod_vec
 
-        if best_prod_vec is None or best_overlap < tol:
+        if best_prod_vec is None or best_overlap < scaled_tol:
             return False  # Stuck: no product state with non-trivial overlap.
 
         # Subtract as much of |prod><prod| as keeps the residual PSD.
@@ -351,13 +364,14 @@ def is_separable(
               Ha-Kye and Breuer-Hall witnesses, DPS hierarchy) are skipped.
               Useful when you want a cheap answer or are batch-processing
               many states and only care about the easy cases.
-            - `strength = 1` (default) — runs everything implemented today,
-              matching the function's behavior prior to the `strength`
-              parameter existing.
+            - `strength = 1` (default) — runs every check currently
+              implemented in the function, including the iterative
+              product-state subtraction constructive witness (section 12b)
+              that was added alongside this parameter's expansion.
             - `strength >= 2` — reserved for future expensive criteria
-              (Filter CMC, iterative product-state subtraction, additional
-              positive maps, refined Breuer/Horodecki conditions); currently
-              equivalent to `strength = 1`.
+              (Filter CMC, additional positive maps, refined
+              Breuer/Horodecki conditions); currently equivalent to
+              `strength = 1`.
             - `strength = -1` — alias for "run every implemented check".
               Currently equivalent to `strength = 1`, will grow with future
               additions.

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -1171,12 +1171,19 @@ def test_rank_marginal_horodecki_is_separable_3x4_low_rank():
 
 
 # --- Tests for iterative product-state subtraction (#1244) ---
+# The helper defaults to a fresh non-deterministic Generator; tests pass a
+# fixed-seed rng for reproducibility so a single rare unlucky restart can't
+# flake the suite.
+
+
+def _rng():
+    return np.random.default_rng(seed=20260601)
 
 
 def test_iter_sub_decomposes_product_state_2x2():
     """A plain product state should be decomposed constructively."""
     rho = np.kron(np.eye(2) / 2, np.diag([0.7, 0.3]))
-    assert _iterative_product_state_subtraction(rho, [2, 2], tol=1e-8) is True
+    assert _iterative_product_state_subtraction(rho, [2, 2], tol=1e-8, rng=_rng()) is True
 
 
 def test_iter_sub_decomposes_classical_mixture_2x2():
@@ -1185,7 +1192,7 @@ def test_iter_sub_decomposes_classical_mixture_2x2():
     p00 = np.kron(e0, e0)
     p11 = np.kron(e1, e1)
     rho = 0.6 * (p00 @ p00.conj().T) + 0.4 * (p11 @ p11.conj().T)
-    assert _iterative_product_state_subtraction(rho, [2, 2], tol=1e-8) is True
+    assert _iterative_product_state_subtraction(rho, [2, 2], tol=1e-8, rng=_rng()) is True
 
 
 def test_iter_sub_decomposes_mixture_of_four_product_states_3x3():
@@ -1193,18 +1200,18 @@ def test_iter_sub_decomposes_mixture_of_four_product_states_3x3():
     e = [basis(3, i) for i in range(3)]
     projs = [np.outer(np.kron(e[i], e[j]), np.kron(e[i], e[j]).conj()) for (i, j) in [(0, 0), (1, 1), (2, 2), (0, 1)]]
     rho = sum(projs) / 4
-    assert _iterative_product_state_subtraction(rho, [3, 3], tol=1e-8) is True
+    assert _iterative_product_state_subtraction(rho, [3, 3], tol=1e-8, rng=_rng()) is True
 
 
 def test_iter_sub_decomposes_maximally_mixed_via_separable_ball():
     """The maximally mixed state is inside the Gurvits-Barnum ball on the very first outer iteration."""
-    assert _iterative_product_state_subtraction(np.eye(9) / 9, [3, 3], tol=1e-8) is True
+    assert _iterative_product_state_subtraction(np.eye(9) / 9, [3, 3], tol=1e-8, rng=_rng()) is True
 
 
 def test_iter_sub_rejects_bell_state():
     """A maximally entangled state cannot be constructively decomposed."""
     rho = bell(0) @ bell(0).conj().T
-    assert _iterative_product_state_subtraction(rho, [2, 2], tol=1e-8) is False
+    assert _iterative_product_state_subtraction(rho, [2, 2], tol=1e-8, rng=_rng()) is False
 
 
 def test_iter_sub_rejects_upb_tile_ppt_entangled():
@@ -1213,7 +1220,7 @@ def test_iter_sub_rejects_upb_tile_ppt_entangled():
     for i in range(5):
         rho = rho - tile(i) @ tile(i).conj().T
     rho = rho / 4
-    assert _iterative_product_state_subtraction(rho, [3, 3], tol=1e-8) is False
+    assert _iterative_product_state_subtraction(rho, [3, 3], tol=1e-8, rng=_rng()) is False
 
 
 def test_iter_sub_respects_iteration_budget_on_entangled_state():
@@ -1222,7 +1229,87 @@ def test_iter_sub_respects_iteration_budget_on_entangled_state():
     # Run with a tighter budget and confirm we still get a clean False.
     assert (
         _iterative_product_state_subtraction(
-            rho, [2, 2], tol=1e-8, max_outer_iter=5, n_restarts=2, max_inner_iter=5
+            rho, [2, 2], tol=1e-8, max_outer_iter=5, n_restarts=2, max_inner_iter=5, rng=_rng()
         )
         is False
     )
+
+
+def test_iter_sub_helper_is_deterministic_when_seeded():
+    """Reproducibility: two calls with the same seeded rng produce the same verdict."""
+    rho = bell(0) @ bell(0).conj().T
+    r1 = _iterative_product_state_subtraction(rho, [2, 2], tol=1e-8, rng=np.random.default_rng(seed=1))
+    r2 = _iterative_product_state_subtraction(rho, [2, 2], tol=1e-8, rng=np.random.default_rng(seed=1))
+    assert r1 == r2
+
+
+# --- Integration tests for is_separable's section 12b gating ---
+#
+# These tests use `rho_ent_symm`, a 3x3 PPT-entangled-looking state from the
+# existing `test_symm_ext_catches_hard_entangled_state` above, which fails all
+# earlier sufficient checks at default strength and reaches DPS naturally --
+# making it the only state in the suite that actually flows through section
+# 12b. The helper is mocked so the tests exercise the *wiring*, not the
+# algorithm itself (that's covered by the direct helper tests above).
+
+
+_RHO_ENT_SYMM_3x3_REACHES_12B = (
+    np.array(
+        [
+            [1.0, 0.67, 0.91, 0.67, 0.45, 0.61, 0.88, 0.59, 0.79],
+            [0.67, 1.0, 0.5, 0.45, 0.67, 0.34, 0.59, 0.88, 0.44],
+            [0.91, 0.5, 1.0, 0.61, 0.34, 0.68, 0.81, 0.44, 0.88],
+            [0.67, 0.45, 0.61, 1.0, 0.67, 0.91, 0.5, 0.33, 0.45],
+            [0.45, 0.67, 0.34, 0.67, 1.0, 0.5, 0.33, 0.5, 0.25],
+            [0.61, 0.34, 0.68, 0.91, 0.5, 1.0, 0.45, 0.26, 0.5],
+            [0.88, 0.59, 0.81, 0.5, 0.33, 0.45, 1.0, 0.66, 0.91],
+            [0.59, 0.88, 0.44, 0.33, 0.5, 0.26, 0.66, 1.0, 0.48],
+            [0.79, 0.44, 0.88, 0.45, 0.25, 0.5, 0.91, 0.48, 1.0],
+        ]
+    )
+    / 8.75
+)
+
+
+def test_is_separable_returns_iter_sub_reason_when_helper_succeeds():
+    """Surface the section 12b reason when the helper returns True.
+
+    This verifies that a successful iterative-subtraction run short-circuits
+    the DPS hierarchy and produces the expected reason string.
+    """
+    with mock.patch(
+        "toqito.state_props.is_separable._iterative_product_state_subtraction",
+        return_value=True,
+    ) as mocked:
+        sep, reason = is_separable(_RHO_ENT_SYMM_3x3_REACHES_12B, dim=[3, 3], level=2)
+    assert sep is True
+    assert "iterative product-state subtraction" in reason
+    assert mocked.called
+
+
+def test_is_separable_strength_zero_skips_iter_sub():
+    """Section 12b must not run at strength=0: the helper should never be called."""
+    with mock.patch(
+        "toqito.state_props.is_separable._iterative_product_state_subtraction",
+        return_value=True,
+    ) as mocked:
+        is_separable(_RHO_ENT_SYMM_3x3_REACHES_12B, dim=[3, 3], strength=0)
+    assert not mocked.called
+
+
+def test_is_separable_falls_through_when_iter_sub_returns_false():
+    """Section 12b returning False must be treated as inconclusive, not entangled.
+
+    When the helper returns False, is_separable must continue to DPS rather
+    than spuriously declaring the state entangled from section 12b.
+    """
+    with mock.patch(
+        "toqito.state_props.is_separable._iterative_product_state_subtraction",
+        return_value=False,
+    ):
+        sep, reason = is_separable(_RHO_ENT_SYMM_3x3_REACHES_12B, dim=[3, 3], level=2)
+    # The helper returning False is inconclusive, not an entanglement verdict,
+    # and DPS catches this state at level=2 via the "passed DPS ... up to
+    # level=2" branch. Either way, the 12b reason must not appear.
+    assert "iterative product-state subtraction" not in reason
+    assert sep is True  # DPS handles it at level=2

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -11,7 +11,10 @@ from toqito.matrix_props.trace_norm import trace_norm
 from toqito.rand import random_density_matrix
 from toqito.state_props import is_separable
 from toqito.state_props.is_ppt import is_ppt
-from toqito.state_props.is_separable import _choi_1975_choi_matrix
+from toqito.state_props.is_separable import (
+    _choi_1975_choi_matrix,
+    _iterative_product_state_subtraction,
+)
 from toqito.states import basis, bell, horodecki, isotropic, max_entangled, tile
 
 # --- Parameterized Tests for Invalid Inputs ---
@@ -1165,3 +1168,61 @@ def test_rank_marginal_horodecki_is_separable_3x4_low_rank():
     # exact partial-transpose rank; we just need the verdict to be correct and
     # the Horodecki family to have flagged it.
     assert "Horodecki" in reason
+
+
+# --- Tests for iterative product-state subtraction (#1244) ---
+
+
+def test_iter_sub_decomposes_product_state_2x2():
+    """A plain product state should be decomposed constructively."""
+    rho = np.kron(np.eye(2) / 2, np.diag([0.7, 0.3]))
+    assert _iterative_product_state_subtraction(rho, [2, 2], tol=1e-8) is True
+
+
+def test_iter_sub_decomposes_classical_mixture_2x2():
+    """A diagonal classical-correlation state is separable and decomposable."""
+    e0, e1 = basis(2, 0), basis(2, 1)
+    p00 = np.kron(e0, e0)
+    p11 = np.kron(e1, e1)
+    rho = 0.6 * (p00 @ p00.conj().T) + 0.4 * (p11 @ p11.conj().T)
+    assert _iterative_product_state_subtraction(rho, [2, 2], tol=1e-8) is True
+
+
+def test_iter_sub_decomposes_mixture_of_four_product_states_3x3():
+    """A rank-4 separable mixture in 3x3 is decomposed constructively."""
+    e = [basis(3, i) for i in range(3)]
+    projs = [np.outer(np.kron(e[i], e[j]), np.kron(e[i], e[j]).conj()) for (i, j) in [(0, 0), (1, 1), (2, 2), (0, 1)]]
+    rho = sum(projs) / 4
+    assert _iterative_product_state_subtraction(rho, [3, 3], tol=1e-8) is True
+
+
+def test_iter_sub_decomposes_maximally_mixed_via_separable_ball():
+    """The maximally mixed state is inside the Gurvits-Barnum ball on the very first outer iteration."""
+    assert _iterative_product_state_subtraction(np.eye(9) / 9, [3, 3], tol=1e-8) is True
+
+
+def test_iter_sub_rejects_bell_state():
+    """A maximally entangled state cannot be constructively decomposed."""
+    rho = bell(0) @ bell(0).conj().T
+    assert _iterative_product_state_subtraction(rho, [2, 2], tol=1e-8) is False
+
+
+def test_iter_sub_rejects_upb_tile_ppt_entangled():
+    """The UPB tile state is PPT entangled; the algorithm should fail to decompose it."""
+    rho = np.identity(9)
+    for i in range(5):
+        rho = rho - tile(i) @ tile(i).conj().T
+    rho = rho / 4
+    assert _iterative_product_state_subtraction(rho, [3, 3], tol=1e-8) is False
+
+
+def test_iter_sub_respects_iteration_budget_on_entangled_state():
+    """Budget exhaustion returns False without hanging or raising."""
+    rho = bell(0) @ bell(0).conj().T
+    # Run with a tighter budget and confirm we still get a clean False.
+    assert (
+        _iterative_product_state_subtraction(
+            rho, [2, 2], tol=1e-8, max_outer_iter=5, n_restarts=2, max_inner_iter=5
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary
Adds a constructive one-sided sufficient test for separability, loosely modelled on QETLAB's `sk_iterate` (with `s = 1`) and the Gühne method. At each outer iteration the algorithm alternates rank-1 maximization (with a handful of random restarts) to find a product state with high overlap on the residual density matrix, then subtracts as much of the projector as positivity allows and repeats. Returns `True` if the residual shrinks into the Gurvits-Barnum separable ball or to numerical zero, `False` if it stalls or the iteration budget runs out.

Closes #1244.

## Algorithm details
Each outer iteration does:

1. **Find a product state.** Alternating rank-1 max: fix `|φ⟩`, set `|ψ⟩` to the dominant eigenvector of `M_ψ[i, k] = Σ_{j,l} conj(φ_j) T[i, j, k, l] φ_l`, where `T` is the residual reshaped as a (dA, dB, dA, dB) tensor. Flip and repeat. 5 random restarts, each with up to 25 inner iterations.
2. **Subtract.** Start with `s = ⟨ψ⟨φ|ρ|φ⟩ψ⟩` and halve on PSD failure until either the residual stays PSD or `s < tol`. The halving is necessary because naive subtraction at full overlap doesn't preserve positivity when the product vector has components in the null space of the residual — a known subtlety I walked through before picking this implementation.
3. **Terminate.** Residual trace below `tol` → separable (full decomposition). Residual in the separable ball → separable. No product state with non-trivial overlap found → inconclusive (fall through). Iteration budget exhausted → inconclusive.

## Placement and gating
New section 12b in `is_separable`, between the positive-map witnesses (section 12) and the DPS hierarchy (section 13). Running before DPS means a successful constructive proof short-circuits the SDP solve. Naturally gated by `strength != 0` because it sits below the strength-0 early-return cutoff.

The helper `_iterative_product_state_subtraction` lives at module level so it's directly unit-testable and the `is_separable` integration site is a one-liner.

## Caveat I want to flag
**No tests exercise section 12b *through* `is_separable`** — they exercise the helper directly. Every separable state in the existing test suite is caught by an earlier, cheaper check (trivial, Schmidt, ball, PPT ≤ 6, operator Schmidt rank, Horodecki ranks, realignment, Vidal-Tarrach, 2×N conditions). Constructing a test state that specifically reaches section 12b would need a PPT-entangled state detected by `sk_iterate` but none of the positive-map witnesses — which is literature territory I don't have on hand. The 96-test regression suite on this module continues to pass, confirming the new section doesn't inadvertently flip any existing verdict.

## Test plan
- [x] `pytest toqito/state_metrics toqito/state_props` → 334 passed (up from 327), 6 skipped, 2 xfailed.
- [x] `ruff check` clean.
- [x] Seven new targeted tests on the helper:
  - Product state 2×2 decomposed.
  - Classical-correlation mixture 2×2 decomposed.
  - Four-product-state mixture 3×3 decomposed.
  - Maximally mixed state caught via the separable-ball early exit.
  - Bell state rejected.
  - UPB tile 3×3 PPT-entangled state rejected (stalls out cleanly).
  - Tight iteration budget on the Bell state returns `False` without hanging or raising.
- [x] Sanity-checked runtime: ~3 ms for 3×3 separable mixtures, ~19 ms for the UPB tile stall-out — well under any reasonable budget.

## Arc status after this PR
- ✅ #1248, #1247, #1245, #1244 — closed
- 🟡 #1251 — rank-marginal done; Breuer rank-4 refinement still deferred (needs paper)
- 🟡 #1249 — Choi 1975 done; UPB-based maps still open
- ⬜ #1246 — Filter CMC (needs paper)

The three items still open all need paper access to do correctly. After this merges, the next natural step is for you to drop the Breuer 2006, Gittsovich 2008, or UPB/Terhal paper PDFs into the repo (or point me at open-access URLs) so I can tackle them with the same level of confidence as the rest of the arc. Otherwise, the arc is effectively done for now.