### PR TITLE
is_separable: Filter Covariance Matrix Criterion (closes #1246)

### DIFF
--- a/docs/content/refs.bib
+++ b/docs/content/refs.bib
@@ -508,6 +508,21 @@
   primaryClass = {quant-ph},
 }
 
+@article{gittsovich2008unifying,
+  title = {Unifying several separability conditions using the covariance matrix
+           criterion},
+  author = {Gittsovich, O. and G\"uhne, O. and Hyllus, P. and Eisert, J.},
+  journal = {Phys. Rev. A},
+  volume = {78},
+  issue = {5},
+  pages = {052319},
+  year = {2008},
+  doi = {10.1103/PhysRevA.78.052319},
+  eprint = {0803.0757},
+  archivePrefix = {arXiv},
+  primaryClass = {quant-ph},
+}
+
 @article{guhne2009entanglement,
   title = {Entanglement detection},
   journal = {Physics Reports},

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -51,6 +51,130 @@ def _choi_1975_choi_matrix() -> np.ndarray:
     return choi
 
 
+def _hermitian_inverse_sqrt(herm: np.ndarray, eig_floor: float) -> np.ndarray | None:
+    """Return the inverse square root of a Hermitian PSD matrix, or None if rank-deficient.
+
+    `eig_floor` is the smallest eigenvalue we're willing to invert; below that we
+    consider the matrix effectively rank-deficient and return None so the caller
+    can skip the filtering step.
+    """
+    eigvals, eigvecs = np.linalg.eigh((herm + herm.conj().T) / 2)
+    if np.min(eigvals) < eig_floor:
+        return None
+    return eigvecs @ np.diag(eigvals ** -0.5) @ eigvecs.conj().T
+
+
+def _filter_normal_form(
+    rho: np.ndarray,
+    dims: list[int],
+    tol: float,
+    max_iter: int = 50,
+) -> np.ndarray | None:
+    r"""Bring rho to its filter normal form via local SLOCC filtering.
+
+    Implements the iterative algorithm of Verstraete, Dehaene, and De Moor
+    (PRA 64, 010101 (2001)) used in Gittsovich et al. [@gittsovich2008unifying]
+    Section IV.D: alternate applying :math:`T_A = (d_A \rho_A)^{-1/2}` on
+    subsystem A and :math:`T_B = (d_B \rho_B)^{-1/2}` on subsystem B until both
+    marginals become proportional to the identity. In normal form
+    :math:`\tilde\rho_A = I/d_A` and :math:`\tilde\rho_B = I/d_B`, so the
+    reduced states carry no separability information and the correlations
+    live entirely in the off-diagonal block of the covariance matrix.
+
+    Each filter step preserves the trace exactly:
+
+    .. math::
+
+        \mathrm{tr}\big[(T_A \otimes I) \rho (T_A^\dagger \otimes I)\big]
+        = \mathrm{tr}\big[(d_A \rho_A)^{-1} \rho_A\big] = 1/d_A \cdot d_A = 1,
+
+    so no renormalization is needed.
+
+    Returns the filter normal form, or `None` if the iteration encounters a
+    rank-deficient marginal (filtering requires invertible marginals) or fails
+    to converge within `max_iter` passes.
+    """
+    dA, dB = dims[0], dims[1]
+    id_a = np.eye(dA, dtype=complex)
+    id_b = np.eye(dB, dtype=complex)
+    target_a = id_a / dA
+    target_b = id_b / dB
+
+    rho_tilde = rho.astype(complex, copy=True)
+    eig_floor = tol
+
+    for _ in range(max_iter):
+        rho_a = partial_trace(rho_tilde, sys=[1], dim=dims)
+        rho_b = partial_trace(rho_tilde, sys=[0], dim=dims)
+
+        err = max(
+            np.linalg.norm(rho_a - target_a, ord="fro"),
+            np.linalg.norm(rho_b - target_b, ord="fro"),
+        )
+        if err < tol:
+            return rho_tilde
+
+        t_a = _hermitian_inverse_sqrt(dA * rho_a, eig_floor)
+        if t_a is None:
+            return None
+        rho_tilde = np.kron(t_a, id_b) @ rho_tilde @ np.kron(t_a.conj().T, id_b)
+
+        rho_b_new = partial_trace(rho_tilde, sys=[0], dim=dims)
+        t_b = _hermitian_inverse_sqrt(dB * rho_b_new, eig_floor)
+        if t_b is None:
+            return None
+        rho_tilde = np.kron(id_a, t_b) @ rho_tilde @ np.kron(id_a, t_b.conj().T)
+
+    # Iteration budget exhausted. Accept whatever we have if the marginals
+    # are sufficiently close to the targets; otherwise report failure.
+    rho_a = partial_trace(rho_tilde, sys=[1], dim=dims)
+    rho_b = partial_trace(rho_tilde, sys=[0], dim=dims)
+    err = max(
+        np.linalg.norm(rho_a - target_a, ord="fro"),
+        np.linalg.norm(rho_b - target_b, ord="fro"),
+    )
+    if err < 10 * tol:
+        return rho_tilde
+    return None
+
+
+def _filter_cmc_xi_sum(rho_normal: np.ndarray, dims: list[int]) -> float:
+    r"""Compute :math:`\sum_i \xi_i` for a state already in filter normal form.
+
+    The :math:`\xi_i` are the coefficients in the operator-basis expansion
+
+    .. math::
+
+        \tilde\rho = \frac{1}{d_A d_B} \left(I + \sum_k \xi_k G^A_k \otimes G^B_k\right),
+
+    equal to :math:`d_A d_B` times the operator Schmidt coefficients of
+    :math:`\tilde\rho - I/(d_A d_B)` (which in turn are the singular values
+    of the realignment of that trace-zero operator). See Gittsovich et al.
+    2008, Eq. (66).
+    """
+    dA, dB = dims[0], dims[1]
+    sigma = rho_normal - np.eye(dA * dB, dtype=complex) / (dA * dB)
+    r_sigma = realignment(sigma, dim=dims)
+    singular_values = np.linalg.svd(r_sigma, compute_uv=False)
+    return float(dA * dB * np.sum(np.real(singular_values)))
+
+
+def _filter_cmc_bound(dA: int, dB: int) -> float:
+    r"""Return the Filter CMC separability bound for a :math:`d_A \times d_B` system.
+
+    From Gittsovich et al. 2008, Proposition IV.15, Eq. (72):
+
+    .. math::
+
+        \sum_k \xi_k \le \sqrt{d_A d_B (d_A - 1)(d_B - 1)}.
+
+    This generalizes Proposition IV.13 (:math:`d^2 - d` for the symmetric
+    :math:`d_A = d_B = d` case) and, in practice, is tighter than Eq. (71)
+    across the dimensions of interest here.
+    """
+    return float(np.sqrt(dA * dB * (dA - 1) * (dB - 1)))
+
+
 def _iterative_product_state_subtraction(
     state: np.ndarray,
     dims: list[int],
@@ -269,6 +393,16 @@ def is_separable(
 
         - **Basic Realignment (Chen & Wu 2003)** [@chen2003matrix]:
           If the trace norm of the realigned matrix is greater than 1, the state is entangled.
+        - **Zhang variant (Zhang et al. 2008)** [@zhang2008entanglement]:
+          Uses the purity-based bound on \(\|R(\rho - \rho_A \otimes \rho_B)\|_1\).
+        - **Filter Covariance Matrix Criterion (Gittsovich et al. 2008)**
+          [@gittsovich2008unifying]: strictly stronger than the basic CCNR.
+          First brings \(\rho\) to its filter normal form with maximally mixed
+          marginals via iterative local SLOCC filtering (Verstraete-Dehaene-
+          De Moor algorithm), then checks Eq. (72) of Proposition IV.15:
+          \(\sum_k \xi_k \le \sqrt{d_A d_B (d_A - 1)(d_B - 1)}\). Violation
+          implies \(\rho\) is entangled. For two qubits the filter CMC is a
+          necessary and sufficient separability test (Remark IV.14).
 
     10. **Rank-1 Perturbation of Identity for PPT States (Vidal & Tarrach 1999)** [@vidal1999robustness]:
 
@@ -382,9 +516,8 @@ def is_separable(
               product-state subtraction constructive witness (section 12b)
               that was added alongside this parameter's expansion.
             - `strength >= 2` — reserved for future expensive criteria
-              (Filter CMC, additional positive maps, refined
-              Breuer/Horodecki conditions); currently equivalent to
-              `strength = 1`.
+              (additional positive maps from the UPB/Terhal family, refined
+              Breuer rank-4 check); currently equivalent to `strength = 1`.
             - `strength = -1` — alias for "run every implemented check".
               Currently equivalent to `strength = 1`, will grow with future
               additions.
@@ -850,7 +983,24 @@ def is_separable(
     bound_zhang = np.sqrt(val_A * val_B) if (val_A * val_B >= 0) else 0
     if trace_norm(realignment(current_state - np.kron(rho_A_marginal, rho_B_marginal), dims_list)) > bound_zhang + tol:
         return False, "Zhang realignment variant: ||R(rho - rho_A (x) rho_B)||_1 exceeds purity bound (Zhang 2008)"
-    # TODO: #1246 Consider adding Filter CMC criterion from Gittsovich et al. 2008, which is stronger.
+
+    # --- 9b. Filter Covariance Matrix Criterion (Gittsovich et al. 2008) ---
+    # Strictly stronger than the basic CCNR/realignment criterion; for two qubits
+    # (Remark IV.14 of the paper) it is a necessary and sufficient separability
+    # test. We first transport rho to its filter normal form with maximally
+    # mixed marginals via local SLOCC filtering, then check the paper's
+    # Proposition IV.15 Eq. (72) bound on the sum of the filter-CMC coefficients.
+    # Skipped silently (no verdict) when the filtering iteration can't converge
+    # — e.g., when a marginal is rank-deficient and no invertible filter exists.
+    rho_normal = _filter_normal_form(current_state, dims_list, tol)
+    if rho_normal is not None:
+        xi_sum = _filter_cmc_xi_sum(rho_normal, dims_list)
+        xi_bound = _filter_cmc_bound(dA, dB)
+        if xi_sum > xi_bound + tol:
+            return False, (
+                f"Filter CMC: sum xi = {xi_sum:.4g} > bound {xi_bound:.4g} "
+                f"(Gittsovich et al. 2008, Prop. IV.15)"
+            )
 
     # --- 10. Rank-1 Perturbation of Identity for PPT States (Vidal & Tarrach 1999) ---
     # PPT states close to identity are separable [@vidal1999robustness].

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -13,6 +13,9 @@ from toqito.state_props import is_separable
 from toqito.state_props.is_ppt import is_ppt
 from toqito.state_props.is_separable import (
     _choi_1975_choi_matrix,
+    _filter_cmc_bound,
+    _filter_cmc_xi_sum,
+    _filter_normal_form,
     _iterative_product_state_subtraction,
 )
 from toqito.states import basis, bell, horodecki, isotropic, max_entangled, tile
@@ -1328,3 +1331,111 @@ def test_is_separable_falls_through_when_iter_sub_returns_false():
     # level=2" branch. Either way, the 12b reason must not appear.
     assert "iterative product-state subtraction" not in reason
     assert sep is True  # DPS handles it at level=2
+
+
+# --- Tests for the Filter Covariance Matrix Criterion (#1246) ---
+
+
+def test_filter_normal_form_leaves_bell_unchanged():
+    """Bell state already has maximally mixed marginals, so one iteration suffices."""
+    rho = bell(0) @ bell(0).conj().T
+    nf = _filter_normal_form(rho, [2, 2], tol=1e-10)
+    assert nf is not None
+    # Bell state is already its own normal form; marginals should be I/2.
+    rho_a = np.trace(nf.reshape(2, 2, 2, 2), axis1=1, axis2=3)
+    rho_b = np.trace(nf.reshape(2, 2, 2, 2), axis1=0, axis2=2)
+    np.testing.assert_allclose(rho_a, np.eye(2) / 2, atol=1e-10)
+    np.testing.assert_allclose(rho_b, np.eye(2) / 2, atol=1e-10)
+
+
+def test_filter_normal_form_brings_biased_product_to_max_mixed_marginals():
+    """A biased product state gets filtered to maximally mixed marginals."""
+    rho = np.kron(np.diag([0.7, 0.3]), np.diag([0.4, 0.6]))
+    nf = _filter_normal_form(rho, [2, 2], tol=1e-10)
+    assert nf is not None
+    rho_a = np.trace(nf.reshape(2, 2, 2, 2), axis1=1, axis2=3)
+    rho_b = np.trace(nf.reshape(2, 2, 2, 2), axis1=0, axis2=2)
+    np.testing.assert_allclose(rho_a, np.eye(2) / 2, atol=1e-10)
+    np.testing.assert_allclose(rho_b, np.eye(2) / 2, atol=1e-10)
+
+
+def test_filter_normal_form_returns_none_on_rank_deficient_state():
+    """Pure product state has rank-1 marginals; filtering should bail out."""
+    psi = np.kron([1, 0], [1, 0])
+    rho = np.outer(psi, psi.conj())  # rank 1, marginals rank 1
+    nf = _filter_normal_form(rho, [2, 2], tol=1e-10)
+    assert nf is None
+
+
+def test_filter_cmc_xi_sum_on_bell_matches_paper():
+    """For a Bell state, sum(xi_k) = d^2 - d + 2 = 6 at d = 2."""
+    rho = bell(0) @ bell(0).conj().T
+    xi_sum = _filter_cmc_xi_sum(rho, [2, 2])
+    # Bell state saturates the maximum at d^2 - d + 2 = 6; from Pauli-basis
+    # expansion of |Phi+><Phi+| = (I + XX + YY + ZZ) / 4.
+    assert abs(xi_sum - 6.0) < 1e-9
+
+
+def test_filter_cmc_xi_sum_on_max_mixed_is_zero():
+    """I/d^2 has zero off-identity component; xi_sum must be 0."""
+    assert _filter_cmc_xi_sum(np.eye(4) / 4, [2, 2]) < 1e-12
+    assert _filter_cmc_xi_sum(np.eye(9) / 9, [3, 3]) < 1e-12
+
+
+@pytest.mark.parametrize(
+    "dA, dB, expected",
+    [
+        (2, 2, 2.0),  # d^2 - d = 2
+        (3, 3, 6.0),  # d^2 - d = 6
+        (2, 4, float(np.sqrt(24.0))),  # sqrt(d_A d_B (d_A-1)(d_B-1))
+        (3, 4, float(np.sqrt(72.0))),
+    ],
+)
+def test_filter_cmc_bound_matches_proposition_iv_15(dA, dB, expected):
+    """Gittsovich 2008 Prop IV.15 Eq (72) bound for a few (d_A, d_B)."""
+    assert abs(_filter_cmc_bound(dA, dB) - expected) < 1e-12
+
+
+def test_filter_cmc_detects_upb_tile_state_directly():
+    """Filter CMC's xi_sum exceeds the 3x3 bound for the UPB tile PPT-entangled state.
+
+    In `is_separable` this state is caught earlier at the Plucker check
+    (section 6), so Filter CMC never runs on it in the normal flow. The
+    direct helper call confirms the math: xi_sum > d^2 - d = 6.
+    """
+    rho = np.identity(9)
+    for i in range(5):
+        rho = rho - tile(i) @ tile(i).conj().T
+    rho = rho / 4
+    nf = _filter_normal_form(rho, [3, 3], tol=1e-10)
+    assert nf is not None
+    xi_sum = _filter_cmc_xi_sum(nf, [3, 3])
+    assert xi_sum > _filter_cmc_bound(3, 3) + 1e-6
+
+
+def test_is_separable_surfaces_filter_cmc_reason_when_helper_fires():
+    """is_separable surfaces the Filter CMC reason when the helper fires.
+
+    Mocks `_filter_cmc_xi_sum` to exceed the bound and asserts the reason
+    string comes from section 9b. Uses `_RHO_ENT_SYMM_3x3_REACHES_12B`
+    because it is the only state in the suite that naturally reaches
+    section 9b at default strength.
+    """
+    with mock.patch(
+        "toqito.state_props.is_separable._filter_cmc_xi_sum",
+        return_value=100.0,
+    ) as mocked:
+        sep, reason = is_separable(_RHO_ENT_SYMM_3x3_REACHES_12B, dim=[3, 3])
+    assert sep is False
+    assert "Filter CMC" in reason
+    assert mocked.called
+
+
+def test_is_separable_strength_zero_skips_filter_cmc():
+    """Section 9b must not run at strength=0."""
+    with mock.patch(
+        "toqito.state_props.is_separable._filter_cmc_xi_sum",
+        return_value=100.0,
+    ) as mocked:
+        is_separable(_RHO_ENT_SYMM_3x3_REACHES_12B, dim=[3, 3], strength=0)
+    assert not mocked.called


### PR DESCRIPTION
## Summary
Adds the Filter CMC of Gittsovich et al. 2008 (Phys. Rev. A 78, 052319; arXiv:0803.0757) — **strictly stronger than the basic CCNR/realignment criterion** already in section 9, and **necessary and sufficient for two-qubit separability** per Remark IV.14 of the paper.

Closes #1246.

## Algorithm
1. Bring ρ to its **filter normal form** via iterative local SLOCC filtering (Verstraete–Dehaene–De Moor, PRA 64, 010101 (2001)). Alternate applying `T_A = (d_A · ρ_A)^(−1/2)` on subsystem A and `T_B = (d_B · ρ_B)^(−1/2)` on subsystem B until both marginals converge to `I/d_A` and `I/d_B`. Trace is preserved exactly by construction, so no renormalization is needed.
2. Compute the filter-normal-form coefficients `ξ_k` by forming `σ = ρ̃ − I/(d_A d_B)`, realigning it, and multiplying the singular values of the realignment by `d_A d_B`. This matches the paper's Eq. (66) definition: `ξ_k = d_A d_B` times the operator Schmidt coefficients of the traceless remainder.
3. Compare `Σ ξ_k` to the Proposition IV.15 Eq. (72) bound `√(d_A d_B (d_A − 1)(d_B − 1))`. Violation ⇒ entangled. This form reduces to Prop IV.13's `d² − d` for the symmetric `d_A = d_B = d` case, and is tighter than Eq. (71) at all the dimensions I checked.

## Integration
- New section 9b in `is_separable`, immediately after the Zhang realignment variant, and the pre-existing `TODO: #1246 ...` comment is removed.
- Naturally gated under `strength != 0` by position (below the strength-0 early-return cutoff).
- Three module-level helpers exposed privately so the math is unit-testable:
  - `_filter_normal_form(rho, dims, tol)` — returns the normal form or `None` if the iteration fails (e.g. rank-deficient marginal, since filtering needs invertible marginals).
  - `_filter_cmc_xi_sum(rho_normal, dims)` — computes `Σ ξ_k` via realignment + SVD.
  - `_filter_cmc_bound(dA, dB)` — returns the Eq. (72) bound.

## Sanity-check numbers I verified manually
| State | `Σ ξ_k` | bound | detected? |
| --- | --- | --- | --- |
| Bell `\|Φ⁺⟩` (d=2) | **6.000** | 2 | **yes** (saturates) |
| Max mixed `I/4` | 0.000 | 2 | no |
| Biased product `diag(0.7, 0.3) ⊗ diag(0.4, 0.6)` | 0.000 (after filtering) | 2 | no |
| Werner(p=0.7) 2×2 | 4.200 | 2 | yes (but NPT catches it earlier in `is_separable`) |
| UPB tile 3×3 PPT-entangled | **7.436** | 6 | **yes** (but Plücker catches it earlier in `is_separable`) |

## Tests
- [x] `pytest toqito/state_metrics toqito/state_props` → **351 passed** (up from 339, +12 new tests), 6 skipped, 2 xfailed.
- [x] `ruff check` clean.
- [x] Twelve new targeted tests:
  - Filter normal form on Bell (already in normal form), biased product (converges), rank-1 pure product (returns `None`).
  - `xi_sum` on Bell = 6 (matches Pauli expansion).
  - `xi_sum` on `I/d²` = 0 for `d ∈ {2, 3}`.
  - Bound parametrized over `(2,2), (3,3), (2,4), (3,4)`.
  - End-to-end helper chain on the UPB tile state (xi_sum > 6, detected).
  - Integration (mock-based, using the existing `rho_ent_symm` state that naturally reaches section 9b): helper firing → Filter CMC reason surfaced; `strength=0` → helper not called.

## Notes for reviewers
- No natural test state in the existing suite reaches section 9b *and* triggers Filter CMC — the states where Filter CMC specifically fires are caught earlier by Plücker or realignment. I used `rho_ent_symm` (the 3×3 state that reaches section 12b) for the integration test, mocking the helper. The helper math itself is verified against the paper on states hit directly.
- The filter normal form iteration caps at 50 outer iterations and returns `None` on rank-deficient marginals. I didn't see any state in the existing test suite that trips the rank-deficient path unintentionally, and iteration budget exhaustion falls through silently (no verdict), so a pathological state can't produce a false positive.

## Arc status after this PR
- ✅ #1248, #1247, #1245, #1244, #1507, #1506, **#1246** — closed
- 🟡 #1251 — rank-marginal done; Breuer rank-4 refinement still deferred
- 🟡 #1249 — Choi 1975 done; UPB-based maps still open