### PR TITLE
Fix symmetric extension logic in is_separable

### DIFF
--- a/toqito/matrix_ops/partial_trace.py
+++ b/toqito/matrix_ops/partial_trace.py
@@ -117,7 +117,7 @@ def partial_trace(
             sys = [1]
     # If the input matrix is a CVX variable for an SDP, we convert it to a numpy array,
     # perform the partial trace, and convert it back to a CVX variable.
-    if isinstance(input_mat, Variable):
+    if isinstance(input_mat, (Expression, Variable)):
         rho_np = expr_as_np_array(input_mat)
         traced_rho = partial_trace(rho_np, sys, dim)
         traced_rho = np_array_as_expr(traced_rho)

--- a/toqito/matrix_ops/partial_trace.py
+++ b/toqito/matrix_ops/partial_trace.py
@@ -9,7 +9,7 @@ from toqito.perms import permute_systems
 
 
 def partial_trace(
-    input_mat: np.ndarray | Variable,
+    input_mat: np.ndarray | Expression | Variable,
     sys: int | list[int] | None = None,
     dim: int | list[int] | np.ndarray | None = None,
 ) -> np.ndarray | Expression:
@@ -115,8 +115,9 @@ def partial_trace(
     if not isinstance(sys, int):
         if sys is None:
             sys = [1]
-    # If the input matrix is a CVX variable for an SDP, we convert it to a numpy array,
-    # perform the partial trace, and convert it back to a CVX variable.
+    # If the input matrix is a CVXPY expression for an SDP, we convert it to a
+    # NumPy object array, perform the partial trace recursively, and convert it
+    # back to a CVXPY expression.
     if isinstance(input_mat, (Expression, Variable)):
         rho_np = expr_as_np_array(input_mat)
         traced_rho = partial_trace(rho_np, sys, dim)

--- a/toqito/matrix_ops/partial_transpose.py
+++ b/toqito/matrix_ops/partial_transpose.py
@@ -117,7 +117,7 @@ def partial_transpose(
     # If the input matrix is a CVX variable for an SDP, we convert it to a
     # numpy array, perform the partial transpose, and convert it back to a CVX
     # variable.
-    if isinstance(rho, Variable):
+    if isinstance(rho, (Expression, Variable)):
         rho_np = expr_as_np_array(rho)
         transposed_rho = partial_transpose(rho_np, sys, dim)
         transposed_rho = np_array_as_expr(transposed_rho)

--- a/toqito/matrix_ops/partial_transpose.py
+++ b/toqito/matrix_ops/partial_transpose.py
@@ -9,7 +9,7 @@ from toqito.perms import permute_systems
 
 
 def partial_transpose(
-    rho: np.ndarray | Variable,
+    rho: np.ndarray | Expression | Variable,
     sys: list[int] | np.ndarray | int | None = None,
     dim: list[int] | np.ndarray | None = None,
 ) -> np.ndarray | Expression:
@@ -114,9 +114,9 @@ def partial_transpose(
     if not isinstance(sys, int):
         if sys is None:
             sys = [1]
-    # If the input matrix is a CVX variable for an SDP, we convert it to a
-    # numpy array, perform the partial transpose, and convert it back to a CVX
-    # variable.
+    # If the input matrix is a CVXPY expression for an SDP, we convert it to a
+    # NumPy object array, perform the partial transpose recursively, and
+    # convert it back to a CVXPY expression.
     if isinstance(rho, (Expression, Variable)):
         rho_np = expr_as_np_array(rho)
         transposed_rho = partial_transpose(rho_np, sys, dim)

--- a/toqito/state_props/__init__.py
+++ b/toqito/state_props/__init__.py
@@ -20,6 +20,7 @@ from toqito.state_props.entanglement_of_formation import entanglement_of_formati
 from toqito.state_props.l1_norm_coherence import l1_norm_coherence
 from toqito.state_props.in_separable_ball import in_separable_ball
 from toqito.state_props.is_separable import is_separable
+from toqito.state_props.has_symmetric_inner_extension import has_symmetric_inner_extension
 from toqito.state_props.has_symmetric_extension import has_symmetric_extension
 from toqito.state_props.sk_vec_norm import sk_vector_norm
 from toqito.state_props.is_antidistinguishable import is_antidistinguishable

--- a/toqito/state_props/has_symmetric_extension.py
+++ b/toqito/state_props/has_symmetric_extension.py
@@ -167,4 +167,4 @@ def has_symmetric_extension(
         problem = cvxpy.Problem(cvxpy.Minimize(0), constraints)
         problem.solve()
 
-    return problem.status == "optimal"
+    return problem.status in {"optimal", "optimal_inaccurate"}

--- a/toqito/state_props/has_symmetric_inner_extension.py
+++ b/toqito/state_props/has_symmetric_inner_extension.py
@@ -1,0 +1,108 @@
+"""Determine whether a bipartite operator has a symmetric inner extension."""
+
+import math
+import warnings
+
+import cvxpy
+import numpy as np
+from scipy.special import roots_jacobi
+
+from toqito.matrix_ops import partial_trace, partial_transpose
+from toqito.matrix_props import is_positive_semidefinite
+from toqito.perms import symmetric_projection
+
+
+def has_symmetric_inner_extension(
+    rho: np.ndarray,
+    level: int = 2,
+    dim: np.ndarray | int | None = None,
+    ppt: bool = True,
+    tol: float = 1e-4,
+) -> bool:
+    r"""Determine whether a bipartite operator lies in the symmetric inner-extension cone.
+
+    This is the inner approximation to the separable cone introduced by
+    Navascués, Owari, and Plenio [@navascues2009complete]. If this function
+    returns ``True``, then the input operator is separable. If it returns
+    ``False``, no conclusion can be drawn.
+
+    The implementation closely follows QETLAB's
+    ``SymmetricInnerExtension`` routine, solving an SDP over the bosonic
+    symmetric subspace of the repeated second subsystem.
+
+    Args:
+        rho: A positive semidefinite bipartite operator.
+        level: Number of copies of the second subsystem in the extension.
+            Must be at least 2.
+        dim: Local dimensions. If ``None``, infer an equal bipartite split.
+        ppt: Whether to impose the PPT inner-extension variant.
+        tol: Numerical tolerance used by the SDP solver.
+
+    Returns:
+        ``True`` if ``rho`` lies in the inner cone at the requested level.
+
+    Raises:
+        ValueError: If the dimensions are incompatible or ``level < 2``.
+
+    """
+    if level < 2:
+        raise ValueError("`level` must be an integer >= 2 for symmetric inner extensions.")
+
+    len_mat = rho.shape[1]
+
+    if dim is None:
+        dim_val = int(np.round(np.sqrt(len_mat)))
+    elif isinstance(dim, int):
+        dim_val = dim
+    else:
+        dim_val = None
+
+    if dim_val is not None:
+        dim_arr = np.array([dim_val, len_mat / dim_val])
+        if np.abs(dim_arr[1] - np.round(dim_arr[1])) >= 2 * len_mat * np.finfo(float).eps:
+            raise ValueError("If `dim` is a scalar, it must evenly divide the length of the matrix.")
+        dim_arr[1] = int(np.round(dim_arr[1]))
+    else:
+        dim_arr = np.array(dim)
+
+    dim_arr = dim_arr.astype(int)
+    dim_x, dim_y = int(dim_arr[0]), int(dim_arr[1])
+
+    if min(dim_x, dim_y) == 1:
+        return is_positive_semidefinite(rho)
+
+    sdp_dim = np.array([dim_x] + [dim_y] * level, dtype=int)
+    sym_basis = symmetric_projection(dim_y, level, partial=True)
+    projector = np.kron(np.eye(dim_x), sym_basis)
+    reduced_dim = dim_x * sym_basis.shape[1]
+
+    sigma_reduced = cvxpy.Variable((reduced_dim, reduced_dim), hermitian=True)
+    sigma = projector @ sigma_reduced @ projector.conj().T
+
+    traced_ab = partial_trace(sigma, list(range(2, level + 1)), sdp_dim)
+    traced_a = partial_trace(sigma, list(range(1, level + 1)), sdp_dim)
+
+    if ppt:
+        jacobi_degree = dim_y - 2
+        if jacobi_degree <= 0:
+            eta = 1.0
+        else:
+            roots, _weights = roots_jacobi(jacobi_degree, level % 2, math.floor(level / 2) + 1)
+            eta = float(np.min(1.0 - roots))
+        eta *= dim_y / (2 * (dim_y - 1))
+        affine_image = (1.0 - eta) * traced_ab + eta * cvxpy.kron(traced_a, np.eye(dim_y)) / dim_y
+    else:
+        affine_image = traced_ab * level / (level + dim_y) + cvxpy.kron(traced_a, np.eye(dim_y)) / (level + dim_y)
+
+    constraints = [sigma_reduced >> 0, affine_image == rho]
+
+    if ppt:
+        ppt_systems = list(range(math.ceil(level / 2) + 1))
+        constraints.append(partial_transpose(sigma, ppt_systems, sdp_dim) >> 0)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Constraint.*subexpressions")
+        problem = cvxpy.Problem(cvxpy.Minimize(0), constraints)
+        problem.solve(solver=cvxpy.SCS, eps_abs=tol, eps_rel=tol, max_iters=100_000, verbose=False)
+
+    return problem.status in {"optimal", "optimal_inaccurate"}

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -12,6 +12,7 @@ from toqito.perms.swap import swap
 from toqito.perms.swap_operator import swap_operator
 from toqito.state_props import is_ppt
 from toqito.state_props.has_symmetric_extension import has_symmetric_extension
+from toqito.state_props.has_symmetric_inner_extension import has_symmetric_inner_extension
 from toqito.state_props.in_separable_ball import in_separable_ball
 from toqito.state_props.schmidt_rank import schmidt_rank
 from toqito.states.max_entangled import max_entangled
@@ -578,21 +579,23 @@ def is_separable(
     13. **Symmetric Extension Hierarchy (DPS)** [@doherty2004complete]:
 
         - A state is separable if and only if it has a k-symmetric extension for all \(k \ge 1\).
-        - This function checks for k-extendibility up to the specified `level`.
-        - If `level=1` and the state is PPT (which it is at this stage),
-          it's 1-extendible and thus considered separable by this specific test level.
-        - For `level >= 2`, if a k-symmetric extension exists for all k up
-          to `level` (specifically, if `has_symmetric_extension` returns
-          `True` for the highest `k_actual_level_check` in the loop, which is
-          `level`), the current implementation returns `True`.
+        - Failing to find a k-symmetric extension at any tested level proves
+          entanglement.
+        - Passing a finite number of extension levels does **not** by itself
+          prove separability; finite k-extendibility is only a relaxation.
+        - To prove separability at finite `level`, this function additionally
+          checks the Navascués-Owari-Plenio inner cone via
+          `has_symmetric_inner_extension`, which is a sufficient test for
+          separability based on bosonic symmetric extensions.
 
         !!! Note
             The symmetric extension check requires CVXPY and a suitable solver. If these are not installed,
             or if the solver fails, a warning is printed to the console and this check is skipped.
 
         !!! Note
-            QETLAB's `SymmetricExtension` typically tests k-PPT-extendibility, where failure means entangled.
-            It also has `SymmetricInnerExtension`, which can prove separability.
+            This matches QETLAB's split: `SymmetricExtension` is used as a
+            one-sided entanglement test, while `SymmetricInnerExtension`
+            supplies the one-sided separability proof.
 
 
     Args:
@@ -602,10 +605,11 @@ def is_separable(
             - Controls only the depth of the DPS symmetric-extension hierarchy
               (default: 2). All other post-PPT checks run regardless of
               `level` (provided `strength` does not cut them off early).
-            - If `level == 1` and the state is PPT, the function accepts the
-              state at the DPS stage via the "1-extendible" branch.
+            - If `level == 1`, no DPS SDP is run; finite 1-extendibility adds
+              no information beyond the earlier PPT checks.
             - If `level >= 2`, the function checks for a k-symmetric extension
-              for every k from 2 up to `level`.
+              and the corresponding inner-extension relaxation for every k from
+              2 up to `level`.
             - `strength == 0` triggers an early inconclusive return before the
               DPS block is reached, so `level` is effectively ignored in that
               mode (see `strength` below).
@@ -1314,28 +1318,26 @@ def is_separable(
         return True, "iterative product-state subtraction decomposed the state (Guhne / sk_iterate)"
 
     # --- 13. Symmetric Extension Hierarchy (DPS) ---
-    # A state is separable iff it has a k-symmetric extension for all k [@doherty2004complete].
-    # The hierarchy is increasingly restrictive: k-extendible ⊃ (k+1)-extendible ⊃ ... ⊃ separable.
-    # - If the state is NOT k-extendible at any level, it is definitively entangled.
-    # - If the state IS k-extendible for all k up to `level`, it passes the DPS test at that level.
-    if level >= 2:  # Level 1 (PPT) is already confirmed if we reach here.
+    # A state is separable iff it has a k-symmetric extension for all k [@doherty2004complete],
+    # but finite k-extendibility is only a relaxation. Thus:
+    # - if the state is NOT k-extendible at any tested level, it is entangled;
+    # - if it lies in the corresponding inner cone, it is separable;
+    # - otherwise, passing the tested k-extendibility levels is only inconclusive.
+    if level >= 2:
         for k_actual_level_check in range(2, int(level) + 1):
             try:
                 if not has_symmetric_extension(rho=current_state, level=k_actual_level_check, dim=dims_list, tol=tol):
-                    # No k-symmetric extension exists — state is entangled.
                     return False, f"no {k_actual_level_check}-symmetric extension (DPS hierarchy)"
+                if has_symmetric_inner_extension(
+                    rho=current_state, level=k_actual_level_check, dim=dims_list, ppt=True, tol=tol
+                ):
+                    return True, f"passed inner DPS symmetric extension cone at level={k_actual_level_check}"
             except ImportError:
                 print("Warning: CVXPY or a solver is not installed; cannot perform symmetric extension check.")
                 break
             except Exception as e:
                 print(f"Warning: Symmetric extension check failed at level {k_actual_level_check} with an error: {e}")
                 break
-        else:
-            # All levels from 2 to `level` passed — state has a k-symmetric extension at every tested level.
-            return True, f"passed DPS symmetric extension hierarchy up to level={int(level)}"
-    elif level == 1 and is_state_ppt:  # is_state_ppt is True at this point
-        # 1-extendibility is equivalent to PPT.
-        return True, "1-extendible (PPT) accepted at level=1"
 
     # If all implemented checks are inconclusive, and the state passed PPT (the most basic necessary condition checked),
     # it implies that the state is either separable but not caught by the simpler sufficient conditions,

--- a/toqito/state_props/tests/test_has_symmetric_inner_extension.py
+++ b/toqito/state_props/tests/test_has_symmetric_inner_extension.py
@@ -1,0 +1,34 @@
+"""Test has_symmetric_inner_extension."""
+
+import numpy as np
+
+from toqito.state_props import has_symmetric_inner_extension
+from toqito.states import max_entangled
+
+
+def test_has_symmetric_inner_extension_qetlab_example():
+    """QETLAB example: a specific 3x3 PPT inner extension certifies separability."""
+    rho = np.array(
+        [
+            [11, 4, -1, -1, -1, -1, -1, -1, -1],
+            [4, 11, -1, -1, -1, -1, -1, -1, -1],
+            [-1, -1, 11, -1, -1, 4, -1, -1, -1],
+            [-1, -1, -1, 11, -1, -1, 4, -1, -1],
+            [-1, -1, -1, -1, 16, -1, -1, -1, -1],
+            [-1, -1, 4, -1, -1, 11, -1, -1, -1],
+            [-1, -1, -1, 4, -1, -1, 11, -1, -1],
+            [-1, -1, -1, -1, -1, -1, -1, 11, 4],
+            [-1, -1, -1, -1, -1, -1, -1, 4, 11],
+        ],
+        dtype=float,
+    )
+
+    assert has_symmetric_inner_extension(rho, level=2, dim=[3, 3], ppt=True)
+
+
+def test_has_symmetric_inner_extension_rejects_maximally_entangled_qutrit():
+    """A maximally entangled qutrit state is not certified by the inner cone."""
+    psi = max_entangled(3)
+    rho = psi @ psi.conj().T
+
+    assert not has_symmetric_inner_extension(rho, level=2, dim=[3, 3], ppt=True)

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -369,7 +369,10 @@ def test_plucker_linalg_error_in_det_fallthrough():
         rho = (
             np.outer(p1, p1.conj()) + np.outer(p2, p2.conj()) + np.outer(p3, p3.conj()) + np.outer(p4, p4.conj())
         ) / 4.0
-        sep, reason = is_separable(rho, dim=[3, 3])
+        with mock.patch("toqito.state_props.is_separable._iterative_product_state_subtraction", return_value=False):
+            with mock.patch("toqito.state_props.is_separable.has_symmetric_extension", return_value=True):
+                with mock.patch("toqito.state_props.is_separable.has_symmetric_inner_extension", return_value=False):
+                    sep, reason = is_separable(rho, dim=[3, 3])
         assert sep is False
         assert "inconclusive" in reason
 
@@ -680,7 +683,10 @@ def test_3x3_rank4_block_orth_finds_lower_rank():
     # Mock orth to return only 3 columns (simulating numerical rank deficiency)
     with mock.patch("toqito.state_props.is_separable.orth") as mocked_orth:
         mocked_orth.return_value = np.eye(9, 3)  # 9x3 matrix
-        sep, reason = is_separable(rho, dim=[3, 3])  # Should proceed past Plücker check
+        with mock.patch("toqito.state_props.is_separable._iterative_product_state_subtraction", return_value=False):
+            with mock.patch("toqito.state_props.is_separable.has_symmetric_extension", return_value=True):
+                with mock.patch("toqito.state_props.is_separable.has_symmetric_inner_extension", return_value=False):
+                    sep, reason = is_separable(rho, dim=[3, 3])  # Should proceed past Plücker check
         assert sep is False
         assert "inconclusive" in reason
         mocked_orth.assert_called_once()

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -359,7 +359,7 @@ def test_entangled_by_reduction_criterion_non_psd_choi_T():
 
 
 def test_plucker_linalg_error_in_det_fallthrough():
-    """Plucker check falls through on LinAlgError; state remains separable."""
+    """Plucker LinAlgError falls through without producing a false separability proof."""
     with mock.patch("numpy.linalg.det", side_effect=np.linalg.LinAlgError("mocked error")):
         p1 = np.kron(basis(3, 0), basis(3, 0))
         p2 = np.kron(basis(3, 1), basis(3, 1))
@@ -369,7 +369,9 @@ def test_plucker_linalg_error_in_det_fallthrough():
         rho = (
             np.outer(p1, p1.conj()) + np.outer(p2, p2.conj()) + np.outer(p3, p3.conj()) + np.outer(p4, p4.conj())
         ) / 4.0
-        assert is_separable(rho, dim=[3, 3])[0]
+        sep, reason = is_separable(rho, dim=[3, 3])
+        assert sep is False
+        assert "inconclusive" in reason
 
 
 def test_eig_calc_fails_rank1_pert_check_skipped():
@@ -496,7 +498,7 @@ def test_2xN_hard_separable_passes_all_witnesses():
 
 
 def test_symm_ext_catches_hard_entangled_state():
-    """Test level=1 behavior for a PPT entangled state."""
+    """Finite DPS levels are inconclusive on a PPT entangled state with extensions."""
     # This appear to pass to last final False sometimes
     rho_ent_symm = (
         np.array(
@@ -514,11 +516,41 @@ def test_symm_ext_catches_hard_entangled_state():
         )
         / 8.75
     )
-    assert is_separable(rho_ent_symm, dim=[3, 3], level=1)[0]  # This state IS PPT
+    assert not is_separable(rho_ent_symm, dim=[3, 3], level=1)[0]
     assert not is_separable(rho_ent_symm, dim=[3, 3], level=0)[0]  # Heuristics alone cannot prove separability
     # This PPT entangled state has a 2-copy symmetric extension, so the DPS
-    # hierarchy at level 2 is insufficient to detect its entanglement.
-    assert is_separable(rho_ent_symm, dim=[3, 3], level=2)[0]
+    # outer relaxation at level 2 is insufficient to detect its entanglement.
+    # A finite passed extension level is now treated as inconclusive unless the
+    # inner-extension SDP certifies separability.
+    assert not is_separable(rho_ent_symm, dim=[3, 3], level=2)[0]
+
+
+def test_symmetric_inner_extension_branch_surfaces_separable_reason():
+    """DPS stage returns separable only when the inner-extension cone succeeds."""
+    rho = (
+        np.array(
+            [
+                [1.0, 0.67, 0.91, 0.67, 0.45, 0.61, 0.88, 0.59, 0.79],
+                [0.67, 1.0, 0.5, 0.45, 0.67, 0.34, 0.59, 0.88, 0.44],
+                [0.91, 0.5, 1.0, 0.61, 0.34, 0.68, 0.81, 0.44, 0.88],
+                [0.67, 0.45, 0.61, 1.0, 0.67, 0.91, 0.5, 0.33, 0.45],
+                [0.45, 0.67, 0.34, 0.67, 1.0, 0.5, 0.33, 0.5, 0.25],
+                [0.61, 0.34, 0.68, 0.91, 0.5, 1.0, 0.45, 0.26, 0.5],
+                [0.88, 0.59, 0.81, 0.5, 0.33, 0.45, 1.0, 0.66, 0.91],
+                [0.59, 0.88, 0.44, 0.33, 0.5, 0.26, 0.66, 1.0, 0.48],
+                [0.79, 0.44, 0.88, 0.45, 0.25, 0.5, 0.91, 0.48, 1.0],
+            ]
+        )
+        / 8.75
+    )
+
+    with mock.patch("toqito.state_props.is_separable._iterative_product_state_subtraction", return_value=False):
+        with mock.patch("toqito.state_props.is_separable.has_symmetric_extension", return_value=True):
+            with mock.patch("toqito.state_props.is_separable.has_symmetric_inner_extension", return_value=True):
+                sep, reason = is_separable(rho, dim=[3, 3], level=2)
+
+    assert sep is True
+    assert "inner DPS symmetric extension cone" in reason
 
 
 def test_plucker_orth_rank_lt_4():
@@ -636,7 +668,7 @@ def test_rank1_pert_skip_for_rank_deficient():
 
 
 def test_3x3_rank4_block_orth_finds_lower_rank():
-    """Test 3x3 rank-4 block when orth() gives <4 columns. cover logic q_orth_basis.shape[1] < 4."""
+    """If the 3x3 rank-4 orth basis is too small, the flow stays inconclusive."""
     # Create a rank-4 state in 3x3 system
     p1 = np.kron(basis(3, 0), basis(3, 0))
     p2 = np.kron(basis(3, 1), basis(3, 1))
@@ -648,7 +680,9 @@ def test_3x3_rank4_block_orth_finds_lower_rank():
     # Mock orth to return only 3 columns (simulating numerical rank deficiency)
     with mock.patch("toqito.state_props.is_separable.orth") as mocked_orth:
         mocked_orth.return_value = np.eye(9, 3)  # 9x3 matrix
-        assert is_separable(rho, dim=[3, 3])[0]  # Should proceed past Plücker check
+        sep, reason = is_separable(rho, dim=[3, 3])  # Should proceed past Plücker check
+        assert sep is False
+        assert "inconclusive" in reason
         mocked_orth.assert_called_once()
 
 
@@ -1327,11 +1361,12 @@ def test_is_separable_falls_through_when_iter_sub_returns_false():
         return_value=False,
     ):
         sep, reason = is_separable(_RHO_ENT_SYMM_3x3_REACHES_12B, dim=[3, 3], level=2)
-    # The helper returning False is inconclusive, not an entanglement verdict,
-    # and DPS catches this state at level=2 via the "passed DPS ... up to
-    # level=2" branch. Either way, the 12b reason must not appear.
+    # The helper returning False is inconclusive, not an entanglement verdict.
+    # Finite DPS outer relaxations are also only inconclusive unless the inner
+    # cone succeeds, so the final answer remains inconclusive.
     assert "iterative product-state subtraction" not in reason
-    assert sep is True  # DPS handles it at level=2
+    assert sep is False
+    assert "inconclusive" in reason
 
 
 # --- Tests for the Filter Covariance Matrix Criterion (#1246) ---


### PR DESCRIPTION
## Summary

- add `has_symmetric_inner_extension`, implementing the Navascues-Owari-Plenio / QETLAB inner-extension SDP
- fix the DPS stage in `is_separable` so finite `k`-extendibility is treated as a one-sided entanglement check rather than an automatic separability certificate
- use the inner-extension cone as the finite-level separability certificate in `is_separable`
- update `partial_trace` and `partial_transpose` to accept affine CVXPY expressions, not just raw variables
- add focused tests for the new helper and update stale `is_separable` expectations that depended on the old finite-DPS behavior

Closes #1243.

## Why this change

The existing `is_separable` flow was too strong at the DPS stage: if a state passed the tested symmetric-extension levels, it could be returned as separable even though finite `k`-extendibility is only a relaxation. QETLAB splits this into two different SDPs:

- `SymmetricExtension` for one-sided entanglement detection
- `SymmetricInnerExtension` for one-sided separability certification

This PR mirrors that split.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest toqito/state_props/tests/test_has_symmetric_extension.py toqito/state_props/tests/test_has_symmetric_inner_extension.py toqito/state_props/tests/test_is_separable.py -q -x`
  - `132 passed, 6 skipped, 2 xfailed`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check toqito/state_props/has_symmetric_inner_extension.py toqito/state_props/is_separable.py toqito/state_props/__init__.py toqito/state_props/tests/test_has_symmetric_inner_extension.py toqito/state_props/tests/test_is_separable.py toqito/matrix_ops/partial_trace.py toqito/matrix_ops/partial_transpose.py`
