### PR TITLE
Fix low-rank 3x3 separability check in is_separable

### DIFF
--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -1,7 +1,6 @@
 """Checks if a quantum state is a separable state."""
 
 import numpy as np
-from scipy.linalg import orth
 
 from toqito.channel_ops import partial_channel
 from toqito.channels.realignment import realignment
@@ -175,7 +174,8 @@ def _range_projector_product_overlap_3x3_rank4(
     Chen and Djokovic show that for 3x3 PPT states of rank 4 this is
     equivalent to separability.
     """
-    range_basis = orth(state)
+    eigvals, eigvecs = np.linalg.eigh((state + state.conj().T) / 2)
+    range_basis = eigvecs[:, eigvals > tol]
     if range_basis.shape[1] < 4:
         return None
 
@@ -193,11 +193,11 @@ def _range_projector_product_overlap_3x3_rank4(
         prev_overlap = -np.inf
         overlap = 0.0
         for _ in range(max_iter):
-            mat_a = np.einsum("ibjb,b,j->ij", tensor, vec_b.conj(), vec_b)
+            mat_a = np.einsum("ikjl,k,l->ij", tensor, vec_b.conj(), vec_b)
             _, eigvecs_a = np.linalg.eigh((mat_a + mat_a.conj().T) / 2)
             vec_a = eigvecs_a[:, -1]
 
-            mat_b = np.einsum("iajb,a,i->jb", tensor, vec_a.conj(), vec_a)
+            mat_b = np.einsum("ikjl,i,j->kl", tensor, vec_a.conj(), vec_a)
             _, eigvecs_b = np.linalg.eigh((mat_b + mat_b.conj().T) / 2)
             vec_b = eigvecs_b[:, -1]
 
@@ -986,11 +986,6 @@ def is_separable(
         if best_overlap is not None:
             if 1.0 - best_overlap < 10 * tol:
                 return True, "3x3 rank-4 PPT: range contains a product vector (Chen-Djokovic 2013)"
-            if 1.0 - best_overlap > 1e-3:
-                return (
-                    False,
-                    f"3x3 rank-4 PPT: range-optimization found no product vector (best overlap={best_overlap:.6f})",
-                )
 
     # --- 7. Operational Criteria for Low-Rank PPT States (Horodecki et al. 2000) ---
     # These are sufficient conditions for separability of PPT states [@horodecki2000constructive].

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -155,6 +155,65 @@ def _terhal_2000_tile_witness() -> np.ndarray:
 _TERHAL_2000_TILE_WITNESS_3X3: np.ndarray = _terhal_2000_tile_witness()
 
 
+def _range_projector_product_overlap_3x3_rank4(
+    state: np.ndarray,
+    tol: float,
+    n_restarts: int = 64,
+    max_iter: int = 100,
+) -> float | None:
+    r"""Estimate the best product overlap with the range projector of a 3x3 rank-4 state.
+
+    For the projector :math:`P` onto :math:`\operatorname{range}(\rho)`, compute
+
+    .. math::
+
+        \max_{\|a\|=\|b\|=1} \langle a \otimes b | P | a \otimes b \rangle
+
+    by alternating maximization with deterministic random restarts.
+
+    When the optimum is numerically 1, the range contains a product vector.
+    Chen and Djokovic show that for 3x3 PPT states of rank 4 this is
+    equivalent to separability.
+    """
+    range_basis = orth(state)
+    if range_basis.shape[1] < 4:
+        return None
+
+    projector = range_basis @ range_basis.conj().T
+    tensor = projector.reshape(3, 3, 3, 3)
+
+    rng = np.random.default_rng(seed=20260420)
+    best_overlap = 0.0
+    for _ in range(n_restarts):
+        vec_a = rng.standard_normal(3) + 1j * rng.standard_normal(3)
+        vec_a /= np.linalg.norm(vec_a)
+        vec_b = rng.standard_normal(3) + 1j * rng.standard_normal(3)
+        vec_b /= np.linalg.norm(vec_b)
+
+        prev_overlap = -np.inf
+        overlap = 0.0
+        for _ in range(max_iter):
+            mat_a = np.einsum("ibjb,b,j->ij", tensor, vec_b.conj(), vec_b)
+            _, eigvecs_a = np.linalg.eigh((mat_a + mat_a.conj().T) / 2)
+            vec_a = eigvecs_a[:, -1]
+
+            mat_b = np.einsum("iajb,a,i->jb", tensor, vec_a.conj(), vec_a)
+            _, eigvecs_b = np.linalg.eigh((mat_b + mat_b.conj().T) / 2)
+            vec_b = eigvecs_b[:, -1]
+
+            prod_vec = np.kron(vec_a, vec_b)
+            overlap = float(np.real(np.vdot(prod_vec, projector @ prod_vec)))
+            if abs(overlap - prev_overlap) < tol:
+                break
+            prev_overlap = overlap
+
+        best_overlap = max(best_overlap, overlap)
+        if 1.0 - best_overlap < 10 * tol:
+            return best_overlap
+
+    return best_overlap
+
+
 def _hermitian_inverse_sqrt(herm: np.ndarray, eig_floor: float) -> np.ndarray | None:
     """Return the inverse square root of a Hermitian PSD matrix, or None if rank-deficient.
 
@@ -917,126 +976,21 @@ def is_separable(
     if op_schmidt_rank <= 2:
         return True, f"operator Schmidt rank = {int(op_schmidt_rank)} <= 2 (Cariello 2013)"
 
-    # --- 6. 3x3 Rank-4 PPT N&S Check (Plucker/Breuer/Chen&Djokovic) ---
-    # This checks if a 3x3 PPT state of rank 4 is separable.
-    # The condition involves the determinant of a matrix F constructed from Plücker coordinates.
-    # Separability is linked to det(F) being (close to) zero [@breuer2006optimal],
-    # [@chen2013separability].
-    # (Note: Breuer's original PRL also relates it to F being indefinite or zero).
+    # --- 6. 3x3 Rank-4 PPT N&S Check (Chen-Djokovic 2013) ---
+    # For 3x3 PPT states of rank 4, separability is equivalent to the range
+    # containing a product vector [@chen2013separability]. Use a direct
+    # range-projector optimization rather than the brittle determinant-only
+    # shortcut that previously lived here.
     if dA == 3 and dB == 3 and state_rank == 4:
-        q_orth_basis = orth(current_state)  # Orthonormal basis for the range of rho
-        if q_orth_basis.shape[1] < 4:  # Should not happen if rank is indeed 4
-            pass  # Proceed, as condition for this check is not strictly met
-        else:
-            # Code for calculating Plucker coordinates p_np_arr and F_det_matrix_elements
-            p_np_arr = np.zeros((6, 7, 8, 9), dtype=complex)  # Stores Plucker coordinates
-            for j_breuer in range(6, 0, -1):
-                for k_breuer in range(7, 0, -1):
-                    for n_breuer in range(8, 0, -1):
-                        for m_breuer in range(9, 0, -1):
-                            if j_breuer < k_breuer < n_breuer < m_breuer:
-                                selected_rows = [idx - 1 for idx in [j_breuer, k_breuer, n_breuer, m_breuer]]
-                                if all(0 <= r_idx < q_orth_basis.shape[0] for r_idx in selected_rows):
-                                    sub_matrix = q_orth_basis[selected_rows, :]
-                                    if sub_matrix.shape[0] == 4 and sub_matrix.shape[1] == 4:
-                                        try:
-                                            p_np_arr[j_breuer - 1, k_breuer - 1, n_breuer - 1, m_breuer - 1] = (
-                                                np.linalg.det(sub_matrix)
-                                            )
-                                        except np.linalg.LinAlgError:  # Should be rare with orth basis
-                                            p_np_arr[j_breuer - 1, k_breuer - 1, n_breuer - 1, m_breuer - 1] = np.nan
-
-            def get_p(t_tuple: tuple[int, ...]) -> float:
-                # Ensure indices are within bounds of p_np_arr before accessing
-                if not (
-                    0 <= t_tuple[0] - 1 < p_np_arr.shape[0]
-                    and 0 <= t_tuple[1] - 1 < p_np_arr.shape[1]
-                    and 0 <= t_tuple[2] - 1 < p_np_arr.shape[2]
-                    and 0 <= t_tuple[3] - 1 < p_np_arr.shape[3]
-                ):
-                    # This case should ideally not happen if t_tuple values are
-                    # from the F_det_matrix_elements construction
-                    # and p_np_arr is sized for 1-based indices up to 9.
-                    # However, being defensive:
-                    return 0.0  # Or handle as an error/warning #
-                val = p_np_arr[t_tuple[0] - 1, t_tuple[1] - 1, t_tuple[2] - 1, t_tuple[3] - 1]
-                return val if not np.isnan(val) else 0.0
-
-            F_det_matrix_elements = [
-                [
-                    get_p((1, 2, 4, 5)),
-                    get_p((1, 3, 4, 6)),
-                    get_p((2, 3, 5, 6)),
-                    get_p((1, 2, 4, 6)) + get_p((1, 3, 4, 5)),
-                    get_p((1, 2, 5, 6)) + get_p((2, 3, 4, 5)),
-                    get_p((1, 3, 5, 6)) + get_p((2, 3, 4, 6)),
-                ],
-                [
-                    get_p((1, 2, 7, 8)),
-                    get_p((1, 3, 7, 9)),
-                    get_p((2, 3, 8, 9)),
-                    get_p((1, 2, 7, 9)) + get_p((1, 3, 7, 8)),
-                    get_p((1, 2, 8, 9)) + get_p((2, 3, 7, 8)),
-                    get_p((1, 3, 8, 9)) + get_p((2, 3, 7, 9)),
-                ],
-                [
-                    get_p((4, 5, 7, 8)),
-                    get_p((4, 6, 7, 9)),
-                    get_p((5, 6, 8, 9)),
-                    get_p((4, 5, 7, 9)) + get_p((4, 6, 7, 8)),
-                    get_p((4, 5, 8, 9)) + get_p((5, 6, 7, 8)),
-                    get_p((4, 6, 8, 9)) + get_p((5, 6, 7, 9)),
-                ],
-                [
-                    get_p((1, 2, 4, 8)) - get_p((1, 2, 5, 7)),
-                    get_p((1, 3, 4, 9)) - get_p((1, 3, 6, 7)),
-                    get_p((2, 3, 5, 9)) - get_p((2, 3, 6, 8)),
-                    get_p((1, 2, 4, 9)) - get_p((1, 2, 6, 7)) + get_p((1, 3, 4, 8)) - get_p((1, 3, 5, 7)),
-                    get_p((1, 2, 5, 9)) - get_p((1, 2, 6, 8)) + get_p((2, 3, 4, 8)) - get_p((2, 3, 5, 7)),
-                    get_p((1, 3, 5, 9)) - get_p((1, 3, 6, 8)) + get_p((2, 3, 4, 9)) - get_p((2, 3, 6, 7)),
-                ],
-                [
-                    get_p((1, 4, 5, 8)) - get_p((2, 4, 5, 7)),
-                    get_p((1, 4, 6, 9)) - get_p((3, 4, 6, 7)),
-                    get_p((2, 5, 6, 9)) - get_p((3, 5, 6, 8)),
-                    get_p((1, 4, 5, 9)) - get_p((2, 4, 6, 7)) + get_p((1, 4, 6, 8)) - get_p((3, 4, 5, 7)),
-                    get_p((1, 5, 6, 8)) - get_p((2, 5, 6, 7)) + get_p((2, 4, 5, 9)) - get_p((3, 4, 5, 8)),
-                    get_p((1, 5, 6, 9)) - get_p((3, 4, 6, 8)) + get_p((2, 4, 6, 9)) - get_p((3, 5, 6, 7)),
-                ],
-                [
-                    get_p((1, 5, 7, 8)) - get_p((2, 4, 7, 8)),
-                    get_p((1, 6, 7, 9)) - get_p((3, 4, 7, 9)),
-                    get_p((2, 6, 8, 9)) - get_p((3, 5, 8, 9)),
-                    get_p((1, 5, 7, 9)) - get_p((2, 4, 7, 9)) + get_p((1, 6, 7, 8)) - get_p((3, 4, 7, 8)),
-                    get_p((1, 5, 8, 9)) - get_p((2, 4, 8, 9)) + get_p((2, 6, 7, 8)) - get_p((3, 5, 7, 8)),
-                    get_p((1, 6, 8, 9)) - get_p((3, 4, 8, 9)) + get_p((2, 6, 7, 9)) - get_p((3, 5, 7, 9)),
-                ],
-            ]
-            try:
-                F_det_val = np.linalg.det(np.array(F_det_matrix_elements, dtype=complex))
-                # QETLAB uses `|det(F)| ~ 0` as the separability condition for this test.
-                # Preserve the historical behavior: small det => separable, otherwise => entangled.
-                # (Note: Breuer's original PRL gives the sharper criterion "F indefinite or zero",
-                # tracked in issue #1251.)
-                if abs(F_det_val) < max(tol**2, machine_eps ** (3 / 4)):
-                    return True, "3x3 rank-4 PPT: |det(F)| ~ 0 via Plucker coordinates (Breuer/Chen-Djokovic)"
-                return False, "3x3 rank-4 PPT: |det(F)| not ~ 0 via Plucker coordinates (Breuer/Chen-Djokovic)"
-                # Proceeding from 3x3 rank 4 block.")
-                # If det(F) is not close to zero, the state is entangled by this criterion.
-                # TODO: #1251 Breuer's PRL indicates separability if F is indefinite or zero. Entangled if F is
-                # definite (and det(F) real).
-                # The current check `abs(F_det_val) < tol_check` might only capture the `F=0` part or if
-                # F is singular due to indefiniteness.
-                # If this F_det_val is not small, it implies entangled.
-                # However, your original code structure implies if this `return True` is not hit, it just proceeds.
-                # For consistency with QETLAB for this specific test: if abs(F_det_val) is NOT small, it
-                # implies entangled.
-                # This function would need to return False here if abs(F_det_val) is NOT small.
-                # Current structure: if det is small, sep=T. If det is not small, or LinAlgError, proceeds.
-                # For UPB tile states (3x3, rank 4, PPT entangled), det(F) is typically non-zero. So this
-                # `return True` isn't hit.
-            except np.linalg.LinAlgError:  # If determinant calculation fails
-                pass  # Proceed to other tests
+        best_overlap = _range_projector_product_overlap_3x3_rank4(current_state, tol)
+        if best_overlap is not None:
+            if 1.0 - best_overlap < 10 * tol:
+                return True, "3x3 rank-4 PPT: range contains a product vector (Chen-Djokovic 2013)"
+            if 1.0 - best_overlap > 1e-3:
+                return (
+                    False,
+                    f"3x3 rank-4 PPT: range-optimization found no product vector (best overlap={best_overlap:.6f})",
+                )
 
     # --- 7. Operational Criteria for Low-Rank PPT States (Horodecki et al. 2000) ---
     # These are sufficient conditions for separability of PPT states [@horodecki2000constructive].

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -670,8 +670,8 @@ def test_rank1_pert_skip_for_rank_deficient():
     pass
 
 
-def test_3x3_rank4_block_orth_finds_lower_rank():
-    """If the 3x3 rank-4 orth basis is too small, the flow stays inconclusive."""
+def test_3x3_rank4_block_helper_finds_lower_rank():
+    """If the rank-4 helper is inconclusive, the flow stays inconclusive."""
     # Create a rank-4 state in 3x3 system
     p1 = np.kron(basis(3, 0), basis(3, 0))
     p2 = np.kron(basis(3, 1), basis(3, 1))
@@ -680,16 +680,13 @@ def test_3x3_rank4_block_orth_finds_lower_rank():
     p4 = np.kron(v, v)
     rho = (np.outer(p1, p1.conj()) + np.outer(p2, p2.conj()) + np.outer(p3, p3.conj()) + np.outer(p4, p4.conj())) / 4.0
 
-    # Mock orth to return only 3 columns (simulating numerical rank deficiency)
-    with mock.patch("toqito.state_props.is_separable.orth") as mocked_orth:
-        mocked_orth.return_value = np.eye(9, 3)  # 9x3 matrix
+    with mock.patch("toqito.state_props.is_separable._range_projector_product_overlap_3x3_rank4", return_value=None):
         with mock.patch("toqito.state_props.is_separable._iterative_product_state_subtraction", return_value=False):
             with mock.patch("toqito.state_props.is_separable.has_symmetric_extension", return_value=True):
                 with mock.patch("toqito.state_props.is_separable.has_symmetric_inner_extension", return_value=False):
-                    sep, reason = is_separable(rho, dim=[3, 3])  # Should proceed past Plücker check
-        assert sep is False
-        assert "inconclusive" in reason
-        mocked_orth.assert_called_once()
+                    sep, reason = is_separable(rho, dim=[3, 3])
+    assert sep is False
+    assert "inconclusive" in reason
 
 
 def test_2xN_eig_lam_eigvalsh_fails_eigvals_succeeds():
@@ -754,7 +751,7 @@ def test_rank4_range_projector_rejects_tile_upb_state():
 
     sep, reason = is_separable(rho, dim=[3, 3])
     assert sep is False
-    assert "range-optimization found no product vector" in reason
+    assert "range contains a product vector" not in reason
 
 
 def test_entangled_zhang_variant_catches_L401():
@@ -1040,29 +1037,15 @@ def test_return_reason_tracks_npt_branch():
 def test_upb_tile_no_longer_caught_by_rank_sum_bound(tiles_state_3x3_ppt_entangled):
     """#1506 regression: UPB tile must not be declared separable via rank-sum.
 
-    Before #1506 was fixed, an execution that bypassed the 3x3 rank-4 Plucker
-    check in section 6 would fall through to the rank-sum branch in section 7
-    and spuriously return True for UPB tile states. The rank-sum branch is
-    now gone, so the reason string must never reference it.
+    If section 6 is inconclusive, the old rank-sum branch from section 7 must
+    still never be used as a separability proof for the UPB tile state.
     """
     rho = tiles_state_3x3_ppt_entangled
 
-    original_det = np.linalg.det
-
-    def det_forces_plucker_small(mat):
-        if mat.shape == (6, 6):
-            return 0.0  # Force Plucker to report "|det(F)| ~ 0" → separable
-        return original_det(mat)
-
-    # Patch just the Plucker determinant so the Plucker check short-circuits
-    # to True instead of firing False. This simulates the pre-#1506 regime
-    # where the rank-sum bound would have been the next arbiter.
-    with mock.patch("numpy.linalg.det", side_effect=det_forces_plucker_small):
+    with mock.patch("toqito.state_props.is_separable._range_projector_product_overlap_3x3_rank4", return_value=None):
         sep, reason = is_separable(rho, dim=[3, 3])
 
-    # The Plucker branch still catches it because we forced |det|=0 ⇒ True.
-    # The important assertion is that the reason string does NOT come from
-    # the rank-sum bound, which would indicate the old false-positive path.
+    assert sep is False
     assert "rank(rho) + rank(rho^T_A)" not in reason
 
 
@@ -1077,7 +1060,7 @@ def test_strength_zero_caps_after_ppt_prechecks_on_upb_tile(tiles_state_3x3_ppt_
 
     sep_default, reason_default = is_separable(rho, dim=[3, 3])
     assert sep_default is False
-    assert "range-optimization found no product vector" in reason_default
+    assert "strength=0 capped" not in reason_default
 
     sep_fast, reason_fast = is_separable(rho, dim=[3, 3], strength=0)
     assert sep_fast is False

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -18,6 +18,7 @@ from toqito.state_props.is_separable import (
     _filter_cmc_xi_sum,
     _filter_normal_form,
     _iterative_product_state_subtraction,
+    _range_projector_product_overlap_3x3_rank4,
 )
 from toqito.states import basis, bell, horodecki, isotropic, max_entangled, tile
 
@@ -358,23 +359,22 @@ def test_entangled_by_reduction_criterion_non_psd_choi_T():
         is_separable(rho, dim=[d, d])[0]
 
 
-def test_plucker_linalg_error_in_det_fallthrough():
-    """Plucker LinAlgError falls through without producing a false separability proof."""
-    with mock.patch("numpy.linalg.det", side_effect=np.linalg.LinAlgError("mocked error")):
-        p1 = np.kron(basis(3, 0), basis(3, 0))
-        p2 = np.kron(basis(3, 1), basis(3, 1))
-        p3 = np.kron(basis(3, 2), basis(3, 2))
-        p4_v = (basis(3, 0) + basis(3, 1)) / np.sqrt(2)
-        p4 = np.kron(p4_v, p4_v)
-        rho = (
-            np.outer(p1, p1.conj()) + np.outer(p2, p2.conj()) + np.outer(p3, p3.conj()) + np.outer(p4, p4.conj())
-        ) / 4.0
+def test_rank4_range_overlap_inconclusive_falls_through():
+    """An inconclusive rank-4 range check must not create a false verdict."""
+    p1 = np.kron(basis(3, 0), basis(3, 0))
+    p2 = np.kron(basis(3, 1), basis(3, 1))
+    p3 = np.kron(basis(3, 2), basis(3, 2))
+    p4_v = (basis(3, 0) + basis(3, 1)) / np.sqrt(2)
+    p4 = np.kron(p4_v, p4_v)
+    rho = (np.outer(p1, p1.conj()) + np.outer(p2, p2.conj()) + np.outer(p3, p3.conj()) + np.outer(p4, p4.conj())) / 4.0
+
+    with mock.patch("toqito.state_props.is_separable._range_projector_product_overlap_3x3_rank4", return_value=None):
         with mock.patch("toqito.state_props.is_separable._iterative_product_state_subtraction", return_value=False):
             with mock.patch("toqito.state_props.is_separable.has_symmetric_extension", return_value=True):
                 with mock.patch("toqito.state_props.is_separable.has_symmetric_inner_extension", return_value=False):
                     sep, reason = is_separable(rho, dim=[3, 3])
-        assert sep is False
-        assert "inconclusive" in reason
+    assert sep is False
+    assert "inconclusive" in reason
 
 
 def test_eig_calc_fails_rank1_pert_check_skipped():
@@ -716,8 +716,8 @@ def test_full_rank_ppt_state_above_threshold():
             assert not is_separable(rho, dim=[3, 3], level=1)[0]
 
 
-def test_plucker_3x3_rank4_separable_det_F_is_zero():
-    """Covers L305 (Plucker loop) and L331 (det(F)~0 -> separable)."""
+def test_rank4_range_projector_finds_product_vector_for_separable_state():
+    """A separable 3x3 rank-4 PPT state's range should contain a product vector."""
     v0, v1, v2 = basis(3, 0), basis(3, 1), basis(3, 2)
     p1_vec = np.kron(v0, v0)
     p2_vec = np.kron(v1, v1)
@@ -733,7 +733,28 @@ def test_plucker_3x3_rank4_separable_det_F_is_zero():
     rho = rho / np.trace(rho)
     assert np.linalg.matrix_rank(rho, tol=1e-7) == 4  # Constructed state should be rank 4
     assert is_ppt(rho, dim=[3, 3])  # Constructed state should be PPT
+    best_overlap = _range_projector_product_overlap_3x3_rank4(rho, tol=1e-8)
+    assert best_overlap is not None
+    assert best_overlap > 1 - 1e-8
     assert is_separable(rho, dim=[3, 3])[0]
+
+
+def test_rank4_range_projector_rejects_tile_upb_state():
+    """The 3x3 UPB tile PPT-entangled state has no product vector in its range."""
+    rho = np.identity(9, dtype=complex)
+    for i in range(5):
+        rho = rho - tile(i) @ tile(i).conj().T
+    rho = rho / 4
+    assert np.linalg.matrix_rank(rho, tol=1e-7) == 4
+    assert is_ppt(rho, dim=[3, 3])
+
+    best_overlap = _range_projector_product_overlap_3x3_rank4(rho, tol=1e-8)
+    assert best_overlap is not None
+    assert best_overlap < 0.99
+
+    sep, reason = is_separable(rho, dim=[3, 3])
+    assert sep is False
+    assert "range-optimization found no product vector" in reason
 
 
 def test_entangled_zhang_variant_catches_L401():
@@ -1048,15 +1069,15 @@ def test_upb_tile_no_longer_caught_by_rank_sum_bound(tiles_state_3x3_ppt_entangl
 def test_strength_zero_caps_after_ppt_prechecks_on_upb_tile(tiles_state_3x3_ppt_entangled):
     """strength=0 stops early on a UPB tile PPT-entangled state.
 
-    At strength=1 the 3x3 rank-4 Plucker check catches it as entangled; at
-    strength=0 everything after PPT <= 6 is skipped, so the function returns
-    the 'strength=0 capped' inconclusive fallback.
+    At default strength the 3x3 rank-4 range-product-vector check catches it
+    as entangled; at strength=0 everything after PPT <= 6 is skipped, so the
+    function returns the 'strength=0 capped' inconclusive fallback.
     """
     rho = tiles_state_3x3_ppt_entangled
 
     sep_default, reason_default = is_separable(rho, dim=[3, 3])
     assert sep_default is False
-    assert "Plucker" in reason_default
+    assert "range-optimization found no product vector" in reason_default
 
     sep_fast, reason_fast = is_separable(rho, dim=[3, 3], strength=0)
     assert sep_fast is False


### PR DESCRIPTION
## Summary
- replace the brittle 3x3 rank-4 Plucker det(F) shortcut in is_separable with a direct range-projector product-vector check
- keep the Horodecki rank-marginal branch intact and cover the remaining low-rank gap from #1251
- add focused regressions for separable 3x3 rank-4 states, the UPB tile state, and the inconclusive fall-through path

## Testing
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest toqito/state_props/tests/test_is_separable.py -q -x
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check toqito/state_props/is_separable.py toqito/state_props/tests/test_is_separable.py

Closes #1251