### PR TITLE
Update documented Python support range

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 ## Before reporting this bug:
 - [ ] Verify there is not an existing issue for it already
-- [ ] You are using the latest version of `toqito` with a python version `>=3.10`
+- [ ] You are using the latest version of `toqito` with a Python version `>=3.11`
 
 ## Describe the bug
 *A clear and concise description of what the bug is.*

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ information.
 
 ## Installing
 
-|toqito⟩ is available via [PyPi](https://pypi.org/project/toqito/) for Linux, and macOS, with support for Python 3.10 to
-3.13.
+|toqito⟩ is available via [PyPi](https://pypi.org/project/toqito/) for Linux and macOS, with support for Python 3.11
+to 3.14.
 
 ```sh
 pip install toqito


### PR DESCRIPTION
## Summary
- update the README to reflect supported Python versions 3.11 through 3.14
- update the bug-report template to require Python 3.11 or newer
- leave the existing package metadata and CI matrix as-is since they already target 3.11 through 3.14

Closes #1529