### PR TITLE
Add sandwiched conditional Renyi entropy

### DIFF
--- a/toqito/state_props/__init__.py
+++ b/toqito/state_props/__init__.py
@@ -30,4 +30,5 @@ from toqito.state_props.is_sic_povm import is_sic_povm
 from toqito.state_props.common_quantum_overlap import common_quantum_overlap
 from toqito.state_props.petz_renyi_conditional_entropy import petz_renyi_conditional_entropy
 from toqito.state_props.renyi_entropy import renyi_entropy
+from toqito.state_props.sandwiched_renyi_conditional_entropy import sandwiched_renyi_conditional_entropy
 from toqito.state_props.learnability import learnability

--- a/toqito/state_props/_renyi_utils.py
+++ b/toqito/state_props/_renyi_utils.py
@@ -1,0 +1,65 @@
+"""Internal helper functions for Rényi entropy calculations."""
+
+import numpy as np
+
+
+def validate_bipartite_dim(
+    rho: np.ndarray, dim: int | list[int] | tuple | np.ndarray | None
+) -> np.ndarray:
+    """Validate and normalize a bipartite dimension specification."""
+    n = rho.shape[0]
+
+    if dim is None:
+        d = int(round(np.sqrt(n)))
+        if d * d != n:
+            raise ValueError("Cannot infer bipartite subsystem dimensions directly. Please provide `dim`.")
+        return np.array([d, d], dtype=int)
+
+    if isinstance(dim, int):
+        if dim <= 0 or n % dim != 0:
+            raise ValueError("If `dim` is a scalar, it must be a positive divisor of the matrix dimension.")
+        return np.array([dim, n // dim], dtype=int)
+
+    dims = np.asarray(dim)
+    if dims.ndim != 1 or len(dims) != 2:
+        raise ValueError("`dim` must describe exactly two subsystem dimensions.")
+    if not np.issubdtype(dims.dtype, np.integer):
+        raise ValueError("`dim` must contain integer subsystem dimensions.")
+    if np.any(dims <= 0):
+        raise ValueError("Subsystem dimensions in `dim` must be positive.")
+    if int(np.prod(dims)) != n:
+        raise ValueError("The product of `dim` must match the dimension of `rho`.")
+    return dims.astype(int)
+
+
+def psd_matrix_power(mat: np.ndarray, power: float, tol: float = 1e-12) -> np.ndarray:
+    """Apply a real power to a PSD matrix on its support."""
+    eigvals, eigvecs = np.linalg.eigh((mat + mat.conj().T) / 2)
+    powered = np.zeros_like(eigvals, dtype=float)
+    positive = eigvals > tol
+    powered[positive] = eigvals[positive] ** power
+    return eigvecs @ np.diag(powered) @ eigvecs.conj().T
+
+
+def support_overlap(mat_1: np.ndarray, mat_2: np.ndarray, tol: float = 1e-12) -> float:
+    """Return the overlap between the supports of two PSD matrices."""
+    proj_1 = support_projector(mat_1, tol)
+    proj_2 = support_projector(mat_2, tol)
+    return float(np.real_if_close(np.trace(proj_1 @ proj_2)))
+
+
+def support_is_subset(mat_1: np.ndarray, mat_2: np.ndarray, tol: float = 1e-12) -> bool:
+    """Check whether support(mat_1) is contained in support(mat_2)."""
+    proj_1 = support_projector(mat_1, tol)
+    proj_2 = support_projector(mat_2, tol)
+    leak = np.trace(proj_1 @ (np.eye(mat_1.shape[0]) - proj_2))
+    return float(np.real_if_close(leak)) <= tol
+
+
+def support_projector(mat: np.ndarray, tol: float = 1e-12) -> np.ndarray:
+    """Return the orthogonal projector onto the support of a PSD matrix."""
+    eigvals, eigvecs = np.linalg.eigh((mat + mat.conj().T) / 2)
+    positive = eigvals > tol
+    if not np.any(positive):
+        return np.zeros_like(mat, dtype=complex)
+    return eigvecs[:, positive] @ eigvecs[:, positive].conj().T

--- a/toqito/state_props/petz_renyi_conditional_entropy.py
+++ b/toqito/state_props/petz_renyi_conditional_entropy.py
@@ -4,6 +4,12 @@ import numpy as np
 
 from toqito.matrix_ops.partial_trace import partial_trace
 from toqito.matrix_props import is_density
+from toqito.state_props._renyi_utils import (
+    psd_matrix_power,
+    support_is_subset,
+    support_overlap,
+    validate_bipartite_dim,
+)
 from toqito.state_props.von_neumann_entropy import von_neumann_entropy
 
 
@@ -106,7 +112,7 @@ def petz_renyi_conditional_entropy(
     if variant not in {"downarrow", "uparrow"}:
         raise ValueError("`variant` must be either 'downarrow' or 'uparrow'.")
 
-    dims = _validate_bipartite_dim(rho, dim)
+    dims = validate_bipartite_dim(rho, dim)
     rho_b = partial_trace(rho, [0], dims)
 
     if alpha == 1:
@@ -122,82 +128,20 @@ def _petz_renyi_conditional_entropy_downarrow(
     """Compute the downarrow Petz conditional Rényi entropy."""
     sigma = np.kron(np.eye(dim_a), rho_b)
 
-    if alpha < 1 and _support_overlap(rho, sigma) <= 0:
+    if alpha < 1 and support_overlap(rho, sigma) <= 0:
         return float("-inf")
-    if alpha > 1 and not _support_is_subset(rho, sigma):
+    if alpha > 1 and not support_is_subset(rho, sigma):
         return float("-inf")
 
-    trace_term = np.trace(_psd_matrix_power(rho, alpha) @ _psd_matrix_power(sigma, 1 - alpha))
+    trace_term = np.trace(psd_matrix_power(rho, alpha) @ psd_matrix_power(sigma, 1 - alpha))
     trace_term = float(np.real_if_close(trace_term))
     return -np.log2(trace_term) / (alpha - 1)
 
 
 def _petz_renyi_conditional_entropy_uparrow(rho: np.ndarray, alpha: float, dims: np.ndarray) -> float:
     """Compute the uparrow Petz conditional Rényi entropy via the closed-form formula."""
-    rho_alpha = _psd_matrix_power(rho, alpha)
+    rho_alpha = psd_matrix_power(rho, alpha)
     traced = partial_trace(rho_alpha, [0], dims)
-    traced_power = _psd_matrix_power(traced, 1 / alpha)
+    traced_power = psd_matrix_power(traced, 1 / alpha)
     trace_term = float(np.real_if_close(np.trace(traced_power)))
     return alpha * np.log2(trace_term) / (1 - alpha)
-
-
-def _validate_bipartite_dim(
-    rho: np.ndarray, dim: int | list[int] | tuple | np.ndarray | None
-) -> np.ndarray:
-    """Validate and normalize a bipartite dimension specification."""
-    n = rho.shape[0]
-
-    if dim is None:
-        d = int(round(np.sqrt(n)))
-        if d * d != n:
-            raise ValueError("Cannot infer bipartite subsystem dimensions directly. Please provide `dim`.")
-        return np.array([d, d], dtype=int)
-
-    if isinstance(dim, int):
-        if dim <= 0 or n % dim != 0:
-            raise ValueError("If `dim` is a scalar, it must be a positive divisor of the matrix dimension.")
-        return np.array([dim, n // dim], dtype=int)
-
-    dims = np.asarray(dim)
-    if dims.ndim != 1 or len(dims) != 2:
-        raise ValueError("`dim` must describe exactly two subsystem dimensions.")
-    if not np.issubdtype(dims.dtype, np.integer):
-        raise ValueError("`dim` must contain integer subsystem dimensions.")
-    if np.any(dims <= 0):
-        raise ValueError("Subsystem dimensions in `dim` must be positive.")
-    if int(np.prod(dims)) != n:
-        raise ValueError("The product of `dim` must match the dimension of `rho`.")
-    return dims.astype(int)
-
-
-def _psd_matrix_power(mat: np.ndarray, power: float, tol: float = 1e-12) -> np.ndarray:
-    """Apply a real power to a PSD matrix on its support."""
-    eigvals, eigvecs = np.linalg.eigh((mat + mat.conj().T) / 2)
-    powered = np.zeros_like(eigvals, dtype=float)
-    positive = eigvals > tol
-    powered[positive] = eigvals[positive] ** power
-    return eigvecs @ np.diag(powered) @ eigvecs.conj().T
-
-
-def _support_overlap(mat_1: np.ndarray, mat_2: np.ndarray, tol: float = 1e-12) -> float:
-    """Return the overlap between the supports of two PSD matrices."""
-    proj_1 = _support_projector(mat_1, tol)
-    proj_2 = _support_projector(mat_2, tol)
-    return float(np.real_if_close(np.trace(proj_1 @ proj_2)))
-
-
-def _support_is_subset(mat_1: np.ndarray, mat_2: np.ndarray, tol: float = 1e-12) -> bool:
-    """Check whether support(mat_1) is contained in support(mat_2)."""
-    proj_1 = _support_projector(mat_1, tol)
-    proj_2 = _support_projector(mat_2, tol)
-    leak = np.trace(proj_1 @ (np.eye(mat_1.shape[0]) - proj_2))
-    return float(np.real_if_close(leak)) <= tol
-
-
-def _support_projector(mat: np.ndarray, tol: float = 1e-12) -> np.ndarray:
-    """Return the orthogonal projector onto the support of a PSD matrix."""
-    eigvals, eigvecs = np.linalg.eigh((mat + mat.conj().T) / 2)
-    positive = eigvals > tol
-    if not np.any(positive):
-        return np.zeros_like(mat, dtype=complex)
-    return eigvecs[:, positive] @ eigvecs[:, positive].conj().T

--- a/toqito/state_props/sandwiched_renyi_conditional_entropy.py
+++ b/toqito/state_props/sandwiched_renyi_conditional_entropy.py
@@ -4,11 +4,11 @@ import numpy as np
 
 from toqito.matrix_ops.partial_trace import partial_trace
 from toqito.matrix_props import is_density
-from toqito.state_props.petz_renyi_conditional_entropy import (
-    _psd_matrix_power,
-    _support_is_subset,
-    _support_overlap,
-    _validate_bipartite_dim,
+from toqito.state_props._renyi_utils import (
+    psd_matrix_power,
+    support_is_subset,
+    support_overlap,
+    validate_bipartite_dim,
 )
 from toqito.state_props.von_neumann_entropy import von_neumann_entropy
 
@@ -101,7 +101,7 @@ def sandwiched_renyi_conditional_entropy(
     if variant != "downarrow":
         raise ValueError("Only the 'downarrow' sandwiched conditional Rényi entropy is currently supported.")
 
-    dims = _validate_bipartite_dim(rho, dim)
+    dims = validate_bipartite_dim(rho, dim)
     rho_b = partial_trace(rho, [0], dims)
 
     if alpha == 1:
@@ -116,14 +116,14 @@ def _sandwiched_renyi_conditional_entropy_downarrow(
     """Compute the downarrow sandwiched conditional Rényi entropy."""
     sigma = np.kron(np.eye(dim_a), rho_b)
 
-    if alpha < 1 and _support_overlap(rho, sigma) <= 0:
+    if alpha < 1 and support_overlap(rho, sigma) <= 0:
         return float("-inf")
-    if alpha > 1 and not _support_is_subset(rho, sigma):
+    if alpha > 1 and not support_is_subset(rho, sigma):
         return float("-inf")
 
     sandwiched_power = (1 - alpha) / (2 * alpha)
-    sigma_power = _psd_matrix_power(sigma, sandwiched_power)
+    sigma_power = psd_matrix_power(sigma, sandwiched_power)
     sandwiched = sigma_power @ rho @ sigma_power
-    trace_term = np.trace(_psd_matrix_power(sandwiched, alpha))
+    trace_term = np.trace(psd_matrix_power(sandwiched, alpha))
     trace_term = float(np.real_if_close(trace_term))
     return -np.log2(trace_term) / (alpha - 1)

--- a/toqito/state_props/sandwiched_renyi_conditional_entropy.py
+++ b/toqito/state_props/sandwiched_renyi_conditional_entropy.py
@@ -1,0 +1,129 @@
+"""Compute the sandwiched conditional Rényi entropy of a bipartite quantum state."""
+
+import numpy as np
+
+from toqito.matrix_ops.partial_trace import partial_trace
+from toqito.matrix_props import is_density
+from toqito.state_props.petz_renyi_conditional_entropy import (
+    _psd_matrix_power,
+    _support_is_subset,
+    _support_overlap,
+    _validate_bipartite_dim,
+)
+from toqito.state_props.von_neumann_entropy import von_neumann_entropy
+
+
+def sandwiched_renyi_conditional_entropy(
+    rho: np.ndarray,
+    alpha: float,
+    dim: int | list[int] | tuple | np.ndarray | None = None,
+    variant: str = "downarrow",
+) -> float:
+    r"""Compute the sandwiched conditional Rényi entropy of a bipartite state.
+
+    For a bipartite density operator \(\rho_{AB}\), the downarrow sandwiched
+    conditional Rényi entropy is defined by
+
+    \[
+        \widetilde{H}^{\downarrow}_{\alpha}(A|B)_{\rho}
+        =
+        -\widetilde{D}_{\alpha}\left(\rho_{AB}\parallel I_A \otimes \rho_B\right),
+    \]
+
+    where \(\widetilde{D}_{\alpha}\) is the sandwiched Rényi divergence
+
+    \[
+        \widetilde{D}_{\alpha}(\rho\|\sigma)
+        =
+        \frac{1}{\alpha - 1}
+        \log_2\left(
+            \mathrm{Tr}\left[
+                \left(
+                    \sigma^{(1-\alpha)/(2\alpha)}
+                    \rho
+                    \sigma^{(1-\alpha)/(2\alpha)}
+                \right)^\alpha
+            \right]
+        \right).
+    \]
+
+    This function currently implements only the downarrow variant. The uparrow
+    variant requires an optimization over density operators on subsystem `B` and
+    is intentionally rejected until that optimization is implemented.
+
+    For `alpha=1`, the downarrow variant recovers the conditional von Neumann
+    entropy `H(AB) - H(B)`.
+
+    Args:
+        rho: Bipartite density operator.
+        alpha: Rényi order. This function supports positive orders and handles
+            `alpha=1` via the conditional von Neumann entropy.
+        dim: Dimensions of the two subsystems. If `None`, both subsystems are
+            assumed to have the same dimension.
+        variant: Currently only `"downarrow"` is supported.
+
+    Returns:
+        The sandwiched conditional Rényi entropy of `rho`.
+
+    Raises:
+        ValueError: If `rho` is not a density matrix, if `alpha <= 0`, if
+            `variant` is not `"downarrow"`, or if `dim` does not describe a
+            bipartite decomposition of `rho`.
+
+    Examples:
+        Compute the downarrow variant for a Bell state:
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.state_props import sandwiched_renyi_conditional_entropy
+
+        psi = np.array([1, 0, 0, 1]) / np.sqrt(2)
+        rho = np.outer(psi, psi.conj())
+        print(sandwiched_renyi_conditional_entropy(rho, alpha=2, dim=2))
+        ```
+
+        For a product state, the conditional entropy matches the Rényi entropy
+        of the first subsystem:
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.state_props import sandwiched_renyi_conditional_entropy
+
+        rho = np.diag([1 / 2, 1 / 2, 0, 0])
+        print(sandwiched_renyi_conditional_entropy(rho, alpha=2, dim=2))
+        ```
+
+    """
+    if not is_density(rho):
+        raise ValueError("Sandwiched conditional Rényi entropy is only defined for density operators.")
+    if alpha <= 0:
+        raise ValueError("Sandwiched conditional Rényi entropy is only defined for positive orders.")
+    if variant != "downarrow":
+        raise ValueError("Only the 'downarrow' sandwiched conditional Rényi entropy is currently supported.")
+
+    dims = _validate_bipartite_dim(rho, dim)
+    rho_b = partial_trace(rho, [0], dims)
+
+    if alpha == 1:
+        return von_neumann_entropy(rho) - von_neumann_entropy(rho_b)
+
+    return _sandwiched_renyi_conditional_entropy_downarrow(rho, rho_b, alpha, dims[0])
+
+
+def _sandwiched_renyi_conditional_entropy_downarrow(
+    rho: np.ndarray, rho_b: np.ndarray, alpha: float, dim_a: int
+) -> float:
+    """Compute the downarrow sandwiched conditional Rényi entropy."""
+    sigma = np.kron(np.eye(dim_a), rho_b)
+
+    if alpha < 1 and _support_overlap(rho, sigma) <= 0:
+        return float("-inf")
+    if alpha > 1 and not _support_is_subset(rho, sigma):
+        return float("-inf")
+
+    sandwiched_power = (1 - alpha) / (2 * alpha)
+    sigma_power = _psd_matrix_power(sigma, sandwiched_power)
+    sandwiched = sigma_power @ rho @ sigma_power
+    trace_term = np.trace(_psd_matrix_power(sandwiched, alpha))
+    trace_term = float(np.real_if_close(trace_term))
+    return -np.log2(trace_term) / (alpha - 1)

--- a/toqito/state_props/tests/test_sandwiched_renyi_conditional_entropy.py
+++ b/toqito/state_props/tests/test_sandwiched_renyi_conditional_entropy.py
@@ -1,0 +1,61 @@
+"""Tests for sandwiched_renyi_conditional_entropy."""
+
+import numpy as np
+import pytest
+
+from toqito.state_props import (
+    renyi_entropy,
+    sandwiched_renyi_conditional_entropy,
+    von_neumann_entropy,
+)
+from toqito.states import bell, max_mixed
+
+RHO_A = np.array([[0.8, 0.0], [0.0, 0.2]])
+RHO_B = np.array([[0.3, 0.0], [0.0, 0.7]])
+PRODUCT_STATE = np.kron(RHO_A, RHO_B)
+MAX_ENTANGLED_STATE = bell(0) @ bell(0).conj().T
+
+
+@pytest.mark.parametrize("alpha", [0.5, 1.0, 1.5, 2.0])
+def test_sandwiched_renyi_conditional_entropy_product_state(alpha: float):
+    """For a product state, conditioning on B should recover the entropy of A."""
+    expected = renyi_entropy(RHO_A, alpha) if alpha != 1 else von_neumann_entropy(RHO_A)
+    result = sandwiched_renyi_conditional_entropy(PRODUCT_STATE, alpha, dim=[2, 2])
+    np.testing.assert_allclose(result, expected, atol=1e-8)
+
+
+@pytest.mark.parametrize("alpha", [0.5, 1.0, 1.5, 2.0])
+def test_sandwiched_renyi_conditional_entropy_maximally_entangled(alpha: float):
+    """For a maximally entangled two-qubit pure state, the entropy should be -1."""
+    result = sandwiched_renyi_conditional_entropy(MAX_ENTANGLED_STATE, alpha)
+    np.testing.assert_allclose(result, -1.0, atol=1e-8)
+
+
+def test_sandwiched_renyi_conditional_entropy_scalar_dim():
+    """Allow scalar subsystem dimensions for bipartite states."""
+    result = sandwiched_renyi_conditional_entropy(np.kron(max_mixed(2, False), max_mixed(3, False)), 2.0, dim=2)
+    np.testing.assert_allclose(result, 1.0, atol=1e-8)
+
+
+def test_sandwiched_renyi_conditional_entropy_unsupported_uparrow():
+    """The uparrow variant should fail clearly until the optimization is implemented."""
+    with pytest.raises(ValueError, match="downarrow"):
+        sandwiched_renyi_conditional_entropy(PRODUCT_STATE, 1.5, dim=[2, 2], variant="uparrow")
+
+
+@pytest.mark.parametrize(
+    "rho, alpha, dim, expected_msg",
+    [
+        (np.array([[1, 2], [3, 4]]), 1.5, [2, 1], "density operators"),
+        (PRODUCT_STATE, 0.0, [2, 2], "positive orders"),
+        (PRODUCT_STATE, 1.5, [4], "exactly two subsystem dimensions"),
+        (PRODUCT_STATE, 1.5, [3, 2], "product of `dim`"),
+        (max_mixed(6, False), 1.5, None, "Cannot infer bipartite subsystem dimensions"),
+    ],
+)
+def test_sandwiched_renyi_conditional_entropy_invalid_input(
+    rho: np.ndarray, alpha: float, dim: int | list[int] | None, expected_msg: str
+):
+    """Invalid inputs should raise a clear ValueError."""
+    with pytest.raises(ValueError, match=expected_msg):
+        sandwiched_renyi_conditional_entropy(rho, alpha, dim=dim)


### PR DESCRIPTION
## Summary
- add a public sandwiched_renyi_conditional_entropy API for the downarrow variant
- implement the sandwiched Renyi divergence formula against I_A kron rho_B
- export the API and add tests for product states, Bell states, scalar dims, invalid inputs, and unsupported uparrow

## Notes
- The uparrow variant is intentionally rejected for now because it requires the optimization tracked separately in #1533.
- Closes #1534.

## Validation
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest toqito/state_props/tests/test_sandwiched_renyi_conditional_entropy.py toqito/state_props/tests/test_petz_renyi_conditional_entropy.py -q
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check toqito/state_props/sandwiched_renyi_conditional_entropy.py toqito/state_props/tests/test_sandwiched_renyi_conditional_entropy.py toqito/state_props/__init__.py