### PR TITLE
Add uparrow sandwiched conditional Renyi entropy (#1533)

### DIFF
--- a/toqito/state_props/sandwiched_renyi_conditional_entropy.py
+++ b/toqito/state_props/sandwiched_renyi_conditional_entropy.py
@@ -1,6 +1,7 @@
 """Compute the sandwiched conditional Rényi entropy of a bipartite quantum state."""
 
 import numpy as np
+from scipy.optimize import minimize
 
 from toqito.matrix_ops.partial_trace import partial_trace
 from toqito.matrix_props import is_density
@@ -12,12 +13,16 @@ from toqito.state_props._renyi_utils import (
 )
 from toqito.state_props.von_neumann_entropy import von_neumann_entropy
 
+_UPARROW_MIN_ALPHA = 0.5
+
 
 def sandwiched_renyi_conditional_entropy(
     rho: np.ndarray,
     alpha: float,
     dim: int | list[int] | tuple | np.ndarray | None = None,
     variant: str = "downarrow",
+    tol: float = 1e-9,
+    max_iters: int = 500,
 ) -> float:
     r"""Compute the sandwiched conditional Rényi entropy of a bipartite state.
 
@@ -28,6 +33,15 @@ def sandwiched_renyi_conditional_entropy(
         \widetilde{H}^{\downarrow}_{\alpha}(A|B)_{\rho}
         =
         -\widetilde{D}_{\alpha}\left(\rho_{AB}\parallel I_A \otimes \rho_B\right),
+    \]
+
+    while the uparrow variant is the optimization
+
+    \[
+        \widetilde{H}^{\uparrow}_{\alpha}(A|B)_{\rho}
+        =
+        \sup_{\sigma_B \succeq 0,\; \mathrm{Tr}(\sigma_B) = 1}
+        -\widetilde{D}_{\alpha}\left(\rho_{AB}\parallel I_A \otimes \sigma_B\right),
     \]
 
     where \(\widetilde{D}_{\alpha}\) is the sandwiched Rényi divergence
@@ -47,28 +61,40 @@ def sandwiched_renyi_conditional_entropy(
         \right).
     \]
 
-    This function currently implements only the downarrow variant. The uparrow
-    variant requires an optimization over density operators on subsystem `B` and
-    is intentionally rejected until that optimization is implemented.
+    For `alpha=1`, both variants reduce to the conditional von Neumann entropy
+    `H(AB) - H(B)`.
 
-    For `alpha=1`, the downarrow variant recovers the conditional von Neumann
-    entropy `H(AB) - H(B)`.
+    The uparrow variant has no closed form, so it is computed by minimizing
+    \(\widetilde{D}_{\alpha}(\rho_{AB}\|I_A \otimes \sigma_B)\) over density
+    operators \(\sigma_B\) via `scipy.optimize.minimize` with the L-BFGS-B
+    method. The density operator is parameterized as
+    \(\sigma_B = A A^* / \mathrm{Tr}(A A^*)\) with a complex matrix \(A\). The
+    sandwiched Rényi divergence is jointly convex in \((\rho, \sigma)\) for
+    \(\alpha \in [1/2, \infty]\), so only that regime is supported for the
+    uparrow variant; outside it, the optimization is non-convex and local
+    minima need not be global. The edge cases `alpha=0` and `alpha=inf` are
+    out of scope.
 
     Args:
         rho: Bipartite density operator.
-        alpha: Rényi order. This function supports positive orders and handles
-            `alpha=1` via the conditional von Neumann entropy.
+        alpha: Rényi order. Positive orders are supported, and `alpha=1` is
+            handled via the conditional von Neumann entropy. For the uparrow
+            variant, the supported range is `alpha >= 1/2`.
         dim: Dimensions of the two subsystems. If `None`, both subsystems are
             assumed to have the same dimension.
-        variant: Currently only `"downarrow"` is supported.
+        variant: Either `"downarrow"` or `"uparrow"`.
+        tol: Gradient tolerance passed to the L-BFGS-B solver (uparrow only).
+        max_iters: Maximum number of solver iterations (uparrow only).
 
     Returns:
         The sandwiched conditional Rényi entropy of `rho`.
 
     Raises:
         ValueError: If `rho` is not a density matrix, if `alpha <= 0`, if
-            `variant` is not `"downarrow"`, or if `dim` does not describe a
-            bipartite decomposition of `rho`.
+            `variant` is not `"downarrow"` or `"uparrow"`, if `dim` does not
+            describe a bipartite decomposition of `rho`, or if the uparrow
+            variant is requested with `alpha < 1/2`.
+        RuntimeError: If the uparrow optimizer fails to converge.
 
     Examples:
         Compute the downarrow variant for a Bell state:
@@ -80,6 +106,17 @@ def sandwiched_renyi_conditional_entropy(
         psi = np.array([1, 0, 0, 1]) / np.sqrt(2)
         rho = np.outer(psi, psi.conj())
         print(sandwiched_renyi_conditional_entropy(rho, alpha=2, dim=2))
+        ```
+
+        Compute the uparrow variant for the same state:
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.state_props import sandwiched_renyi_conditional_entropy
+
+        psi = np.array([1, 0, 0, 1]) / np.sqrt(2)
+        rho = np.outer(psi, psi.conj())
+        print(sandwiched_renyi_conditional_entropy(rho, alpha=2, dim=2, variant="uparrow"))
         ```
 
         For a product state, the conditional entropy matches the Rényi entropy
@@ -98,8 +135,8 @@ def sandwiched_renyi_conditional_entropy(
         raise ValueError("Sandwiched conditional Rényi entropy is only defined for density operators.")
     if alpha <= 0:
         raise ValueError("Sandwiched conditional Rényi entropy is only defined for positive orders.")
-    if variant != "downarrow":
-        raise ValueError("Only the 'downarrow' sandwiched conditional Rényi entropy is currently supported.")
+    if variant not in {"downarrow", "uparrow"}:
+        raise ValueError("`variant` must be either 'downarrow' or 'uparrow'.")
 
     dims = validate_bipartite_dim(rho, dim)
     rho_b = partial_trace(rho, [0], dims)
@@ -107,7 +144,17 @@ def sandwiched_renyi_conditional_entropy(
     if alpha == 1:
         return von_neumann_entropy(rho) - von_neumann_entropy(rho_b)
 
-    return _sandwiched_renyi_conditional_entropy_downarrow(rho, rho_b, alpha, dims[0])
+    if variant == "downarrow":
+        return _sandwiched_renyi_conditional_entropy_downarrow(rho, rho_b, alpha, dims[0])
+
+    if alpha < _UPARROW_MIN_ALPHA:
+        raise ValueError(
+            "The uparrow sandwiched conditional Rényi entropy is only supported for "
+            "alpha >= 1/2, where the underlying optimization is convex."
+        )
+    return _sandwiched_renyi_conditional_entropy_uparrow(
+        rho, rho_b, alpha, int(dims[0]), int(dims[1]), tol, max_iters
+    )
 
 
 def _sandwiched_renyi_conditional_entropy_downarrow(
@@ -127,3 +174,70 @@ def _sandwiched_renyi_conditional_entropy_downarrow(
     trace_term = np.trace(psd_matrix_power(sandwiched, alpha))
     trace_term = float(np.real_if_close(trace_term))
     return -np.log2(trace_term) / (alpha - 1)
+
+
+def _sandwiched_renyi_conditional_entropy_uparrow(
+    rho: np.ndarray,
+    rho_b: np.ndarray,
+    alpha: float,
+    dim_a: int,
+    dim_b: int,
+    tol: float,
+    max_iters: int,
+) -> float:
+    """Compute the uparrow sandwiched conditional Rényi entropy via optimization."""
+    identity_a = np.eye(dim_a)
+    sandwich_exp = (1 - alpha) / (2 * alpha)
+    penalty = 1e12
+    n_real = dim_b * dim_b
+
+    def params_to_sigma_b(params: np.ndarray) -> np.ndarray:
+        a_real = params[:n_real].reshape(dim_b, dim_b)
+        a_imag = params[n_real:].reshape(dim_b, dim_b)
+        a_mat = a_real + 1j * a_imag
+        mat = a_mat @ a_mat.conj().T
+        trace_val = float(np.real(np.trace(mat)))
+        if trace_val < 1e-15:
+            return np.eye(dim_b) / dim_b
+        return mat / trace_val
+
+    def divergence(params: np.ndarray) -> float:
+        sigma_b = params_to_sigma_b(params)
+        sigma = np.kron(identity_a, sigma_b)
+
+        if alpha < 1 and support_overlap(rho, sigma) <= 0:
+            return penalty
+        if alpha > 1 and not support_is_subset(rho, sigma):
+            return penalty
+
+        sigma_power = psd_matrix_power(sigma, sandwich_exp)
+        sandwiched = sigma_power @ rho @ sigma_power
+        trace_term = float(np.real(np.trace(psd_matrix_power(sandwiched, alpha))))
+        if trace_term <= 0:
+            return penalty
+        return np.log2(trace_term) / (alpha - 1)
+
+    eigvals, eigvecs = np.linalg.eigh((rho_b + rho_b.conj().T) / 2)
+    eigvals = np.maximum(eigvals, 0.0)
+    max_eig = float(np.max(eigvals)) if eigvals.size else 0.0
+    if max_eig <= 0:
+        eigvals = np.ones_like(eigvals) / dim_b
+    else:
+        eigvals = eigvals + 1e-3 * max_eig
+        eigvals = eigvals / np.sum(eigvals)
+    a_init = eigvecs @ np.diag(np.sqrt(eigvals)) @ eigvecs.conj().T
+    x0 = np.concatenate([a_init.real.flatten(), a_init.imag.flatten()])
+
+    result = minimize(
+        divergence,
+        x0,
+        method="L-BFGS-B",
+        options={"gtol": tol, "ftol": tol, "maxiter": max_iters},
+    )
+
+    if not result.success and float(result.fun) >= penalty / 2:
+        raise RuntimeError(
+            f"Uparrow sandwiched conditional Rényi entropy optimizer failed to converge: {result.message}"
+        )
+
+    return -float(result.fun)

--- a/toqito/state_props/sandwiched_renyi_conditional_entropy.py
+++ b/toqito/state_props/sandwiched_renyi_conditional_entropy.py
@@ -196,7 +196,7 @@ def _sandwiched_renyi_conditional_entropy_uparrow(
         a_imag = params[n_real:].reshape(dim_b, dim_b)
         a_mat = a_real + 1j * a_imag
         mat = a_mat @ a_mat.conj().T
-        trace_val = float(np.real(np.trace(mat)))
+        trace_val = float(np.real_if_close(np.trace(mat)))
         if trace_val < 1e-15:
             return np.eye(dim_b) / dim_b
         return mat / trace_val
@@ -235,9 +235,10 @@ def _sandwiched_renyi_conditional_entropy_uparrow(
         options={"gtol": tol, "ftol": tol, "maxiter": max_iters},
     )
 
-    if not result.success and float(result.fun) >= penalty / 2:
+    result_fun = float(result.fun)
+    if not np.isfinite(result_fun) or result_fun >= penalty / 2:
         raise RuntimeError(
             f"Uparrow sandwiched conditional Rényi entropy optimizer failed to converge: {result.message}"
         )
 
-    return -float(result.fun)
+    return -result_fun

--- a/toqito/state_props/tests/test_sandwiched_renyi_conditional_entropy.py
+++ b/toqito/state_props/tests/test_sandwiched_renyi_conditional_entropy.py
@@ -16,19 +16,21 @@ PRODUCT_STATE = np.kron(RHO_A, RHO_B)
 MAX_ENTANGLED_STATE = bell(0) @ bell(0).conj().T
 
 
+@pytest.mark.parametrize("variant", ["downarrow", "uparrow"])
 @pytest.mark.parametrize("alpha", [0.5, 1.0, 1.5, 2.0])
-def test_sandwiched_renyi_conditional_entropy_product_state(alpha: float):
+def test_sandwiched_renyi_conditional_entropy_product_state(variant: str, alpha: float):
     """For a product state, conditioning on B should recover the entropy of A."""
     expected = renyi_entropy(RHO_A, alpha) if alpha != 1 else von_neumann_entropy(RHO_A)
-    result = sandwiched_renyi_conditional_entropy(PRODUCT_STATE, alpha, dim=[2, 2])
-    np.testing.assert_allclose(result, expected, atol=1e-8)
+    result = sandwiched_renyi_conditional_entropy(PRODUCT_STATE, alpha, dim=[2, 2], variant=variant)
+    np.testing.assert_allclose(result, expected, atol=1e-6)
 
 
+@pytest.mark.parametrize("variant", ["downarrow", "uparrow"])
 @pytest.mark.parametrize("alpha", [0.5, 1.0, 1.5, 2.0])
-def test_sandwiched_renyi_conditional_entropy_maximally_entangled(alpha: float):
+def test_sandwiched_renyi_conditional_entropy_maximally_entangled(variant: str, alpha: float):
     """For a maximally entangled two-qubit pure state, the entropy should be -1."""
-    result = sandwiched_renyi_conditional_entropy(MAX_ENTANGLED_STATE, alpha)
-    np.testing.assert_allclose(result, -1.0, atol=1e-8)
+    result = sandwiched_renyi_conditional_entropy(MAX_ENTANGLED_STATE, alpha, variant=variant)
+    np.testing.assert_allclose(result, -1.0, atol=1e-6)
 
 
 def test_sandwiched_renyi_conditional_entropy_scalar_dim():
@@ -37,10 +39,68 @@ def test_sandwiched_renyi_conditional_entropy_scalar_dim():
     np.testing.assert_allclose(result, 1.0, atol=1e-8)
 
 
-def test_sandwiched_renyi_conditional_entropy_unsupported_uparrow():
-    """The uparrow variant should fail clearly until the optimization is implemented."""
+@pytest.mark.parametrize("alpha", [0.7, 1.5, 2.0, 3.0])
+def test_sandwiched_renyi_conditional_entropy_uparrow_dominates_downarrow(alpha: float):
+    """The uparrow variant is a supremum, so it is at least the downarrow variant."""
+    np.random.seed(42)
+    mat = np.random.randn(4, 4) + 1j * np.random.randn(4, 4)
+    rho = mat @ mat.conj().T
+    rho = rho / np.trace(rho)
+
+    down = sandwiched_renyi_conditional_entropy(rho, alpha, dim=[2, 2], variant="downarrow")
+    up = sandwiched_renyi_conditional_entropy(rho, alpha, dim=[2, 2], variant="uparrow")
+    assert up >= down - 1e-6
+
+
+def test_sandwiched_renyi_conditional_entropy_uparrow_classical_quantum():
+    """On a classical-quantum state the uparrow variant matches a reference calculation.
+
+    For rho_AB = sum_x p(x) |x><x|_A ⊗ rho_B^x with orthogonal |x>,
+    the optimal sigma_B equals the conditional Rényi mixture
+        sigma_B* ∝ (sum_x p(x)^alpha (rho_B^x)^alpha)^{1/alpha},
+    and the uparrow value has a closed form that we cross-check numerically.
+    """
+    p = np.array([0.6, 0.4])
+    rho_b_1 = np.diag([0.9, 0.1])
+    rho_b_2 = np.diag([0.2, 0.8])
+    rho = p[0] * np.kron(np.diag([1, 0]), rho_b_1) + p[1] * np.kron(np.diag([0, 1]), rho_b_2)
+    alpha = 2.0
+
+    up = sandwiched_renyi_conditional_entropy(rho, alpha, dim=[2, 2], variant="uparrow")
+
+    # Closed form for classical-quantum states: H^↑_α(A|B) = α/(1-α) · log2 Tr[(sum_x p_x^α (rho_B^x)^α)^{1/α}]
+    mixture = p[0] ** alpha * np.linalg.matrix_power(rho_b_1, int(alpha)) + p[1] ** alpha * np.linalg.matrix_power(
+        rho_b_2, int(alpha)
+    )
+    expected = alpha / (1 - alpha) * np.log2(np.trace(_fractional_power(mixture, 1 / alpha)))
+    np.testing.assert_allclose(up, expected, atol=1e-6)
+
+
+def _fractional_power(mat: np.ndarray, power: float) -> np.ndarray:
+    """Apply a fractional power to a PSD matrix."""
+    eigs, vecs = np.linalg.eigh((mat + mat.conj().T) / 2)
+    eigs = np.maximum(eigs, 0.0)
+    return vecs @ np.diag(eigs**power) @ vecs.conj().T
+
+
+@pytest.mark.parametrize("variant", ["downarrow", "uparrow"])
+def test_sandwiched_renyi_conditional_entropy_alpha_one_is_conditional_vn(variant: str):
+    """At alpha=1 both variants reduce to the conditional von Neumann entropy."""
+    expected = von_neumann_entropy(PRODUCT_STATE) - von_neumann_entropy(RHO_B)
+    result = sandwiched_renyi_conditional_entropy(PRODUCT_STATE, 1.0, dim=[2, 2], variant=variant)
+    np.testing.assert_allclose(result, expected, atol=1e-8)
+
+
+def test_sandwiched_renyi_conditional_entropy_uparrow_rejects_small_alpha():
+    """The uparrow variant requires alpha >= 1/2 for a convex formulation."""
+    with pytest.raises(ValueError, match="alpha >= 1/2"):
+        sandwiched_renyi_conditional_entropy(PRODUCT_STATE, 0.25, dim=[2, 2], variant="uparrow")
+
+
+def test_sandwiched_renyi_conditional_entropy_rejects_unknown_variant():
+    """An unknown variant should raise a clear ValueError."""
     with pytest.raises(ValueError, match="downarrow"):
-        sandwiched_renyi_conditional_entropy(PRODUCT_STATE, 1.5, dim=[2, 2], variant="uparrow")
+        sandwiched_renyi_conditional_entropy(PRODUCT_STATE, 1.5, dim=[2, 2], variant="sideways")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1533.

## Summary
- Replaces the `variant=\"uparrow\"` stub in `sandwiched_renyi_conditional_entropy` with an optimization-based implementation.
- Uses `scipy.optimize.minimize` (L-BFGS-B) to minimize the sandwiched Rényi divergence $\widetilde D_\alpha(\rho_{AB} \parallel I_A \otimes \sigma_B)$ over density operators $\sigma_B$. The density operator is parameterized as $\sigma_B = A A^* / \mathrm{Tr}(A A^*)$ with a complex matrix $A$, which removes the positivity / trace constraints from the solver.
- Supported range: $\alpha \in [1/2, \infty)$, where the sandwiched Rényi divergence is jointly convex in $(\rho, \sigma)$ (Frank–Lieb) and the optimization is convex in $\sigma_B$. Below $1/2$ the API raises a clear `ValueError` rather than silently returning a non-global minimum. $\alpha=1$ continues to fall through to the conditional von Neumann entropy; $\alpha=0$ and $\alpha=\infty$ remain out of scope per the issue.
- Exposes `tol` and `max_iters` kwargs for solver control, and raises `RuntimeError` if the optimizer fails to converge.

## Test plan
- [x] Product states: uparrow recovers the Rényi entropy of subsystem $A$ (equal to downarrow).
- [x] Maximally entangled two-qubit state: uparrow equals $-1$.
- [x] $\alpha = 1$ falls through to the conditional von Neumann entropy.
- [x] Uparrow $\ge$ downarrow on a random mixed state.
- [x] Classical–quantum state: uparrow matches the closed-form reference computed from the mixture formula.
- [x] $\alpha < 1/2$ is rejected with a clear error message.
- [x] `uv run pytest toqito/state_props/tests/` — 368 passed, 6 skipped, 2 xfailed.
- [x] `uv run --group lint ruff check` — clean.