### PR TITLE
Route coverage badge through shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![build status](https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml/badge.svg)](https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml)
 [![doc status](https://img.shields.io/badge/docs-passing-brightgreen)](https://vprusso.github.io/toqito/)
-[![codecov](https://codecov.io/gh/vprusso/toqito/branch/master/graph/badge.svg)](https://app.codecov.io/gh/vprusso/toqito)
+[![codecov](https://img.shields.io/codecov/c/github/vprusso/toqito/master)](https://app.codecov.io/gh/vprusso/toqito)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4743211.svg)](https://doi.org/10.5281/zenodo.4743211)
 [![Downloads](https://static.pepy.tech/personalized-badge/toqito?style=platic&period=total&units=none&left_color=black&right_color=brightgreen&left_text=Downloads)](https://pepy.tech/project/toqito)
 [![Unitary Foundation](https://img.shields.io/badge/Supported%20By-Unitary%20Foundation-FFFF00.svg)](https://unitary.foundation)


### PR DESCRIPTION
## Summary
- The codecov-hosted badge URL (`codecov.io/gh/vprusso/toqito/branch/master/graph/badge.svg`) returns valid data (98%), but the badge has not been rendering on github.com.
- Most likely cause: a stale cached copy in GitHub's camo image proxy.
- Switch to `img.shields.io/codecov/c/github/vprusso/toqito/master`, which re-proxies through a new camo URL and matches the style of the other shields.io badges already in the README (build, docs, Unitary Foundation).
- Click-through still lands on `app.codecov.io/gh/vprusso/toqito`.

## Test plan
- [x] `curl https://img.shields.io/codecov/c/github/vprusso/toqito/master` → returns `coverage 98%`.
- [ ] Verify the badge renders on GitHub after merge.