### PR TITLE
Fix docs-deploy circular import in matrix_ops cone files

### DIFF
--- a/toqito/matrix_ops/geometric_mean.py
+++ b/toqito/matrix_ops/geometric_mean.py
@@ -4,7 +4,6 @@ import numpy as np
 from scipy.linalg import fractional_matrix_power, sqrtm
 
 from toqito.matrix_ops._cone_utils import _require_square_2d
-from toqito.matrix_props.is_positive_definite import is_positive_definite
 
 
 def geometric_mean(mat_a: np.ndarray, mat_b: np.ndarray, t: float) -> np.ndarray:
@@ -39,6 +38,8 @@ def geometric_mean(mat_a: np.ndarray, mat_b: np.ndarray, t: float) -> np.ndarray
       A matrix with the same shape as the inputs.
 
     """
+    from toqito.matrix_props.is_positive_definite import is_positive_definite  # noqa: PLC0415
+
     if mat_a.shape != mat_b.shape:
         raise ValueError("The matrices must be the same size.")
     _require_square_2d(mat_a, "The matrices")

--- a/toqito/matrix_ops/lieb_ando.py
+++ b/toqito/matrix_ops/lieb_ando.py
@@ -12,7 +12,6 @@ from toqito.matrix_ops._cone_utils import _require_2d, _require_square_2d
 from toqito.matrix_ops.geometric_mean_epi_cone import geometric_mean_epi_cone
 from toqito.matrix_ops.geometric_mean_hypo_cone import geometric_mean_hypo_cone
 from toqito.matrix_ops.trace_matrix_power import trace_matrix_power
-from toqito.matrix_props import is_positive_semidefinite
 
 
 def lieb_ando(
@@ -67,6 +66,8 @@ def lieb_ando(
         ```
 
     """
+    from toqito.matrix_props import is_positive_semidefinite  # noqa: PLC0415
+
     if not isinstance(mat_a, (np.ndarray, cvxpy.Expression)):
         raise TypeError("mat_a must be a numpy.ndarray or a cvxpy expression.")
     if not isinstance(mat_b, (np.ndarray, cvxpy.Expression)):

--- a/toqito/matrix_ops/trace_matrix_power.py
+++ b/toqito/matrix_ops/trace_matrix_power.py
@@ -10,7 +10,6 @@ from scipy.linalg import fractional_matrix_power
 from toqito.matrix_ops._cone_utils import _require_square_2d
 from toqito.matrix_ops.geometric_mean_epi_cone import geometric_mean_epi_cone
 from toqito.matrix_ops.geometric_mean_hypo_cone import geometric_mean_hypo_cone
-from toqito.matrix_props import is_positive_semidefinite
 
 
 def trace_matrix_power(
@@ -56,6 +55,8 @@ def trace_matrix_power(
         ```
 
     """
+    from toqito.matrix_props import is_positive_semidefinite  # noqa: PLC0415
+
     if not isinstance(mat_a, (np.ndarray, cvxpy.Expression)):
         raise TypeError("mat_a must be a numpy.ndarray or a cvxpy expression.")
 


### PR DESCRIPTION
## Summary

- Defer `from toqito.matrix_props...` imports inside the function bodies of `geometric_mean.py`, `trace_matrix_power.py`, and `lieb_ando.py` to break a circular import that has been silently failing the docs-deploy job since #1544.

## Why

The docs-deploy workflow has failed on master for both #1544 (2026-05-08) and #1547 (2026-05-11) with the same two errors:

- `TypeError: 'module' object is not callable` at `pusey_barrett_rudolph.py:49` (`e_0, e_1 = standard_basis(2)`)
- `ImportError: cannot import name 'pauli' from partially initialized module 'toqito.matrices.pauli'`

Both stem from one circular chain introduced when `geometric_mean` was wired into `matrix_ops/__init__.py`:

```
matrices/__init__.py
  -> matrices.pauli                       (line 11, before standard_basis on line 12)
    -> matrix_ops.tensor
      -> matrix_ops/__init__.py
        -> matrix_ops.geometric_mean
          -> matrix_props.is_positive_definite  (forces matrix_props/__init__.py)
            -> matrix_props.is_orthonormal
              -> state_props.is_mutually_orthogonal
                -> state_props/__init__ -> is_separable
                  -> channels.realignment
                    -> channels/__init__ -> channels.pauli_channel
                      -> matrices.pauli  ← CYCLE (partially-initialized)
```

The ImportError interrupts `matrices/__init__.py` before `standard_basis` is rebound from the submodule to the function, so callers that do `from toqito.matrices import standard_basis` end up with the module — hence "module is not callable" downstream.

The same fix-pattern as #1235 ("Fix: circular import with kraus to choi"): move the cross-package imports into the function body so module import order doesn't trip the cycle.

## Test plan

- [x] `uv run pytest toqito/matrix_ops/tests/test_geometric_mean.py toqito/matrix_ops/tests/test_trace_matrix_power.py toqito/matrix_ops/tests/test_lieb_ando.py` — 180 passed
- [x] `uv run ruff check` on the three changed files — clean (PLC0415 suppressed with explanation)
- [x] Repro check: `from toqito.matrices import standard_basis; standard_basis(2)` now returns the function and works; `pusey_barrett_rudolph(n=2, theta=0.5)` returns 4 states.
- [ ] CI matrix run + docs-deploy preview should now succeed end-to-end.