### PR TITLE
Break matrix_props -> state_props load-time cycle

### DIFF
--- a/toqito/matrix_props/__init__.py
+++ b/toqito/matrix_props/__init__.py
@@ -1,5 +1,8 @@
 """Matrix operations is a set of modules that implements various properties of matrices and vectors."""
 
+import sys
+from importlib import import_module
+
 from toqito.matrix_props.has_same_dimension import has_same_dimension
 from toqito.matrix_props.is_square import is_square
 from toqito.matrix_props.kp_norm import kp_norm
@@ -22,7 +25,11 @@ from toqito.matrix_props.is_commuting import is_commuting
 from toqito.matrix_props.is_projection import is_projection
 from toqito.matrix_props.is_unitary import is_unitary
 from toqito.matrix_props.majorizes import majorizes
-from toqito.matrix_props.sk_norm import sk_operator_norm
+# sk_operator_norm is loaded lazily below: sk_norm transitively imports state_props
+# (for schmidt_rank / sk_vector_norm), and several state_props modules import back
+# into matrix_ops, which creates a load-time cycle for any matrix_ops module that
+# imports matrix_props at top level. Deferring this single attribute keeps every
+# other matrix_props consumer free to do plain top-level imports.
 from toqito.matrix_props.is_block_positive import is_block_positive
 from toqito.matrix_props.trace_norm import trace_norm
 from toqito.matrix_props.is_diagonally_dominant import is_diagonally_dominant
@@ -43,3 +50,14 @@ from toqito.matrix_props.is_ldoi import is_ldoi
 from toqito.matrix_props.is_tight_frame import is_tight_frame
 from toqito.matrix_props.is_equiangular_tight_frame import is_equiangular_tight_frame
 from toqito.matrix_props.nonnegative_rank import nonnegative_rank
+
+_LAZY_ATTRS = {"sk_operator_norm": "sk_norm"}
+
+
+def __getattr__(name: str) -> object:
+    if name not in _LAZY_ATTRS:
+        raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+    module = import_module(f"{__name__}.{_LAZY_ATTRS[name]}")
+    attr = getattr(module, name)
+    setattr(sys.modules[__name__], name, attr)
+    return attr

--- a/toqito/matrix_props/is_block_positive.py
+++ b/toqito/matrix_props/is_block_positive.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from toqito.matrix_props.is_hermitian import is_hermitian
 from toqito.matrix_props.is_positive_semidefinite import is_positive_semidefinite
-from toqito.matrix_props.sk_norm import sk_operator_norm
 
 
 def is_block_positive(
@@ -88,6 +87,12 @@ def is_block_positive(
     #   c >= S(k)-norm of(c*I - X)
     # See Corollary 4.2.9. of `[@johnston2012norms].
     c_mat = op_norm * np.eye(dim_xy) - mat
+    # Deferred to call time: sk_norm pulls in state_props (schmidt_rank, sk_vector_norm),
+    # which transitively imports back into matrix_ops via the entropy modules. A top-level
+    # import here would re-introduce the matrix_props -> state_props -> matrix_ops cycle
+    # at package-load time.
+    from toqito.matrix_props.sk_norm import sk_operator_norm  # noqa: PLC0415
+
     lower_bound, upper_bound = sk_operator_norm(c_mat, k, dim_arr, op_norm, effort)
 
     # block positive

--- a/toqito/matrix_props/is_orthonormal.py
+++ b/toqito/matrix_props/is_orthonormal.py
@@ -2,8 +2,6 @@
 
 import numpy as np
 
-from toqito.state_props.is_mutually_orthogonal import is_mutually_orthogonal
-
 
 def is_orthonormal(vectors: list[np.ndarray]) -> bool:
     r"""Check if the vectors are orthonormal.
@@ -46,6 +44,4 @@ def is_orthonormal(vectors: list[np.ndarray]) -> bool:
         ```
 
     """
-    return is_mutually_orthogonal(vectors) and np.allclose(
-        np.dot(vectors, np.conjugate(vectors).T), np.eye(len(vectors))
-    )
+    return np.allclose(np.dot(vectors, np.conjugate(vectors).T), np.eye(len(vectors)))

--- a/toqito/matrix_props/tests/test_is_block_positive.py
+++ b/toqito/matrix_props/tests/test_is_block_positive.py
@@ -1,11 +1,10 @@
 """Test is_block_positive."""
 
-import sys
-
 import numpy as np
 import pytest
 from picos import partial_transpose
 
+import toqito.matrix_props.sk_norm as sk_module
 from toqito.channels import choi
 from toqito.matrix_props import is_block_positive
 from toqito.perms import swap, swap_operator
@@ -94,7 +93,6 @@ def test_dim_input(input_mat, input_dim):
 
 def test_is_block_positive_raises_when_bounds_inconclusive(monkeypatch):
     """If the S(k)-norm bounds don't decide k-block positivity, a clear RuntimeError is raised."""
-    bp_module = sys.modules["toqito.matrix_props.is_block_positive"]
 
     def _fake_sk_operator_norm(mat, k, dim, op_norm, effort):
         # Return bounds that straddle op_norm beyond the rtol band so both
@@ -102,7 +100,7 @@ def test_is_block_positive_raises_when_bounds_inconclusive(monkeypatch):
         # are false; this forces the inconclusive branch.
         return 0.5, 2.0
 
-    monkeypatch.setattr(bp_module, "sk_operator_norm", _fake_sk_operator_norm)
+    monkeypatch.setattr(sk_module, "sk_operator_norm", _fake_sk_operator_norm)
 
     with pytest.raises(RuntimeError, match="Unable to determine k-block positivity"):
         is_block_positive(swap_operator(3), k=1, rtol=1e-5)


### PR DESCRIPTION
## Summary

Breaks the `matrix_props → state_props → matrix_ops → matrix_props` load-time cycle that has forced every recent CVXQUAD-cone module (and now PR #1552) to defer its `matrix_props` import inside the function body with `# noqa: PLC0415`. After this, those modules can use plain top-level imports.

The cycle exists because `matrix_props/__init__.py` eagerly loads `is_orthonormal` and `is_block_positive`, both of which transitively reach back into `state_props` / `matrix_ops`:

- `is_orthonormal` imported `is_mutually_orthogonal` from `state_props` — a call that was already **redundant** (the `M == I` check that follows already implies pairwise orthogonality).
- `is_block_positive` imported `sk_operator_norm` at module top, which pulls in `sk_norm.py`, which imports `schmidt_rank` / `sk_vector_norm` from `state_props`. State_props in turn loads `quantum_relative_entropy` (added in #1552), which imports back into `matrix_ops.ln_quantum_entropy` — closing the cycle.

## Changes

- `toqito/matrix_props/is_orthonormal.py`: drop the redundant `is_mutually_orthogonal` call (and the import that came with it). The function now just checks `M @ M^H == I`, which is the actual definition of orthonormality.
- `toqito/matrix_props/__init__.py`: lazy-load `sk_operator_norm` via a module-level `__getattr__`. Public API (`from toqito.matrix_props import sk_operator_norm`) is unchanged.
- `toqito/matrix_props/is_block_positive.py`: defer the `sk_operator_norm` import to call time. Same value, no module-init back-edge into state_props. The deferred import carries a comment explaining the structural reason and a `# noqa: PLC0415`.
- `toqito/matrix_props/tests/test_is_block_positive.py`: update the monkeypatch target to `sk_norm.sk_operator_norm` (where the function actually lives) instead of `is_block_positive.sk_operator_norm` (which no longer rebinds, since the import is deferred).

## Test plan

- [x] `pytest toqito/matrix_props toqito/state_props` — passes
- [x] `pytest toqito/matrix_props/tests/test_is_block_positive.py` — passes
- [x] `ruff check toqito/matrix_props/` — clean
- [x] Fresh-process smoke: `import toqito.matrix_props` no longer eagerly loads `toqito.state_props` or `toqito.matrix_props.sk_norm`; sk_operator_norm still resolves to a callable function via both `toqito.matrix_props.sk_operator_norm` and `from toqito.matrix_props import sk_operator_norm`.
- [ ] Full CI matrix on PR.

After this lands, #1552 can hoist its currently-deferred `matrix_props` imports back to module top with no `# noqa`.
