### PR TITLE
Defer is_ldoi's channels import to fix docs-deploy cycle

### DIFF
--- a/toqito/matrix_props/is_ldoi.py
+++ b/toqito/matrix_props/is_ldoi.py
@@ -2,8 +2,6 @@
 
 import numpy as np
 
-from toqito.channels import ldot_channel
-
 
 def is_ldoi(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
     r"""Check if a quantum state is LDOI (Local Diagonal Orthogonal Invariant).
@@ -75,6 +73,13 @@ def is_ldoi(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
     """
     if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
         raise ValueError("Input matrix must be square.")
+
+    # Deferred to call time: toqito.channels eagerly loads pauli_channel, which
+    # imports from toqito.matrices.pauli. Since the latter transitively loads
+    # toqito.matrix_ops (for `tensor`), and matrix_ops triggers the entropy modules
+    # that come back to matrix_props, a top-level import here would re-introduce a
+    # matrices.pauli -> matrix_ops -> matrix_props -> channels -> matrices.pauli cycle.
+    from toqito.channels import ldot_channel  # noqa: PLC0415
 
     # A matrix is LDOI if Φ_O(mat) = mat
     ldot_result = ldot_channel(mat)


### PR DESCRIPTION
## Summary

Fixes the docs-deploy failure on master (https://github.com/vprusso/toqito/actions/runs/26533163567) after the entropy trilogy (#1552) landed. Same shape of cycle as #1559, different back-edge.

## The cycle

```
docs/.../intro_tutorial.py
  → matrices/__init__.py:12 → matrices.pauli
    → matrices.pauli:6      → matrix_ops (init load)
      → matrix_ops/__init__:26 → ln_quantum_entropy
        → ln_quantum_entropy:14 → matrix_props (init load)
          → matrix_props/__init__:49 → is_ldoi
            → is_ldoi:5     → from toqito.channels import ldot_channel
              → channels/__init__:9 → channels.pauli_channel
                → from toqito.matrices.pauli import pauli  ← pauli.py mid-loading
                  ImportError
```

Pytest tolerated this because its import ordering loaded `matrices.pauli` before `matrix_ops`; docs-deploy did not.

## Change

Defer the `from toqito.channels import ldot_channel` import in `is_ldoi.py` to call time, with a `# noqa: PLC0415` and a comment describing the cycle. Same pattern as `is_block_positive`'s `sk_operator_norm` deferral in #1559.

## Test plan

- [x] Repro: `python3 -c "from toqito.matrices import standard_basis"` (the docs entry path) — now succeeds.
- [x] `pytest toqito/matrix_props/tests/test_is_ldoi.py` — passes.
- [x] `ruff check toqito/matrix_props/is_ldoi.py` — clean.
- [x] Broader import sanity: `from toqito.matrices import standard_basis, pauli` + `from toqito.channels import pauli_channel, ldot_channel` + `from toqito.matrix_props import is_ldoi, is_block_positive, sk_operator_norm` + `is_ldoi(np.eye(4))` returns `True`.
- [ ] Full CI on PR; docs-deploy re-run on master after merge.
