### PR TITLE
Add state exclusion to the symmetric extension hierarchy SDP

### DIFF
--- a/toqito/state_opt/symmetric_extension_hierarchy.py
+++ b/toqito/state_opt/symmetric_extension_hierarchy.py
@@ -14,6 +14,7 @@ def symmetric_extension_hierarchy(
     probs: list[float] | None = None,
     level: int = 2,
     dim: int | list[int] | None = None,
+    objective: str = "distinguish",
 ) -> float:
     r"""Compute optimal value of the symmetric extension hierarchy SDP [@navascues2008pure].
 
@@ -58,14 +59,35 @@ def symmetric_extension_hierarchy(
         \end{equation}
     \]
 
+    For state **exclusion**, set `objective="exclude"`. The feasible region is identical; only the
+    objective is *minimized* rather than maximized,
+
+    \[
+        \begin{equation}
+            \text{minimize:} \quad \sum_{k=1}^N p_k \langle \rho_k, \mu(k) \rangle
+            \quad \text{subject to the same constraints.}
+        \end{equation}
+    \]
+
+    At level 1 this recovers the PPT exclusion value, and as the level increases it gives a
+    non-decreasing lower bound on the separable exclusion error -- in contrast to the
+    distinguishability case, where the hierarchy yields an upper bound that decreases with the
+    level. In the implementation, `meas[k]` is the measurement operator \(\mu(k)\), `x_var[k]` is
+    its symmetric extension \(X_k\), and `sym` is the symmetric projector \(\Pi\).
+
     Args:
         states: A list of states provided as either matrices or vectors.
         probs: Respective list of probabilities each state is selected.
         level: Level of the hierarchy to compute.
         dim: The default has both subsystems of equal dimension.
+        objective: Either `"distinguish"` (default) to maximize the success probability of state
+            distinguishability, or `"exclude"` to minimize the error probability of state
+            exclusion. The constraints are identical for both objectives.
 
     Returns:
-        The optimal probability of the symmetric extension hierarchy SDP for level `level`.
+        The optimal value of the symmetric extension hierarchy SDP at level `level`: the
+        distinguishability value for `objective="distinguish"`, or the exclusion error for
+        `objective="exclude"`.
 
     Examples:
         It is known from [@cosentino2015quantum] that distinguishing three Bell states along with a resource
@@ -130,12 +152,35 @@ def symmetric_extension_hierarchy(
         print(f"True separable value: {np.around(true_sep_val, decimals=2)}")
         ```
 
+        The exclusion analogue is selected with `objective="exclude"`. Here three
+        non-antidistinguishable two-qubit states have a strictly positive separable exclusion
+        error already at the first level of the hierarchy.
+
+        ```python exec="1" source="above" result="text"
+        from toqito.state_opt import symmetric_extension_hierarchy
+        import numpy as np
+
+        # Three states (computational basis ordered as |00>, |01>, |10>, |11>).
+        vecs = [
+        np.array([[0], [1], [1], [1]], dtype=complex),
+        np.array([[0], [0], [1], [1]], dtype=complex),
+        np.array([[1], [0], [1], [1]], dtype=complex),
+        ]
+        states = [v @ v.conj().T / (v.conj().T @ v).real.item() for v in vecs]
+
+        # The first level of the hierarchy equals the PPT exclusion error.
+        val = symmetric_extension_hierarchy(states=states, level=1, objective="exclude")
+        print(f"Separable exclusion error (level 1): {np.around(val, decimals=2)}")
+        ```
+
     """
     obj_func = []
     meas = []
     x_var = []
     constraints = []
 
+    if objective not in ("distinguish", "exclude"):
+        raise ValueError("Argument `objective` must be either 'distinguish' or 'exclude'.")
     if not states:
         raise ValueError("At least one state must be provided.")
     if probs is None:
@@ -186,10 +231,14 @@ def symmetric_extension_hierarchy(
 
     constraints.append(sum(meas) == np.identity(dim_xy))
 
-    objective = cvxpy.Maximize(cvxpy.real(sum(obj_func)))
+    # For distinguishability we maximize the success probability; for exclusion we
+    # minimize the error probability. The feasible region (symmetric extension + PPT
+    # constraints) is identical in both cases.
+    obj_expr = cvxpy.real(sum(obj_func))
+    problem_objective = cvxpy.Maximize(obj_expr) if objective == "distinguish" else cvxpy.Minimize(obj_expr)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="Constraint.*subexpressions")
-        problem = cvxpy.Problem(objective, constraints)
+        problem = cvxpy.Problem(problem_objective, constraints)
         sol_default = problem.solve()
 
     return sol_default

--- a/toqito/state_opt/symmetric_extension_hierarchy.py
+++ b/toqito/state_opt/symmetric_extension_hierarchy.py
@@ -162,11 +162,11 @@ def symmetric_extension_hierarchy(
 
         # Three states (computational basis ordered as |00>, |01>, |10>, |11>).
         vecs = [
-        np.array([[0], [1], [1], [1]], dtype=complex),
-        np.array([[0], [0], [1], [1]], dtype=complex),
-        np.array([[1], [0], [1], [1]], dtype=complex),
+            np.array([[0], [1], [1], [1]], dtype=complex),
+            np.array([[0], [0], [1], [1]], dtype=complex),
+            np.array([[1], [0], [1], [1]], dtype=complex),
         ]
-        states = [v @ v.conj().T / (v.conj().T @ v).real.item() for v in vecs]
+        states = [v @ v.conj().T / float(np.linalg.norm(v) ** 2) for v in vecs]
 
         # The first level of the hierarchy equals the PPT exclusion error.
         val = symmetric_extension_hierarchy(states=states, level=1, objective="exclude")

--- a/toqito/state_opt/tests/test_symmetric_extension_hierarchy.py
+++ b/toqito/state_opt/tests/test_symmetric_extension_hierarchy.py
@@ -1,8 +1,10 @@
 """Test symmetric_extension_hierarchy."""
 
+import cvxpy
 import numpy as np
 import pytest
 
+from toqito.matrix_ops import partial_transpose
 from toqito.perms import swap
 from toqito.state_opt import symmetric_extension_hierarchy
 from toqito.states import basis, bell, werner
@@ -165,3 +167,73 @@ def test_symmetric_extension_hierarchy_scalar_dim_must_divide():
     states = [bell(0) @ bell(0).conj().T]
     with pytest.raises(ValueError, match="evenly divide"):
         symmetric_extension_hierarchy(states=states, probs=[1.0], level=1, dim=3)
+
+
+def _gap_ensemble():
+    """Return a fixed two-qubit ensemble whose separable exclusion error exceeds the global one.
+
+    The three (unnormalized) pure states, in the computational basis ordered as
+    (|00>, |01>, |10>, |11>), are |01> + |10> + |11>, |10> + |11>, and |00> + |10> + |11>. They
+    are not antidistinguishable, so the exclusion error is strictly positive, and restricting to
+    PPT/separable measurements makes it strictly larger than the global exclusion error.
+    """
+    vecs = [
+        np.array([[0], [1], [1], [1]], dtype=complex),
+        np.array([[0], [0], [1], [1]], dtype=complex),
+        np.array([[1], [0], [1], [1]], dtype=complex),
+    ]
+    return [v @ v.conj().T / (v.conj().T @ v).real.item() for v in vecs]
+
+
+def _direct_exclusion_sdp(states, ppt=False, dim=(2, 2)):
+    """Minimal-error state-exclusion probability via a direct SDP (reference value).
+
+    With `ppt=True` the measurement operators are additionally constrained to be PPT, which
+    yields the value the level-1 symmetric-extension hierarchy should reproduce.
+    """
+    n, d = len(states), states[0].shape[0]
+    meas = [cvxpy.Variable((d, d), hermitian=True) for _ in range(n)]
+    constraints = [m >> 0 for m in meas] + [sum(meas) == np.identity(d)]
+    if ppt:
+        constraints += [partial_transpose(m, [0], list(dim)) >> 0 for m in meas]
+    obj = cvxpy.Minimize(cvxpy.real(sum(cvxpy.trace(states[k] @ meas[k]) for k in range(n)) / n))
+    return cvxpy.Problem(obj, constraints).solve()
+
+
+def test_exclusion_orthogonal_states_perfectly_excludable():
+    """Orthogonal Bell states are perfectly antidistinguishable: the exclusion error is zero."""
+    states = [bell(i) @ bell(i).conj().T for i in range(4)]
+    res = symmetric_extension_hierarchy(states=states, probs=None, level=1, objective="exclude")
+    np.testing.assert_allclose(res, 0.0, atol=1e-5)
+
+
+def test_exclusion_level_one_matches_ppt_value():
+    """Level 1 of the exclusion hierarchy equals the PPT state-exclusion value."""
+    states = _gap_ensemble()
+    res = symmetric_extension_hierarchy(states=states, probs=None, level=1, objective="exclude")
+    np.testing.assert_allclose(res, _direct_exclusion_sdp(states, ppt=True), atol=1e-4)
+
+
+def test_exclusion_separable_strictly_worse_than_global():
+    """The separable (level-1/PPT) exclusion error is strictly larger than the global one."""
+    states = _gap_ensemble()
+    sep = symmetric_extension_hierarchy(states=states, probs=None, level=1, objective="exclude")
+    glob = _direct_exclusion_sdp(states, ppt=False)
+    np.testing.assert_equal(sep > glob + 1e-2, True)
+
+
+def test_exclusion_hierarchy_is_monotonic():
+    """Higher levels give a non-decreasing lower bound on the separable exclusion error."""
+    states = _gap_ensemble()
+    lvl_1 = symmetric_extension_hierarchy(states=states, probs=None, level=1, objective="exclude")
+    lvl_2 = symmetric_extension_hierarchy(states=states, probs=None, level=2, objective="exclude")
+    # For this ensemble the PPT relaxation is already tight, so level 2 coincides with level 1 to
+    # solver precision; the test asserts only that the hierarchy never decreases with the level.
+    np.testing.assert_equal(lvl_2 >= lvl_1 - 1e-5, True)
+
+
+def test_invalid_objective_raises():
+    """An unknown `objective` value raises a ValueError."""
+    states = [bell(0) @ bell(0).conj().T, bell(1) @ bell(1).conj().T]
+    with pytest.raises(ValueError, match="objective"):
+        symmetric_extension_hierarchy(states=states, level=1, objective="antidistinguish")

--- a/toqito/state_opt/tests/test_symmetric_extension_hierarchy.py
+++ b/toqito/state_opt/tests/test_symmetric_extension_hierarchy.py
@@ -182,7 +182,7 @@ def _gap_ensemble():
         np.array([[0], [0], [1], [1]], dtype=complex),
         np.array([[1], [0], [1], [1]], dtype=complex),
     ]
-    return [v @ v.conj().T / (v.conj().T @ v).real.item() for v in vecs]
+    return [v @ v.conj().T / float(np.linalg.norm(v) ** 2) for v in vecs]
 
 
 def _direct_exclusion_sdp(states, ppt=False, dim=(2, 2)):
@@ -222,13 +222,48 @@ def test_exclusion_separable_strictly_worse_than_global():
     np.testing.assert_equal(sep > glob + 1e-2, True)
 
 
-def test_exclusion_hierarchy_is_monotonic():
-    """Higher levels give a non-decreasing lower bound on the separable exclusion error."""
+def test_exclusion_three_bell_with_resource_state():
+    """Three Bell states tensored with a resource state are perfectly excludable.
+
+    This is the ensemble from the distinguishability example. The states are mutually orthogonal,
+    so they are perfectly antidistinguishable (exclusion error 0) even though PPT measurements
+    cannot perfectly distinguish them (the distinguishability value is well below 1). This makes
+    the exclusion and distinguishability hierarchy values directly comparable on a known example.
+    """
+    e_0, e_1 = basis(2, 0), basis(2, 1)
+    e_00, e_11 = np.kron(e_0, e_0), np.kron(e_1, e_1)
+    eps = 1 / 2
+    eps_state = np.sqrt((1 + eps) / 2) * e_00 + np.sqrt((1 - eps) / 2) * e_11
+    eps_dm = eps_state @ eps_state.conj().T
+
+    states = [
+        np.kron(bell(0) @ bell(0).conj().T, eps_dm),
+        np.kron(bell(1) @ bell(1).conj().T, eps_dm),
+        np.kron(bell(2) @ bell(2).conj().T, eps_dm),
+    ]
+    states = [
+        swap(states[0], [2, 3], [2, 2, 2, 2]),
+        swap(states[1], [2, 3], [2, 2, 2, 2]),
+        swap(states[2], [2, 3], [2, 2, 2, 2]),
+    ]
+
+    exclude = symmetric_extension_hierarchy(states=states, probs=None, level=1, objective="exclude")
+    distinguish = symmetric_extension_hierarchy(states=states, probs=None, level=1)
+    np.testing.assert_allclose(exclude, 0.0, atol=1e-4)
+    np.testing.assert_equal(distinguish > 0.9, True)
+
+
+def test_exclusion_level_two_does_not_decrease():
+    """Level 2 of the exclusion hierarchy is at least level 1 (the bound never decreases).
+
+    For this ensemble the PPT relaxation is already tight, so level 2 coincides with level 1 to
+    solver precision; a strict level-2 > level-1 separation would require an ensemble where the
+    separable exclusion value lies strictly above the PPT one, which is hard to realize at this
+    dimension. The test therefore only asserts the non-decreasing direction of the hierarchy.
+    """
     states = _gap_ensemble()
     lvl_1 = symmetric_extension_hierarchy(states=states, probs=None, level=1, objective="exclude")
     lvl_2 = symmetric_extension_hierarchy(states=states, probs=None, level=2, objective="exclude")
-    # For this ensemble the PPT relaxation is already tight, so level 2 coincides with level 1 to
-    # solver precision; the test asserts only that the hierarchy never decreases with the level.
     np.testing.assert_equal(lvl_2 >= lvl_1 - 1e-5, True)
 
 


### PR DESCRIPTION
Closes #1523.

`symmetric_extension_hierarchy` previously computed only upper bounds on the separable (SEP) value for state *distinguishability*. This adds an `objective` parameter so the same hierarchy can also bound state *exclusion*.

With `objective="exclude"` the SDP keeps the identical feasible region (the symmetric-extension and PPT constraints are unchanged) and only flips the objective from `Maximize` to `Minimize`, which matches the global exclusion SDP in `state_exclusion.py`. At level 1 this equals the PPT exclusion value, and the bound is non-decreasing in the level (it converges to the separable value from below), mirroring the distinguishability hierarchy that converges from above.

`objective` defaults to `"distinguish"`, so existing behaviour is unchanged.

The docstring includes the exclusion SDP formulation, the monotonicity direction, the mapping from the thesis notation to the code variables (`mu(k)` -> `meas[k]`, `X_k` -> `x_var[k]`, the symmetric projector -> `sym`), and a runnable worked example.

### Tests

- level 1 of the exclusion hierarchy equals a directly computed PPT exclusion SDP;
- monotonicity in the level;
- a case where separable exclusion is strictly worse than global exclusion, with the gap certified independently by a direct PPT-vs-global comparison (so it is not a solver artifact);
- orthogonal states are perfectly excludable (value 0);
- an invalid `objective` raises a clear error.

All new and existing tests pass, and `ruff check`/`ruff format` are clean.

---

AI disclosure: I used Claude Code to help implement and test this change. I reviewed, ran, and verified all of the code and tests myself.
