### PR TITLE
Add one-way LOCC state exclusion via see-saw optimization

### DIFF
--- a/toqito/state_opt/__init__.py
+++ b/toqito/state_opt/__init__.py
@@ -7,6 +7,7 @@ from toqito.state_opt.optimal_clone import optimal_clone
 from toqito.matrix_props import has_same_dimension as _has_same_dimension  # noqa: F401
 from toqito.state_opt.state_distinguishability import state_distinguishability
 from toqito.state_opt.state_exclusion import state_exclusion
+from toqito.state_opt.state_exclusion_locc import state_exclusion_locc
 from toqito.state_opt.npa_hierarchy import npa_constraints, bell_npa_constraints
 from toqito.state_opt.symmetric_extension_hierarchy import symmetric_extension_hierarchy
 from toqito.state_opt.bell_inequality_max import bell_inequality_max, bell_inequality_max_qubits

--- a/toqito/state_opt/state_exclusion_locc.py
+++ b/toqito/state_opt/state_exclusion_locc.py
@@ -10,7 +10,7 @@ from toqito.rand import random_povm
 def state_exclusion_locc(
     states: list[np.ndarray],
     probs: list[float] | None = None,
-    dims: list[int] | None = None,
+    dim: list[int] | None = None,
     *,
     num_alice_outcomes: int | None = None,
     reps: int = 5,
@@ -67,7 +67,7 @@ def state_exclusion_locc(
         states: Bipartite states, each given as a density matrix (or a vector, which is converted
             to a density matrix) on the \(\mathcal{H}_A \otimes \mathcal{H}_B\) system.
         probs: Respective selection probabilities. Defaults to the uniform distribution.
-        dims: The two subsystem dimensions `[dim_A, dim_B]`. Their product must equal the dimension
+        dim: The two subsystem dimensions `[dim_A, dim_B]`. Their product must equal the dimension
             of each state.
         num_alice_outcomes: Number of measurement outcomes available to Alice. Defaults to the
             number of states. Allowing more outcomes can only tighten (lower) the value.
@@ -89,21 +89,21 @@ def state_exclusion_locc(
         import numpy as np
 
         vecs = [
-        np.array([[0], [1], [1], [1]], dtype=complex),
-        np.array([[0], [0], [1], [1]], dtype=complex),
-        np.array([[1], [0], [1], [1]], dtype=complex),
+            np.array([[0], [1], [1], [1]], dtype=complex),
+            np.array([[0], [0], [1], [1]], dtype=complex),
+            np.array([[1], [0], [1], [1]], dtype=complex),
         ]
-        states = [v @ v.conj().T / (v.conj().T @ v).real.item() for v in vecs]
+        states = [v @ v.conj().T / float(np.linalg.norm(v) ** 2) for v in vecs]
 
-        val = state_exclusion_locc(states, dims=[2, 2], reps=3, seed=1)
+        val = state_exclusion_locc(states, dim=[2, 2], reps=3, seed=1)
         print(f"One-way LOCC exclusion error: {np.around(val, decimals=2)}")
         ```
 
     """
     if not states:
         raise ValueError("At least one state must be provided.")
-    if dims is None or len(dims) != 2:
-        raise ValueError("Argument `dims` must be a list `[dim_A, dim_B]` of the two subsystem dimensions.")
+    if dim is None or len(dim) != 2:
+        raise ValueError("Argument `dim` must be a list `[dim_A, dim_B]` of the two subsystem dimensions.")
 
     states = [to_density_matrix(state) for state in states]
     num_states = len(states)
@@ -112,9 +112,9 @@ def state_exclusion_locc(
     if not np.isclose(sum(probs), 1):
         raise ValueError("Probabilities must sum to 1.")
 
-    dim_a, dim_b = int(dims[0]), int(dims[1])
+    dim_a, dim_b = int(dim[0]), int(dim[1])
     if states[0].shape[0] != dim_a * dim_b:
-        raise ValueError("The product of `dims` must equal the dimension of the states.")
+        raise ValueError("The product of `dim` must equal the dimension of the states.")
     num_a = num_states if num_alice_outcomes is None else num_alice_outcomes
 
     best = float("inf")

--- a/toqito/state_opt/state_exclusion_locc.py
+++ b/toqito/state_opt/state_exclusion_locc.py
@@ -1,0 +1,189 @@
+"""Computes state exclusion under one-way LOCC via see-saw optimization."""
+
+import cvxpy
+import numpy as np
+
+from toqito.matrix_ops import partial_trace, to_density_matrix
+from toqito.rand import random_povm
+
+
+def state_exclusion_locc(
+    states: list[np.ndarray],
+    probs: list[float] | None = None,
+    dims: list[int] | None = None,
+    *,
+    num_alice_outcomes: int | None = None,
+    reps: int = 5,
+    tol: float = 1e-7,
+    max_iters: int = 100,
+    seed: int | None = None,
+) -> float:
+    r"""Compute state exclusion under one-way LOCC via a see-saw optimization.
+
+    The *state exclusion* problem asks Bob to identify a state that was **not** sent, incurring an
+    error whenever his guess coincides with the prepared state. Here the measurement is restricted
+    to **one-way local operations and classical communication (LOCC)**: for a bipartite ensemble
+    \(\{(p_k, \rho_k)\}\) on \(\mathcal{H}_A \otimes \mathcal{H}_B\), Alice measures her subsystem
+    with a POVM \(\{A_a\}\), communicates the outcome \(a\) to Bob, who then applies a conditional
+    POVM \(\{B^a_k\}\) and announces the excluded index \(k\). The induced global measurement
+    operator for guessing \(k\) is \(M_k = \sum_a A_a \otimes B^a_k\), and the error probability is
+
+    \[
+        \sum_{k} p_k \sum_a \operatorname{Tr}\!\left[(A_a \otimes B^a_k)\, \rho_k\right].
+    \]
+
+    Minimizing this jointly over \(\{A_a\}\) and \(\{B^a_k\}\) is bilinear, so it is solved by a
+    see-saw (alternating optimization), exactly as in
+    [`NonlocalGame.quantum_value_lower_bound`][toqito.nonlocal_games.nonlocal_game.NonlocalGame].
+    Each half is a semidefinite program:
+
+    With Alice's POVM \(\{A_a\}\) fixed, Bob's conditional ensemble is
+    \(\sigma^a_k = \operatorname{Tr}_A[(A_a \otimes \mathbb{I}_B)\rho_k]\) and he solves, for every
+    outcome \(a\),
+
+    \[
+        \begin{aligned}
+            \text{minimize:} \quad & \sum_k p_k \operatorname{Tr}[B^a_k\, \sigma^a_k], \\
+            \text{subject to:} \quad & \sum_k B^a_k = \mathbb{I}_B, \qquad B^a_k \succeq 0.
+        \end{aligned}
+    \]
+
+    With Bob's POVMs fixed, write \(\tau_a = \sum_k p_k \operatorname{Tr}_B[(\mathbb{I}_A \otimes
+    B^a_k)\rho_k]\); Alice solves
+
+    \[
+        \begin{aligned}
+            \text{minimize:} \quad & \sum_a \operatorname{Tr}[A_a\, \tau_a], \\
+            \text{subject to:} \quad & \sum_a A_a = \mathbb{I}_A, \qquad A_a \succeq 0.
+        \end{aligned}
+    \]
+
+    Each returned value is the error of a concrete one-way LOCC strategy, hence an upper bound on
+    the optimal one-way LOCC exclusion error and at least the global exclusion error
+    (`global` \(\le\) `PPT` \(\le\) `LOCC`). Because the see-saw can converge to a local optimum,
+    the procedure is restarted from `reps` random initial POVMs and the smallest value is returned.
+
+    Args:
+        states: Bipartite states, each given as a density matrix (or a vector, which is converted
+            to a density matrix) on the \(\mathcal{H}_A \otimes \mathcal{H}_B\) system.
+        probs: Respective selection probabilities. Defaults to the uniform distribution.
+        dims: The two subsystem dimensions `[dim_A, dim_B]`. Their product must equal the dimension
+            of each state.
+        num_alice_outcomes: Number of measurement outcomes available to Alice. Defaults to the
+            number of states. Allowing more outcomes can only tighten (lower) the value.
+        reps: Number of random restarts of the see-saw. Defaults to 5.
+        tol: Convergence tolerance on the error decrease between iterations.
+        max_iters: Maximum number of see-saw iterations per restart.
+        seed: Optional base seed for the random initial POVMs, for reproducibility. Restart `r`
+            uses ``seed + r``.
+
+    Returns:
+        The smallest one-way LOCC exclusion error found across the random restarts.
+
+    Examples:
+        Three non-antidistinguishable two-qubit states whose separable (and hence LOCC) exclusion
+        error is strictly larger than the global one.
+
+        ```python exec="1" source="above" result="text"
+        from toqito.state_opt import state_exclusion_locc
+        import numpy as np
+
+        vecs = [
+        np.array([[0], [1], [1], [1]], dtype=complex),
+        np.array([[0], [0], [1], [1]], dtype=complex),
+        np.array([[1], [0], [1], [1]], dtype=complex),
+        ]
+        states = [v @ v.conj().T / (v.conj().T @ v).real.item() for v in vecs]
+
+        val = state_exclusion_locc(states, dims=[2, 2], reps=3, seed=1)
+        print(f"One-way LOCC exclusion error: {np.around(val, decimals=2)}")
+        ```
+
+    """
+    if not states:
+        raise ValueError("At least one state must be provided.")
+    if dims is None or len(dims) != 2:
+        raise ValueError("Argument `dims` must be a list `[dim_A, dim_B]` of the two subsystem dimensions.")
+
+    states = [to_density_matrix(state) for state in states]
+    num_states = len(states)
+    if probs is None:
+        probs = [1 / num_states] * num_states
+    if not np.isclose(sum(probs), 1):
+        raise ValueError("Probabilities must sum to 1.")
+
+    dim_a, dim_b = int(dims[0]), int(dims[1])
+    if states[0].shape[0] != dim_a * dim_b:
+        raise ValueError("The product of `dims` must equal the dimension of the states.")
+    num_a = num_states if num_alice_outcomes is None else num_alice_outcomes
+
+    best = float("inf")
+    for rep in range(reps):
+        rep_seed = None if seed is None else seed + rep
+        povm = random_povm(dim_a, 1, num_a, seed=rep_seed)
+        alice = [povm[:, :, 0, a] for a in range(num_a)]
+
+        prev = float("inf")
+        current = float("inf")
+        for _ in range(max_iters):
+            bob = _optimize_bob(states, probs, dim_a, dim_b, alice)
+            alice = _optimize_alice(states, probs, dim_a, dim_b, bob, num_a)
+            current = _locc_error(states, probs, alice, bob, num_a)
+            if abs(prev - current) < tol:
+                break
+            prev = current
+
+        best = min(best, current)
+
+    return best
+
+
+def _optimize_bob(states, probs, dim_a, dim_b, alice):
+    """Fix Alice's POVM and optimize Bob's conditional exclusion POVMs."""
+    num_a, num_states = len(alice), len(states)
+    bob = {(a, k): cvxpy.Variable((dim_b, dim_b), hermitian=True) for a in range(num_a) for k in range(num_states)}
+
+    constraints = []
+    error = 0
+    for a in range(num_a):
+        conditional = [
+            partial_trace(np.kron(alice[a], np.identity(dim_b)) @ states[k], [0], [dim_a, dim_b])
+            for k in range(num_states)
+        ]
+        for k in range(num_states):
+            constraints.append(bob[a, k] >> 0)
+            error += probs[k] * cvxpy.trace(bob[a, k] @ conditional[k])
+        constraints.append(sum(bob[a, k] for k in range(num_states)) == np.identity(dim_b))
+
+    cvxpy.Problem(cvxpy.Minimize(cvxpy.real(error)), constraints).solve()
+    return {key: np.array(var.value) for key, var in bob.items()}
+
+
+def _optimize_alice(states, probs, dim_a, dim_b, bob, num_a):
+    """Fix Bob's conditional POVMs and optimize Alice's POVM."""
+    num_states = len(states)
+    alice = [cvxpy.Variable((dim_a, dim_a), hermitian=True) for _ in range(num_a)]
+
+    constraints = [a >> 0 for a in alice]
+    constraints.append(sum(alice) == np.identity(dim_a))
+
+    error = 0
+    for a in range(num_a):
+        tau = sum(
+            probs[k] * partial_trace(np.kron(np.identity(dim_a), bob[a, k]) @ states[k], [1], [dim_a, dim_b])
+            for k in range(num_states)
+        )
+        error += cvxpy.trace(alice[a] @ tau)
+
+    cvxpy.Problem(cvxpy.Minimize(cvxpy.real(error)), constraints).solve()
+    return [np.array(a.value) for a in alice]
+
+
+def _locc_error(states, probs, alice, bob, num_a):
+    """Evaluate the exclusion error of a concrete one-way LOCC strategy."""
+    num_states = len(states)
+    total = 0.0
+    for k in range(num_states):
+        guess_k = sum(np.kron(alice[a], bob[a, k]) for a in range(num_a))
+        total += probs[k] * np.real(np.trace(guess_k @ states[k]))
+    return float(total)

--- a/toqito/state_opt/tests/test_state_exclusion_locc.py
+++ b/toqito/state_opt/tests/test_state_exclusion_locc.py
@@ -93,3 +93,25 @@ def test_requires_states():
     """An empty list of states raises a ValueError."""
     with pytest.raises(ValueError, match="At least one state"):
         state_exclusion_locc([], dim=[2, 2])
+
+
+def test_dim_product_must_match_states():
+    """A `dim` whose product is not the state dimension raises a ValueError."""
+    states = [_dm((1, 0, 0, 0)), _dm((0, 0, 0, 1))]  # dimension 4
+    with pytest.raises(ValueError, match="product"):
+        state_exclusion_locc(states, dim=[2, 3])  # 2 * 3 = 6 != 4
+
+
+def test_runs_without_seed():
+    """The see-saw runs with the default (None) seed."""
+    e_0, e_1 = np.array([1, 0]), np.array([0, 1])
+    states = [_dm(np.kron(e_0, e_0)), _dm(np.kron(e_1, e_1)), _dm(np.kron(e_0, e_1))]
+    val = state_exclusion_locc(states, dim=[2, 2], reps=1)
+    np.testing.assert_allclose(val, 0.0, atol=1e-4)
+
+
+def test_custom_num_alice_outcomes():
+    """`num_alice_outcomes` is accepted; more outcomes cannot raise the value."""
+    states = [_dm(v) for v in _GAP_VECS]
+    val = state_exclusion_locc(states, dim=[2, 2], num_alice_outcomes=4, reps=2, seed=0)
+    np.testing.assert_equal(val >= -1e-6, True)

--- a/toqito/state_opt/tests/test_state_exclusion_locc.py
+++ b/toqito/state_opt/tests/test_state_exclusion_locc.py
@@ -12,16 +12,16 @@ from toqito.states import domino
 def _dm(vec):
     """Build a normalized density matrix from a (possibly unnormalized) vector."""
     v = np.array(vec, dtype=complex).reshape(-1, 1)
-    return v @ v.conj().T / (v.conj().T @ v).real.item()
+    return v @ v.conj().T / float(np.linalg.norm(v) ** 2)
 
 
-def _direct_exclusion_sdp(states, ppt=False, dims=(2, 2)):
+def _direct_exclusion_sdp(states, ppt=False, dim=(2, 2)):
     """Global (or PPT) minimal-error state-exclusion probability via a direct SDP (reference)."""
     n, d = len(states), states[0].shape[0]
     meas = [cvxpy.Variable((d, d), hermitian=True) for _ in range(n)]
     constraints = [m >> 0 for m in meas] + [sum(meas) == np.identity(d)]
     if ppt:
-        constraints += [partial_transpose(m, [0], list(dims)) >> 0 for m in meas]
+        constraints += [partial_transpose(m, [0], list(dim)) >> 0 for m in meas]
     obj = cvxpy.Minimize(cvxpy.real(sum(cvxpy.trace(states[k] @ meas[k]) for k in range(n)) / n))
     return cvxpy.Problem(obj, constraints).solve()
 
@@ -35,14 +35,14 @@ def test_product_orthogonal_states_match_global():
     """Orthogonal product states are perfectly LOCC-excludable (error ~ 0, matching global)."""
     e_0, e_1 = np.array([1, 0]), np.array([0, 1])
     states = [_dm(np.kron(e_0, e_0)), _dm(np.kron(e_1, e_1)), _dm(np.kron(e_0, e_1))]
-    val = state_exclusion_locc(states, dims=[2, 2], reps=3, seed=0)
+    val = state_exclusion_locc(states, dim=[2, 2], reps=3, seed=0)
     np.testing.assert_allclose(val, 0.0, atol=1e-4)
 
 
 def test_locc_never_below_global():
     """The one-way LOCC exclusion error is never below the global exclusion error."""
     states = [_dm(v) for v in _GAP_VECS]
-    locc = state_exclusion_locc(states, dims=[2, 2], reps=3, seed=1)
+    locc = state_exclusion_locc(states, dim=[2, 2], reps=3, seed=1)
     glob = _direct_exclusion_sdp(states, ppt=False)
     np.testing.assert_equal(locc >= glob - 1e-4, True)
 
@@ -50,7 +50,7 @@ def test_locc_never_below_global():
 def test_locc_strictly_worse_than_global():
     """One-way LOCC exclusion is strictly worse than global; PPT > global certifies the gap."""
     states = [_dm(v) for v in _GAP_VECS]
-    locc = state_exclusion_locc(states, dims=[2, 2], reps=3, seed=1)
+    locc = state_exclusion_locc(states, dim=[2, 2], reps=3, seed=1)
     glob = _direct_exclusion_sdp(states, ppt=False)
     ppt = _direct_exclusion_sdp(states, ppt=True)
     # PPT exclusion is a certified lower bound on LOCC exclusion, so PPT > global proves the
@@ -62,8 +62,8 @@ def test_locc_strictly_worse_than_global():
 def test_reproducible_with_seed():
     """A fixed seed yields a reproducible value."""
     states = [_dm(v) for v in _GAP_VECS]
-    first = state_exclusion_locc(states, dims=[2, 2], reps=2, seed=7)
-    second = state_exclusion_locc(states, dims=[2, 2], reps=2, seed=7)
+    first = state_exclusion_locc(states, dim=[2, 2], reps=2, seed=7)
+    second = state_exclusion_locc(states, dim=[2, 2], reps=2, seed=7)
     np.testing.assert_allclose(first, second, atol=1e-9)
 
 
@@ -71,14 +71,14 @@ def test_reproducible_with_seed():
 def test_domino_states_are_locc_excludable():
     """Domino states are not LOCC-distinguishable, yet they are perfectly LOCC-excludable."""
     states = [_dm(domino(i)) for i in range(9)]
-    val = state_exclusion_locc(states, dims=[3, 3], reps=2, seed=0)
+    val = state_exclusion_locc(states, dim=[3, 3], reps=2, seed=0)
     np.testing.assert_allclose(val, 0.0, atol=1e-4)
 
 
-def test_requires_dims():
-    """Omitting `dims` raises a ValueError."""
+def test_requires_dim():
+    """Omitting `dim` raises a ValueError."""
     states = [_dm((1, 0, 0, 0)), _dm((0, 0, 0, 1))]
-    with pytest.raises(ValueError, match="dims"):
+    with pytest.raises(ValueError, match="dim"):
         state_exclusion_locc(states)
 
 
@@ -86,10 +86,10 @@ def test_invalid_probs():
     """Probabilities that do not sum to 1 raise a ValueError."""
     states = [_dm((1, 0, 0, 0)), _dm((0, 0, 0, 1))]
     with pytest.raises(ValueError, match="sum to 1"):
-        state_exclusion_locc(states, probs=[0.2, 0.2], dims=[2, 2])
+        state_exclusion_locc(states, probs=[0.2, 0.2], dim=[2, 2])
 
 
 def test_requires_states():
     """An empty list of states raises a ValueError."""
     with pytest.raises(ValueError, match="At least one state"):
-        state_exclusion_locc([], dims=[2, 2])
+        state_exclusion_locc([], dim=[2, 2])

--- a/toqito/state_opt/tests/test_state_exclusion_locc.py
+++ b/toqito/state_opt/tests/test_state_exclusion_locc.py
@@ -1,0 +1,95 @@
+"""Test state_exclusion_locc."""
+
+import cvxpy
+import numpy as np
+import pytest
+
+from toqito.matrix_ops import partial_transpose
+from toqito.state_opt import state_exclusion_locc
+from toqito.states import domino
+
+
+def _dm(vec):
+    """Build a normalized density matrix from a (possibly unnormalized) vector."""
+    v = np.array(vec, dtype=complex).reshape(-1, 1)
+    return v @ v.conj().T / (v.conj().T @ v).real.item()
+
+
+def _direct_exclusion_sdp(states, ppt=False, dims=(2, 2)):
+    """Global (or PPT) minimal-error state-exclusion probability via a direct SDP (reference)."""
+    n, d = len(states), states[0].shape[0]
+    meas = [cvxpy.Variable((d, d), hermitian=True) for _ in range(n)]
+    constraints = [m >> 0 for m in meas] + [sum(meas) == np.identity(d)]
+    if ppt:
+        constraints += [partial_transpose(m, [0], list(dims)) >> 0 for m in meas]
+    obj = cvxpy.Minimize(cvxpy.real(sum(cvxpy.trace(states[k] @ meas[k]) for k in range(n)) / n))
+    return cvxpy.Problem(obj, constraints).solve()
+
+
+# A fixed two-qubit ensemble with a known global < PPT (<= LOCC) exclusion gap, taken from the
+# symmetric-extension exclusion analysis (issue #1523). Computational basis order |00>,|01>,|10>,|11>.
+_GAP_VECS = [(0, 1, 1, 1), (0, 0, 1, 1), (1, 0, 1, 1)]
+
+
+def test_product_orthogonal_states_match_global():
+    """Orthogonal product states are perfectly LOCC-excludable (error ~ 0, matching global)."""
+    e_0, e_1 = np.array([1, 0]), np.array([0, 1])
+    states = [_dm(np.kron(e_0, e_0)), _dm(np.kron(e_1, e_1)), _dm(np.kron(e_0, e_1))]
+    val = state_exclusion_locc(states, dims=[2, 2], reps=3, seed=0)
+    np.testing.assert_allclose(val, 0.0, atol=1e-4)
+
+
+def test_locc_never_below_global():
+    """The one-way LOCC exclusion error is never below the global exclusion error."""
+    states = [_dm(v) for v in _GAP_VECS]
+    locc = state_exclusion_locc(states, dims=[2, 2], reps=3, seed=1)
+    glob = _direct_exclusion_sdp(states, ppt=False)
+    np.testing.assert_equal(locc >= glob - 1e-4, True)
+
+
+def test_locc_strictly_worse_than_global():
+    """One-way LOCC exclusion is strictly worse than global; PPT > global certifies the gap."""
+    states = [_dm(v) for v in _GAP_VECS]
+    locc = state_exclusion_locc(states, dims=[2, 2], reps=3, seed=1)
+    glob = _direct_exclusion_sdp(states, ppt=False)
+    ppt = _direct_exclusion_sdp(states, ppt=True)
+    # PPT exclusion is a certified lower bound on LOCC exclusion, so PPT > global proves the
+    # LOCC > global gap is genuine and not an artifact of the (heuristic) see-saw.
+    np.testing.assert_equal(ppt > glob + 1e-2, True)
+    np.testing.assert_equal(locc > glob + 1e-2, True)
+
+
+def test_reproducible_with_seed():
+    """A fixed seed yields a reproducible value."""
+    states = [_dm(v) for v in _GAP_VECS]
+    first = state_exclusion_locc(states, dims=[2, 2], reps=2, seed=7)
+    second = state_exclusion_locc(states, dims=[2, 2], reps=2, seed=7)
+    np.testing.assert_allclose(first, second, atol=1e-9)
+
+
+@pytest.mark.slow
+def test_domino_states_are_locc_excludable():
+    """Domino states are not LOCC-distinguishable, yet they are perfectly LOCC-excludable."""
+    states = [_dm(domino(i)) for i in range(9)]
+    val = state_exclusion_locc(states, dims=[3, 3], reps=2, seed=0)
+    np.testing.assert_allclose(val, 0.0, atol=1e-4)
+
+
+def test_requires_dims():
+    """Omitting `dims` raises a ValueError."""
+    states = [_dm((1, 0, 0, 0)), _dm((0, 0, 0, 1))]
+    with pytest.raises(ValueError, match="dims"):
+        state_exclusion_locc(states)
+
+
+def test_invalid_probs():
+    """Probabilities that do not sum to 1 raise a ValueError."""
+    states = [_dm((1, 0, 0, 0)), _dm((0, 0, 0, 1))]
+    with pytest.raises(ValueError, match="sum to 1"):
+        state_exclusion_locc(states, probs=[0.2, 0.2], dims=[2, 2])
+
+
+def test_requires_states():
+    """An empty list of states raises a ValueError."""
+    with pytest.raises(ValueError, match="At least one state"):
+        state_exclusion_locc([], dims=[2, 2])


### PR DESCRIPTION
Closes #1525.

Adds `state_exclusion_locc`, which computes the minimum-error probability of quantum state exclusion under one-way LOCC: Alice measures her subsystem, communicates her outcome to Bob, and Bob announces a state to exclude.

The induced global measurement operator for guessing `k` is `M_k = sum_a A_a (x) B^a_k`, and the error `sum_k p_k sum_a Tr[(A_a (x) B^a_k) rho_k]` is bilinear in Alice's and Bob's operators, so it is minimized by a see-saw of two SDPs:

- fix Alice's POVM and optimize Bob's conditional POVMs on the steered ensembles `sigma^a_k = Tr_A[(A_a (x) I) rho_k]`;
- fix Bob's POVMs and optimize Alice's POVM.

This mirrors the see-saw in `NonlocalGame.quantum_value_lower_bound`, including the random restarts. The value returned is the error of a concrete one-way LOCC strategy, hence at least the global exclusion error.

The docstring gives the two-SDP formulation, the notation mapping, and a runnable worked example.

### Tests

- orthogonal product states are perfectly LOCC-excludable (matching the global value);
- a fixed entangled ensemble where LOCC exclusion is strictly worse than global, with the gap certified by a direct PPT lower bound (PPT exclusion is a lower bound on LOCC exclusion, so PPT > global proves the gap is real rather than a see-saw artifact);
- reproducibility under a fixed seed;
- input validation.

### A note on the suggested domino-states test

The issue suggested that domino states would show a global-vs-LOCC exclusion gap. They do not: domino states are an orthonormal product basis, so although they are not LOCC-*distinguishable*, they are perfectly LOCC-*excludable* (exclusion only needs to rule out one state). I included a test confirming the domino exclusion error is 0, and demonstrated the strict global-vs-LOCC gap with the entangled ensemble above instead. Happy to adjust if you prefer a different example.

`ruff check`/`ruff format` are clean and all tests pass.

---

AI disclosure: I used Claude Code to help implement and test this change. I reviewed, ran, and verified all of the code and tests myself.
