### PR TITLE
Allow for PPT measurements using primal/dual SDP formulation for both `min_error` and `unambiguous` strategies in `state_exclusion` and `state_distinguishability`

### DIFF
--- a/toqito/state_opt/state_distinguishability.py
+++ b/toqito/state_opt/state_distinguishability.py
@@ -482,27 +482,50 @@ def _ppt_dual(
     strategy: str = "min_error",
 ):
     """Semidefinite program with PPT constraints (dual problem)."""
+    n = len(vectors)
     d = vectors[0].shape[0]
 
-    if strategy != "min_error":
-        raise ValueError("Only min_error strategy is supported for PPT dual.")
-
     problem = picos.Problem()
-    q_vars = [picos.HermitianVariable(f"Q[{i}]", (d, d)) for i in range(len(vectors))]
+    num_qvars = n if strategy == "min_error" else n + 1
+    q_vars = [picos.HermitianVariable(f"Q[{i}]", (d, d)) for i in range(num_qvars)]
+    problem.add_list_of_constraints([q_var >> 0 for q_var in q_vars])
 
     y_var = picos.HermitianVariable("Y", (d, d))
-    problem.add_list_of_constraints(
-        [
-            y_var - probs[i] * to_density_matrix(vectors[i])
-            >> picos.partial_transpose(
-                q_var,
-                subsystems=subsystems,
-                dimensions=dimensions,
-            )
-            for i, q_var in enumerate(q_vars)
-        ]
-    )
-    problem.add_list_of_constraints([q_var >> 0 for q_var in q_vars])
+    dms = [to_density_matrix(vector) for vector in vectors]
+
+    if strategy == "unambiguous":
+        m_vars = [[picos.RealVariable(f"m[{i}, {j}]") if i != j else 0 for j in range(n)] for i in range(n)]
+
+        problem.add_list_of_constraints(
+            [
+                y_var - probs[i] * dms[i]
+                - picos.sum([m_vars[i][j] * probs[j] * dms[j] for j in range(n) if j != i])
+                >> picos.partial_transpose(
+                    q_vars[i],
+                    subsystems=subsystems,
+                    dimensions=dimensions,
+                )
+                for i in range(n)
+            ]
+        )
+
+        problem.add_constraint(y_var >> picos.partial_transpose(
+                    q_vars[n],
+                    subsystems=subsystems,
+                    dimensions=dimensions,
+                ))
+    else:
+        problem.add_list_of_constraints(
+            [
+                y_var - probs[i] * dms[i]
+                >> picos.partial_transpose(
+                    q_vars[i],
+                    subsystems=subsystems,
+                    dimensions=dimensions,
+                )
+                for i in range(n)
+            ]
+        )
 
     problem.set_objective("min", picos.trace(y_var))
     solution = problem.solve(solver=solver)

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -381,27 +381,50 @@ def _ppt_dual(
     strategy: str = "min_error",
 ):
     """Semidefinite program with PPT constraints (dual problem)."""
+    n = len(vectors)
     d = vectors[0].shape[0]
 
-    if strategy != "min_error":
-        raise ValueError("Only min_error strategy is supported for PPT dual.")
-
     problem = picos.Problem()
-    q_vars = [picos.HermitianVariable(f"Q[{i}]", (d, d)) for i in range(len(vectors))]
+    num_qvars = n if strategy == "min_error" else n + 1
+    q_vars = [picos.HermitianVariable(f"Q[{i}]", (d, d)) for i in range(num_qvars)]
+    problem.add_list_of_constraints([q_var >> 0 for q_var in q_vars])
 
     y_var = picos.HermitianVariable("Y", (d, d))
-    problem.add_list_of_constraints(
-        [
-            - y_var + probs[i] * to_density_matrix(vectors[i])
-            >> picos.partial_transpose(
-                q_var,
-                subsystems=subsystems,
-                dimensions=dimensions,
-            )
-            for i, q_var in enumerate(q_vars)
-        ]
-    )
-    problem.add_list_of_constraints([q_var >> 0 for q_var in q_vars])
+    dms = [to_density_matrix(vector) for vector in vectors]
+
+    if strategy == "unambiguous":
+        m_vars = [[picos.RealVariable(f"m[{i}, {j}]") if i != j else 0 for j in range(n)] for i in range(n)]
+
+        problem.add_list_of_constraints(
+            [
+                - y_var + probs[i] * dms[i]
+                - picos.sum([m_vars[i][j] * probs[j] * dms[j] for j in range(n) if j != i])
+                >> picos.partial_transpose(
+                    q_vars[i],
+                    subsystems=subsystems,
+                    dimensions=dimensions,
+                )
+                for i in range(n)
+            ]
+        )
+
+        problem.add_constraint(- y_var >> picos.partial_transpose(
+                    q_vars[n],
+                    subsystems=subsystems,
+                    dimensions=dimensions,
+                ))
+    else:
+        problem.add_list_of_constraints(
+            [
+                - y_var + probs[i] * dms[i]
+                >> picos.partial_transpose(
+                    q_vars[i],
+                    subsystems=subsystems,
+                    dimensions=dimensions,
+                )
+                for i in range(n)
+            ]
+        )
 
     problem.set_objective("max", picos.trace(y_var))
     solution = problem.solve(solver=solver)

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -13,6 +13,9 @@ def state_exclusion(
     vectors: list[np.ndarray],
     probs: list[float] | None = None,
     strategy: str = "min_error",
+    measurement: str = "positive",
+    subsystems: list[int] | None = None,
+    dimensions: list[int] | None = None,
     solver: str = "cvxopt",
     primal_dual: str = "dual",
     **kwargs: Any,
@@ -105,6 +108,11 @@ def state_exclusion(
             probability distribution is assumed.
         strategy: Whether to perform minimal error or unambiguous discrimination task. Possible values are "min_error"
             and "unambiguous". Both strategies support pure and mixed states.
+        measurement: The type of measurement to use. Possible values are "positive" (default) for standard positive
+            measurements and "ppt" for PPT (positive partial transpose) measurements.
+        subsystems: A list of integers specifying which subsystems to transpose for PPT measurements. Required when
+            `measurement="ppt"`.
+        dimensions: A list of integers specifying the dimensions of each subsystem. Required when `measurement="ppt"`.
         solver: Optimization option for `picos` solver. Default option is `solver_option="cvxopt"`.
         primal_dual: Option for the optimization problem.
         kwargs: Additional arguments to pass to picos' solve method.
@@ -184,6 +192,18 @@ def state_exclusion(
     n = len(vectors)
     probs = [1 / n] * n if probs is None else probs
     dim = calculate_vector_matrix_dimension(vectors[0])
+
+    if measurement == "ppt":
+        if subsystems is None or dimensions is None:
+            raise ValueError("The 'subsystems' and 'dimensions' parameters are required for PPT measurements.")
+        if primal_dual == "primal":
+            return _ppt_primal(
+                vectors=vectors, subsystems=subsystems, dimensions=dimensions,
+                probs=probs, solver=solver, strategy=strategy,
+            )
+        return _ppt_dual(
+            vectors=vectors, subsystems=subsystems, dimensions=dimensions, probs=probs, solver=solver, strategy=strategy
+        )
 
     if strategy == "min_error":
         if primal_dual == "primal":
@@ -305,3 +325,86 @@ def _unambiguous_dual(
     solution = problem.solve(solver=solver, primals=None, **kwargs)
 
     return solution.value, (lagrangian_variable_big_n, lagrangian_variables_a)
+
+
+def _ppt_primal(
+    vectors: list[np.ndarray],
+    subsystems: list[int],
+    dimensions: list[int],
+    probs: list[float],
+    solver: str = "cvxopt",
+    strategy: str = "min_error",
+):
+    """Primal problem for the SDP with PPT constraints."""
+    n = len(vectors)
+    d = calculate_vector_matrix_dimension(vectors[0])
+
+    problem = picos.Problem()
+    num_measurements = n if strategy == "min_error" else n + 1
+    measurements = [picos.HermitianVariable(f"M[{i}]", (d, d)) for i in range(num_measurements)]
+
+    problem.add_list_of_constraints([meas >> 0 for meas in measurements])
+    problem.add_constraint(picos.sum(measurements) == picos.I(d))
+
+    # Add PPT constraint.
+    problem.add_list_of_constraints(
+        [
+            picos.partial_transpose(
+                meas,
+                subsystems=subsystems,
+                dimensions=dimensions,
+            )
+            >> 0
+            for meas in measurements
+        ]
+    )
+
+    dms = [to_density_matrix(vector) for vector in vectors]
+    if strategy == "unambiguous":
+        for i in range(n):
+            for j in range(n):
+                if i != j:
+                    problem.add_constraint(probs[j] * dms[j] | measurements[i] == 0)
+
+    problem.set_objective("min", np.real(picos.sum([probs[i] * (dms[i] | measurements[i]) for i in range(n)])))
+    solution = problem.solve(solver=solver)
+
+    return solution.value, measurements
+
+
+def _ppt_dual(
+    vectors: list[np.ndarray],
+    subsystems: list[int],
+    dimensions: list[int],
+    probs: list[float],
+    solver: str = "cvxopt",
+    strategy: str = "min_error",
+):
+    """Semidefinite program with PPT constraints (dual problem)."""
+    d = vectors[0].shape[0]
+
+    if strategy != "min_error":
+        raise ValueError("Only min_error strategy is supported for PPT dual.")
+
+    problem = picos.Problem()
+    q_vars = [picos.HermitianVariable(f"Q[{i}]", (d, d)) for i in range(len(vectors))]
+
+    y_var = picos.HermitianVariable("Y", (d, d))
+    problem.add_list_of_constraints(
+        [
+            - y_var + probs[i] * to_density_matrix(vectors[i])
+            >> picos.partial_transpose(
+                q_var,
+                subsystems=subsystems,
+                dimensions=dimensions,
+            )
+            for i, q_var in enumerate(q_vars)
+        ]
+    )
+    problem.add_list_of_constraints([q_var >> 0 for q_var in q_vars])
+
+    problem.set_objective("max", picos.trace(y_var))
+    solution = problem.solve(solver=solver)
+
+    measurements = [problem.get_constraint(k).dual for k in range(len(vectors))]
+    return solution.value, measurements


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->

Fixes #1520.

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  - [x] Add SDP formulation for PPT measurements to `state_exclusion` (primal and dual, `min_error` strategy)
  - [x] Add SDP formulation for PPT measurements to `state_exclusion` (primal and dual, `unambiguous` strategy)
  - [x] Add SDP formulation for PPT measurements to `state_distinguishability` (dual, `unambiguous` strategy)
  - [ ] Add tests
  - [ ] Update docstring

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://vprusso.github.io/toqito/contributing-guide/).

  -  [ ] Use `ruff` for errors related to code style and formatting.
  -  [ ] Verify all previous and newly added unit tests pass in `pytest`.
  -  [ ] Check the documentation build does not lead to any failures.
  
  ## AI disclosure
  No AI was used for this PR.
