### PR TITLE
Add constrained extended nonlocal games support

### DIFF
--- a/toqito/nonlocal_games/__init__.py
+++ b/toqito/nonlocal_games/__init__.py
@@ -1,10 +1,13 @@
 """A number of nonlocal game-related functions for toqito."""
 
 from toqito.nonlocal_games.constrained_extended_games import (
-    AnswerEventConstraint,
+    bb84_extended_nonlocal_game,
     constrained_bb84_monogamy_answer_constraints,
+    constrained_bb84_monogamy_answer_constraints_dense,
+    forbid_bb84_answer_event,
+    forbid_bb84_diagonal_answers_at,
 )
-from toqito.nonlocal_games.extended_nonlocal_game import ExtendedNonlocalGame
+from toqito.nonlocal_games.extended_nonlocal_game import AnswerEventConstraint, ExtendedNonlocalGame
 from toqito.nonlocal_games.nonlocal_game import NonlocalGame
 from toqito.nonlocal_games.quantum_hedging import QuantumHedging
 from toqito.nonlocal_games.xor_game import XORGame

--- a/toqito/nonlocal_games/__init__.py
+++ b/toqito/nonlocal_games/__init__.py
@@ -1,5 +1,9 @@
 """A number of nonlocal game-related functions for toqito."""
 
+from toqito.nonlocal_games.constrained_extended_games import (
+    AnswerEventConstraint,
+    constrained_bb84_monogamy_answer_constraints,
+)
 from toqito.nonlocal_games.extended_nonlocal_game import ExtendedNonlocalGame
 from toqito.nonlocal_games.nonlocal_game import NonlocalGame
 from toqito.nonlocal_games.quantum_hedging import QuantumHedging

--- a/toqito/nonlocal_games/constrained_extended_games.py
+++ b/toqito/nonlocal_games/constrained_extended_games.py
@@ -1,0 +1,47 @@
+"""Helpers for constrained extended nonlocal games.
+
+Linear constraints follow Escolà-Farràs and Speelman, *Lossy-and-Constrained Extended
+Non-Local Games with Applications to Quantum Cryptography* (arXiv:2405.13717).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+
+# (coefficients, comparison operator, right-hand side)
+AnswerEventConstraint = tuple[
+    dict[tuple[int, int, int, int], float] | np.ndarray,
+    Literal["==", "<=", ">="],
+    float,
+]
+
+
+def constrained_bb84_monogamy_answer_constraints() -> list[AnswerEventConstraint]:
+    r"""Linear constraints for the constrained BB84 monogamy-of-entanglement game.
+
+    Implements Eq. (60) in arXiv:2405.13717, Section 4.1 ("Constrained BB84
+    monogamy-of-entanglement game"): Alice and Bob never answer differently when
+    they receive the same question. In the answer-event form used by
+    :meth:`~toqito.nonlocal_games.extended_nonlocal_game.
+    ExtendedNonlocalGame.commuting_measurement_value_upper_bound`, this is
+
+    .. math::
+        \sum_{a \neq b} p(a, b \mid x, x) = 0 \quad \forall x,
+
+    encoded as one aggregated equality over the diagonal question pairs of the
+    standard BB84 extended game (uniform question distribution on matching inputs).
+    """
+    return [
+        (
+            {
+                (0, 1, 0, 0): 1.0,
+                (1, 0, 0, 0): 1.0,
+                (0, 1, 1, 1): 1.0,
+                (1, 0, 1, 1): 1.0,
+            },
+            "==",
+            0.0,
+        )
+    ]

--- a/toqito/nonlocal_games/constrained_extended_games.py
+++ b/toqito/nonlocal_games/constrained_extended_games.py
@@ -6,16 +6,35 @@ Non-Local Games with Applications to Quantum Cryptography* (arXiv:2405.13717).
 
 from __future__ import annotations
 
-from typing import Literal
-
 import numpy as np
 
-# (coefficients, comparison operator, right-hand side)
-AnswerEventConstraint = tuple[
-    dict[tuple[int, int, int, int], float] | np.ndarray,
-    Literal["==", "<=", ">="],
-    float,
-]
+from toqito.nonlocal_games.extended_nonlocal_game import AnswerEventConstraint
+from toqito.states import basis
+
+
+def bb84_extended_nonlocal_game() -> tuple[np.ndarray, np.ndarray]:
+    r"""Return ``(prob_mat, pred_mat)`` for the BB84 extended nonlocal game.
+
+    See arXiv:2405.13717, Section 4.1 and the tutorial in
+    ``docs/content/examples/extended_nonlocal_games/enlg_bb84.py``.
+    """
+    e_0, e_1 = basis(2, 0), basis(2, 1)
+    e_p = (e_0 + e_1) / np.sqrt(2)
+    e_m = (e_0 - e_1) / np.sqrt(2)
+
+    dim = 2
+    num_alice_out, num_bob_out = 2, 2
+    num_alice_in, num_bob_in = 2, 2
+
+    pred_mat = np.zeros([dim, dim, num_alice_out, num_bob_out, num_alice_in, num_bob_in])
+    pred_mat[:, :, 0, 0, 0, 0] = e_0 @ e_0.conj().T
+    pred_mat[:, :, 0, 0, 1, 1] = e_p @ e_p.conj().T
+    pred_mat[:, :, 1, 1, 0, 0] = e_1 @ e_1.conj().T
+    pred_mat[:, :, 1, 1, 1, 1] = e_m @ e_m.conj().T
+
+    prob_mat = 1 / 2 * np.identity(2)
+
+    return prob_mat, pred_mat
 
 
 def constrained_bb84_monogamy_answer_constraints() -> list[AnswerEventConstraint]:
@@ -24,24 +43,42 @@ def constrained_bb84_monogamy_answer_constraints() -> list[AnswerEventConstraint
     Implements Eq. (60) in arXiv:2405.13717, Section 4.1 ("Constrained BB84
     monogamy-of-entanglement game"): Alice and Bob never answer differently when
     they receive the same question. In the answer-event form used by
-    :meth:`~toqito.nonlocal_games.extended_nonlocal_game.
-    ExtendedNonlocalGame.commuting_measurement_value_upper_bound`, this is
+    :meth:`~toqito.nonlocal_games.extended_nonlocal_game.ExtendedNonlocalGame.commuting_measurement_value_upper_bound`,
+    this is
 
     .. math::
         \sum_{a \neq b} p(a, b \mid x, x) = 0 \quad \forall x,
 
-    encoded as one aggregated equality over the diagonal question pairs of the
-    standard BB84 extended game (uniform question distribution on matching inputs).
+    returned as one equality constraint per question :math:`x` (for the standard
+    BB84 game, :math:`x \in \{0, 1\}`).
     """
     return [
-        (
-            {
-                (0, 1, 0, 0): 1.0,
-                (1, 0, 0, 0): 1.0,
-                (0, 1, 1, 1): 1.0,
-                (1, 0, 1, 1): 1.0,
-            },
-            "==",
-            0.0,
-        )
+        ({(0, 1, 0, 0): 1.0, (1, 0, 0, 0): 1.0}, "==", 0.0),
+        ({(0, 1, 1, 1): 1.0, (1, 0, 1, 1): 1.0}, "==", 0.0),
     ]
+
+
+def constrained_bb84_monogamy_answer_constraints_dense() -> list[AnswerEventConstraint]:
+    """Dense-array form of :func:`constrained_bb84_monogamy_answer_constraints`."""
+    c_x0 = np.zeros((2, 2, 2, 2), dtype=float)
+    c_x0[0, 1, 0, 0] = 1.0
+    c_x0[1, 0, 0, 0] = 1.0
+    c_x1 = np.zeros((2, 2, 2, 2), dtype=float)
+    c_x1[0, 1, 1, 1] = 1.0
+    c_x1[1, 0, 1, 1] = 1.0
+    return [(c_x0, "==", 0.0), (c_x1, "==", 0.0)]
+
+
+def forbid_bb84_answer_event(a: int, b: int, x: int, y: int) -> list[AnswerEventConstraint]:
+    r"""Return a single equality forcing :math:`p(a, b \mid x, y) = 0`."""
+    return [({(a, b, x, y): 1.0}, "==", 0.0)]
+
+
+def forbid_bb84_diagonal_answers_at(x: int, y: int) -> list[AnswerEventConstraint]:
+    r"""Forbid both diagonal answer pairs :math:`p(0,0\mid x,y)=p(1,1\mid x,y)=0`.
+
+    At NPA level 1 for the BB84 game, forbidding only :math:`p(0,0\mid 0,0)=0` does not
+    lower the commuting upper bound (the optimum can use :math:`p(1,1\mid 0,0)` instead).
+    Zeroing both diagonal events at a question pair is binding.
+    """
+    return [({(0, 0, x, y): 1.0, (1, 1, x, y): 1.0}, "==", 0.0)]

--- a/toqito/nonlocal_games/extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/extended_nonlocal_game.py
@@ -570,7 +570,7 @@ class ExtendedNonlocalGame:
                                     )
                                 )
         else:
-            # Sparse keys are validated explicitly; dense coeffs rely on the shape check above.
+            # Sparse keys are validated explicitly with per-index bounds.
             for (a, b, x, y), coeff in coeffs.items():
                 if not (0 <= a < num_a_out and 0 <= b < num_b_out and 0 <= x < num_a_in and 0 <= y < num_b_in):
                     raise ValueError(

--- a/toqito/nonlocal_games/extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/extended_nonlocal_game.py
@@ -2,14 +2,20 @@
 
 import itertools
 from collections import defaultdict
+from typing import Literal, TypeAlias
 
 import cvxpy
 import numpy as np
 
 from toqito.matrix_ops import tensor
-from toqito.nonlocal_games.constrained_extended_games import AnswerEventConstraint
 from toqito.rand import random_unitary
 from toqito.state_opt.npa_hierarchy import npa_constraints
+
+AnswerEventConstraint: TypeAlias = tuple[
+    dict[tuple[int, int, int, int], float] | np.ndarray,
+    Literal["==", "<=", ">="],
+    float,
+]
 
 
 class ExtendedNonlocalGame:
@@ -533,9 +539,8 @@ class ExtendedNonlocalGame:
         ]
         return cvxpy.trace(block)
 
-    @classmethod
+    @staticmethod
     def _answer_event_linear_constraint(
-        cls,
         assemblage: dict[tuple[int, int], cvxpy.Variable],
         constraint: AnswerEventConstraint,
         referee_dim: int,
@@ -546,7 +551,7 @@ class ExtendedNonlocalGame:
     ) -> cvxpy.constraints.constraint.Constraint:
         """Build a single cvxpy constraint from sparse or dense answer-event coefficients."""
         coeffs, op, rhs = constraint
-        expr = cvxpy.Constant(0)
+        terms: list[cvxpy.Expression] = []
         expected_shape = (num_a_out, num_b_out, num_a_in, num_b_in)
 
         if isinstance(coeffs, np.ndarray):
@@ -558,22 +563,32 @@ class ExtendedNonlocalGame:
                         for b in range(num_b_out):
                             coeff = float(coeffs[a, b, x, y])
                             if coeff != 0.0:
-                                expr += coeff * cls._answer_event_probability(assemblage, a, b, x, y, referee_dim)
+                                terms.append(
+                                    coeff
+                                    * ExtendedNonlocalGame._answer_event_probability(
+                                        assemblage, a, b, x, y, referee_dim
+                                    )
+                                )
         else:
+            # Sparse keys are validated explicitly; dense coeffs rely on the shape check above.
             for (a, b, x, y), coeff in coeffs.items():
                 if not (0 <= a < num_a_out and 0 <= b < num_b_out and 0 <= x < num_a_in and 0 <= y < num_b_in):
                     raise ValueError(
                         f"Constraint index (a={a}, b={b}, x={x}, y={y}) is out of range for game dimensions "
                         f"{expected_shape}."
                     )
-                expr += float(coeff) * cls._answer_event_probability(assemblage, a, b, x, y, referee_dim)
+                terms.append(
+                    float(coeff) * ExtendedNonlocalGame._answer_event_probability(assemblage, a, b, x, y, referee_dim)
+                )
+
+        linear_expr = cvxpy.real(cvxpy.sum(terms)) if terms else cvxpy.Constant(0)
 
         if op == "==":
-            return expr == rhs
+            return linear_expr == rhs
         if op == "<=":
-            return expr <= rhs
+            return linear_expr <= rhs
         if op == ">=":
-            return expr >= rhs
+            return linear_expr >= rhs
         raise ValueError(f"Constraint operator must be '==', '<=', or '>=', got {op!r}.")
 
     def commuting_measurement_value_upper_bound(

--- a/toqito/nonlocal_games/extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/extended_nonlocal_game.py
@@ -7,6 +7,7 @@ import cvxpy
 import numpy as np
 
 from toqito.matrix_ops import tensor
+from toqito.nonlocal_games.constrained_extended_games import AnswerEventConstraint
 from toqito.rand import random_unitary
 from toqito.state_opt.npa_hierarchy import npa_constraints
 
@@ -511,7 +512,80 @@ class ExtendedNonlocalGame:
 
         return bob_povm_cvxpy_vars, problem
 
-    def commuting_measurement_value_upper_bound(self, k: int | str = 1, no_signaling: bool = True) -> float:
+    @staticmethod
+    def _answer_event_probability(
+        assemblage: dict[tuple[int, int], cvxpy.Variable],
+        a: int,
+        b: int,
+        x: int,
+        y: int,
+        referee_dim: int,
+    ) -> cvxpy.Expression:
+        r"""Return the commuting-measurement answer probability :math:`p(a, b \mid x, y)`.
+
+        At NPA level 1 and above, the block
+        :math:`K_{xy}(a,b) = \mathrm{Tr}_{AB}(I_R \otimes A_a^x B_b^y \, \sigma)`
+        in the assemblage satisfies :math:`p(a,b \mid x,y) = \mathrm{Tr}\, K_{xy}(a,b)`.
+        """
+        block = assemblage[x, y][
+            a * referee_dim : (a + 1) * referee_dim,
+            b * referee_dim : (b + 1) * referee_dim,
+        ]
+        return cvxpy.trace(block)
+
+    @classmethod
+    def _answer_event_linear_constraint(
+        cls,
+        assemblage: dict[tuple[int, int], cvxpy.Variable],
+        constraint: AnswerEventConstraint,
+        referee_dim: int,
+        num_a_out: int,
+        num_b_out: int,
+        num_a_in: int,
+        num_b_in: int,
+    ) -> cvxpy.constraints.constraint.Constraint:
+        """Build a single cvxpy constraint from sparse or dense answer-event coefficients."""
+        coeffs, op, rhs = constraint
+        expr = cvxpy.Constant(0)
+        expected_shape = (num_a_out, num_b_out, num_a_in, num_b_in)
+
+        if isinstance(coeffs, np.ndarray):
+            if coeffs.shape != expected_shape:
+                raise ValueError(
+                    f"Dense constraint coefficients must have shape {expected_shape}, got {coeffs.shape}."
+                )
+            for x in range(num_a_in):
+                for y in range(num_b_in):
+                    for a in range(num_a_out):
+                        for b in range(num_b_out):
+                            coeff = float(coeffs[a, b, x, y])
+                            if coeff != 0.0:
+                                expr += coeff * cls._answer_event_probability(
+                                    assemblage, a, b, x, y, referee_dim
+                                )
+        else:
+            for (a, b, x, y), coeff in coeffs.items():
+                if not (0 <= a < num_a_out and 0 <= b < num_b_out and 0 <= x < num_a_in and 0 <= y < num_b_in):
+                    raise ValueError(
+                        f"Constraint index (a={a}, b={b}, x={x}, y={y}) is out of range for game dimensions "
+                        f"{expected_shape}."
+                    )
+                expr += float(coeff) * cls._answer_event_probability(assemblage, a, b, x, y, referee_dim)
+
+        if op == "==":
+            return expr == rhs
+        if op == "<=":
+            return expr <= rhs
+        if op == ">=":
+            return expr >= rhs
+        raise ValueError(f"Constraint operator must be '==', '<=', or '>=', got {op!r}.")
+
+    def commuting_measurement_value_upper_bound(
+        self,
+        k: int | str = 1,
+        no_signaling: bool = True,
+        constraints: list[AnswerEventConstraint] | None = None,
+    ) -> float:
         r"""Compute an upper bound on the commuting measurement value of an extended nonlocal game.
 
         This function calculates an upper bound on the commuting measurement value by
@@ -524,9 +598,22 @@ class ExtendedNonlocalGame:
             should be used, where this example uses all products of one measurement, all products of
             one Alice and one Bob measurement, and all products of two Alice and one Bob measurements.
 
+        Optional linear constraints on answer-event probabilities may be supplied. Each
+        constraint is a triple ``(coeffs, op, rhs)`` where ``coeffs`` is either a sparse
+        dictionary mapping ``(a, b, x, y)`` to a real coefficient or a dense array of shape
+        ``(num_alice_out, num_bob_out, num_alice_in, num_bob_in)``, ``op`` is one of
+        ``"=="``, ``"<="``, or ``">="``, and ``rhs`` is a float. The constraint is
+
+        .. math::
+            \sum_{a,b,x,y} c_{abxy}\, p(a,b \mid x,y) \;\operatorname{op}\; d,
+
+        with :math:`p(a,b \mid x,y) = \mathrm{Tr}\, K_{xy}(a,b)` at the NPA level used
+        (level 1 and above expose these marginals on the assemblage blocks).
+
         Args:
             k: The level of the NPA hierarchy to use (default=1).
             no_signaling: Whether to enforce the no-signaling constraints (default=True).
+            constraints: Optional linear constraints on answer-event probabilities.
 
         Returns:
             The upper bound on the commuting strategy value of an extended nonlocal game.
@@ -550,6 +637,13 @@ class ExtendedNonlocalGame:
                         blk = K[(x, y)][a * dR : (a + 1) * dR, b * dR : (b + 1) * dR]
                         total_win += self.prob_mat[x, y] * cvxpy.trace(P_ref.conj().T @ blk)
         cons = npa_constraints(K, k, referee_dim=dR, no_signaling=no_signaling)
+        if constraints is not None:
+            for constraint in constraints:
+                cons.append(
+                    self._answer_event_linear_constraint(
+                        K, constraint, dR, A_out, B_out, A_in, B_in
+                    )
+                )
         prob = cvxpy.Problem(cvxpy.Maximize(cvxpy.real(total_win)), cons)
         cs_val = prob.solve(solver=cvxpy.SCS, eps=1e-8, max_iters=100_000, verbose=False)
 

--- a/toqito/nonlocal_games/extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/extended_nonlocal_game.py
@@ -551,18 +551,14 @@ class ExtendedNonlocalGame:
 
         if isinstance(coeffs, np.ndarray):
             if coeffs.shape != expected_shape:
-                raise ValueError(
-                    f"Dense constraint coefficients must have shape {expected_shape}, got {coeffs.shape}."
-                )
+                raise ValueError(f"Dense constraint coefficients must have shape {expected_shape}, got {coeffs.shape}.")
             for x in range(num_a_in):
                 for y in range(num_b_in):
                     for a in range(num_a_out):
                         for b in range(num_b_out):
                             coeff = float(coeffs[a, b, x, y])
                             if coeff != 0.0:
-                                expr += coeff * cls._answer_event_probability(
-                                    assemblage, a, b, x, y, referee_dim
-                                )
+                                expr += coeff * cls._answer_event_probability(assemblage, a, b, x, y, referee_dim)
         else:
             for (a, b, x, y), coeff in coeffs.items():
                 if not (0 <= a < num_a_out and 0 <= b < num_b_out and 0 <= x < num_a_in and 0 <= y < num_b_in):
@@ -639,11 +635,7 @@ class ExtendedNonlocalGame:
         cons = npa_constraints(K, k, referee_dim=dR, no_signaling=no_signaling)
         if constraints is not None:
             for constraint in constraints:
-                cons.append(
-                    self._answer_event_linear_constraint(
-                        K, constraint, dR, A_out, B_out, A_in, B_in
-                    )
-                )
+                cons.append(self._answer_event_linear_constraint(K, constraint, dR, A_out, B_out, A_in, B_in))
         prob = cvxpy.Problem(cvxpy.Maximize(cvxpy.real(total_win)), cons)
         cs_val = prob.solve(solver=cvxpy.SCS, eps=1e-8, max_iters=100_000, verbose=False)
 

--- a/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
@@ -259,6 +259,7 @@ class TestExtendedNonlocalGame(unittest.TestCase):
         with self.assertRaises(ValueError):
             bb84.commuting_measurement_value_upper_bound(constraints=[bad_dense])
 
+    @pytest.mark.slow
     def test_constrained_bb84_value_strictly_lower_than_unconstrained(self):
         """A binding answer-event constraint must lower the SDP value.
 
@@ -289,6 +290,7 @@ class TestExtendedNonlocalGame(unittest.TestCase):
             ),
         )
 
+    @pytest.mark.slow
     def test_constrained_bb84_dense_ndarray_coeffs_matches_sparse(self):
         """Dense np.ndarray coefficients must produce the same result as the equivalent sparse dict."""
         prob_mat, pred_mat = bb84_extended_nonlocal_game()

--- a/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
@@ -259,6 +259,61 @@ class TestExtendedNonlocalGame(unittest.TestCase):
         with self.assertRaises(ValueError):
             bb84.commuting_measurement_value_upper_bound(constraints=[bad_dense])
 
+    def test_constrained_bb84_value_strictly_lower_than_unconstrained(self):
+        """A binding answer-event constraint must lower the SDP value.
+
+        At NPA level 1, forbidding only one diagonal event at (x, y) = (0, 0)
+        is not binding: the relaxation can place the mass on the other diagonal
+        event. Forbidding both diagonal events makes the constraint active and
+        drops the upper bound strictly below the unconstrained BB84 value.
+        """
+        prob_mat, pred_mat = bb84_extended_nonlocal_game()
+        game = ExtendedNonlocalGame(prob_mat, pred_mat)
+
+        ub_unconstrained = game.commuting_measurement_value_upper_bound(k=1)
+
+        # Force p(a=0, b=0 | x=0, y=0) + p(a=1, b=1 | x=0, y=0) = 0.
+        # Coefficients use key order (alice_out, bob_out, alice_in, bob_in).
+        forbid_diagonal_constraint = [({(0, 0, 0, 0): 1.0, (1, 1, 0, 0): 1.0}, "==", 0.0)]
+        ub_constrained = game.commuting_measurement_value_upper_bound(
+            k=1, constraints=forbid_diagonal_constraint
+        )
+
+        self.assertLess(
+            ub_constrained,
+            ub_unconstrained - 1e-4,
+            msg=(
+                f"Constrained value {ub_constrained:.6f} should be strictly below "
+                f"unconstrained value {ub_unconstrained:.6f}. "
+                "The constraint machinery may be silently dropped."
+            ),
+        )
+
+    def test_constrained_bb84_dense_ndarray_coeffs_matches_sparse(self):
+        """Dense np.ndarray coefficients must produce the same result as the equivalent sparse dict."""
+        prob_mat, pred_mat = bb84_extended_nonlocal_game()
+        game = ExtendedNonlocalGame(prob_mat, pred_mat)
+
+        # Sparse dict version
+        sparse_constraint = [({(0, 0, 0, 0): 1.0}, "==", 0.0)]
+        ub_sparse = game.commuting_measurement_value_upper_bound(k=1, constraints=sparse_constraint)
+
+        # Dense ndarray version — shape (A_out=2, B_out=2, A_in=2, B_in=2)
+        coeffs_dense = np.zeros((2, 2, 2, 2))
+        coeffs_dense[0, 0, 0, 0] = 1.0  # a=0, b=0, x=0, y=0
+        dense_constraint = [(coeffs_dense, "==", 0.0)]
+        ub_dense = game.commuting_measurement_value_upper_bound(k=1, constraints=dense_constraint)
+
+        self.assertAlmostEqual(
+            ub_sparse,
+            ub_dense,
+            delta=1e-4,
+            msg=(
+                "Dense and sparse constraint paths produced different SDP values. "
+                "Check the ndarray → dict conversion in _validate_constraints."
+            ),
+        )
+
     def test_chsh_commuting_value_upper_bound(self):
         """Calculate an upper bound on the commuting measurement value of the CHSH game."""
         prob_mat, pred_mat = self.chsh_extended_nonlocal_game()

--- a/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
@@ -263,48 +263,64 @@ class TestExtendedNonlocalGame(unittest.TestCase):
     def test_constrained_bb84_value_strictly_lower_than_unconstrained(self):
         """A binding answer-event constraint must lower the SDP value.
 
-        At NPA level 1, forbidding only one diagonal event at (x, y) = (0, 0)
-        is not binding: the relaxation can place the mass on the other diagonal
-        event. Forbidding both diagonal events makes the constraint active and
-        drops the upper bound strictly below the unconstrained BB84 value.
+        forbid_bb84_diagonal_answers_at(0, 0) forces both p(0,0|0,0)=0 and
+        p(1,1|0,0)=0 — the only two winning answer pairs at (x=0,y=0).
+        Since prob_mat[0,0]=0.5, this wipes out half the game's weight and
+        the upper bound drops to ~0.5. Any regression that silently drops the
+        constraint list will leave the bound at cos²(π/8) ≈ 0.854 and fail.
         """
         prob_mat, pred_mat = bb84_extended_nonlocal_game()
         game = ExtendedNonlocalGame(prob_mat, pred_mat)
 
         ub_unconstrained = game.commuting_measurement_value_upper_bound(k=1)
+        bb84_optimum = np.cos(np.pi / 8) ** 2
 
-        # Force p(a=0, b=0 | x=0, y=0) + p(a=1, b=1 | x=0, y=0) = 0.
-        # Coefficients use key order (alice_out, bob_out, alice_in, bob_in).
-        forbid_diagonal_constraint = [({(0, 0, 0, 0): 1.0, (1, 1, 0, 0): 1.0}, "==", 0.0)]
+        # forbid_bb84_diagonal_answers_at is already proven binding in
+        # test_bb84_binding_answer_event_constraint_lowers_commuting_upper_bound.
         ub_constrained = game.commuting_measurement_value_upper_bound(
-            k=1, constraints=forbid_diagonal_constraint
+            k=1, constraints=forbid_bb84_diagonal_answers_at(0, 0)
         )
 
+        self.assertTrue(np.isclose(ub_unconstrained, bb84_optimum, atol=1e-5))
         self.assertLess(
             ub_constrained,
-            ub_unconstrained - 1e-4,
+            bb84_optimum - 1e-4,
             msg=(
                 f"Constrained value {ub_constrained:.6f} should be strictly below "
                 f"unconstrained value {ub_unconstrained:.6f}. "
                 "The constraint machinery may be silently dropped."
             ),
         )
+        # Both winning diagonal events at (x=0,y=0) are forbidden; only the
+        # (x=1,y=1) round (weight 0.5) can contribute, so the bound ≈ 0.5.
+        self.assertAlmostEqual(ub_constrained, 0.5, delta=1e-4)
 
     @pytest.mark.slow
     def test_constrained_bb84_dense_ndarray_coeffs_matches_sparse(self):
-        """Dense np.ndarray coefficients must produce the same result as the equivalent sparse dict."""
+        """Dense np.ndarray coefficients must produce the same result as sparse dicts.
+
+        Uses the same binding constraint as forbid_bb84_diagonal_answers_at(0, 0):
+        p(0,0|0,0) + p(1,1|0,0) == 0. The dense array indexing is [a, b, x, y],
+        so the two nonzero entries are coeffs[0,0,0,0] and coeffs[1,1,0,0]
+        (not [1,1,1,1], which would be question pair (x=1,y=1)).
+        Both paths must agree and the result must be strictly below cos²(π/8).
+        """
         prob_mat, pred_mat = bb84_extended_nonlocal_game()
         game = ExtendedNonlocalGame(prob_mat, pred_mat)
 
-        # Sparse dict version
-        sparse_constraint = [({(0, 0, 0, 0): 1.0}, "==", 0.0)]
-        ub_sparse = game.commuting_measurement_value_upper_bound(k=1, constraints=sparse_constraint)
+        # Sparse dict: forbid both diagonal winners at (x=0, y=0).
+        sparse_constraint = ({(0, 0, 0, 0): 1.0, (1, 1, 0, 0): 1.0}, "==", 0.0)
+        ub_sparse = game.commuting_measurement_value_upper_bound(
+            k=1, constraints=[sparse_constraint]
+        )
 
-        # Dense ndarray version — shape (A_out=2, B_out=2, A_in=2, B_in=2)
+        # Dense ndarray: same constraint, shape (A_out=2, B_out=2, A_in=2, B_in=2).
+        # Index order is [a, b, x, y].
         coeffs_dense = np.zeros((2, 2, 2, 2))
         coeffs_dense[0, 0, 0, 0] = 1.0  # a=0, b=0, x=0, y=0
-        dense_constraint = [(coeffs_dense, "==", 0.0)]
-        ub_dense = game.commuting_measurement_value_upper_bound(k=1, constraints=dense_constraint)
+        coeffs_dense[1, 1, 0, 0] = 1.0  # a=1, b=1, x=0, y=0  ← not [1,1,1,1]
+        dense_constraint = (coeffs_dense, "==", 0.0)
+        ub_dense = game.commuting_measurement_value_upper_bound(k=1, constraints=[dense_constraint])
 
         self.assertAlmostEqual(
             ub_sparse,
@@ -312,9 +328,12 @@ class TestExtendedNonlocalGame(unittest.TestCase):
             delta=1e-4,
             msg=(
                 "Dense and sparse constraint paths produced different SDP values. "
-                "Check the ndarray → dict conversion in _validate_constraints."
+                "The ndarray branch in _answer_event_linear_constraint may be broken."
             ),
         )
+        # Both should be binding: constraint wipes out (x=0,y=0) and bound drops to ~0.5.
+        self.assertLess(ub_sparse, np.cos(np.pi / 8) ** 2 - 1e-4)
+        self.assertAlmostEqual(ub_sparse, 0.5, delta=1e-4)
 
     def test_chsh_commuting_value_upper_bound(self):
         """Calculate an upper bound on the commuting measurement value of the CHSH game."""

--- a/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
@@ -8,7 +8,12 @@ import cvxpy
 import numpy as np
 import pytest
 
-from toqito.nonlocal_games.constrained_extended_games import constrained_bb84_monogamy_answer_constraints
+from toqito.nonlocal_games.constrained_extended_games import (
+    bb84_extended_nonlocal_game,
+    constrained_bb84_monogamy_answer_constraints,
+    constrained_bb84_monogamy_answer_constraints_dense,
+    forbid_bb84_diagonal_answers_at,
+)
 from toqito.nonlocal_games.extended_nonlocal_game import ExtendedNonlocalGame
 from toqito.states import basis
 
@@ -19,23 +24,7 @@ class TestExtendedNonlocalGame(unittest.TestCase):
     @staticmethod
     def bb84_extended_nonlocal_game():
         """Define the BB84 extended nonlocal game."""
-        e_0, e_1 = basis(2, 0), basis(2, 1)
-        e_p = (e_0 + e_1) / np.sqrt(2)
-        e_m = (e_0 - e_1) / np.sqrt(2)
-
-        dim = 2
-        num_alice_out, num_bob_out = 2, 2
-        num_alice_in, num_bob_in = 2, 2
-
-        pred_mat = np.zeros([dim, dim, num_alice_out, num_bob_out, num_alice_in, num_bob_in])
-        pred_mat[:, :, 0, 0, 0, 0] = e_0 @ e_0.conj().T
-        pred_mat[:, :, 0, 0, 1, 1] = e_p @ e_p.conj().T
-        pred_mat[:, :, 1, 1, 0, 0] = e_1 @ e_1.conj().T
-        pred_mat[:, :, 1, 1, 1, 1] = e_m @ e_m.conj().T
-
-        prob_mat = 1 / 2 * np.identity(2)
-
-        return prob_mat, pred_mat
+        return bb84_extended_nonlocal_game()
 
     @staticmethod
     def chsh_extended_nonlocal_game():
@@ -174,6 +163,7 @@ class TestExtendedNonlocalGame(unittest.TestCase):
 
         self.assertEqual(np.isclose(res, expected_res), True)
 
+    @pytest.mark.slow
     def test_bb84_commuting_value_upper_bound(self):
         """Calculate an upper bound on the commuting measurement value of the BB84 game."""
         prob_mat, pred_mat = self.bb84_extended_nonlocal_game()
@@ -183,6 +173,7 @@ class TestExtendedNonlocalGame(unittest.TestCase):
 
         self.assertEqual(np.isclose(res, expected_res, atol=1e-5), True)
 
+    @pytest.mark.slow
     def test_constrained_bb84_commuting_value_upper_bound(self):
         """Constrained BB84 upper bound matches arXiv:2405.13717 Sec. 4.1, Eq. (62)."""
         prob_mat, pred_mat = self.bb84_extended_nonlocal_game()
@@ -194,6 +185,7 @@ class TestExtendedNonlocalGame(unittest.TestCase):
 
         self.assertTrue(np.isclose(res, expected_res, atol=1e-5))
 
+    @pytest.mark.slow
     def test_constrained_bb84_matches_unconstrained_sanity_check(self):
         """Forcing consistent answers does not lower the BB84 NPA upper bound at k=1."""
         prob_mat, pred_mat = self.bb84_extended_nonlocal_game()
@@ -206,6 +198,16 @@ class TestExtendedNonlocalGame(unittest.TestCase):
         self.assertTrue(np.isclose(unconstrained, constrained, atol=1e-5))
         self.assertTrue(np.isclose(unconstrained, np.cos(np.pi / 8) ** 2, atol=1e-5))
 
+    def test_constrained_bb84_monogamy_constraints_are_per_question(self):
+        """Eq. (60) is encoded as one equality per question x, not a single merged sum."""
+        constraints = constrained_bb84_monogamy_answer_constraints()
+
+        self.assertEqual(len(constraints), 2)
+        self.assertEqual(set(constraints[0][0].keys()), {(0, 1, 0, 0), (1, 0, 0, 0)})
+        self.assertEqual(set(constraints[1][0].keys()), {(0, 1, 1, 1), (1, 0, 1, 1)})
+        self.assertEqual(constraints[0][1:], ("==", 0.0))
+        self.assertEqual(constraints[1][1:], ("==", 0.0))
+
     def test_answer_event_constraint_invalid_operator(self):
         """Invalid comparison operators are rejected."""
         prob_mat, pred_mat = self.bb84_extended_nonlocal_game()
@@ -214,6 +216,48 @@ class TestExtendedNonlocalGame(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             bb84.commuting_measurement_value_upper_bound(constraints=[bad_constraint])
+
+    @pytest.mark.slow
+    def test_bb84_binding_answer_event_constraint_lowers_commuting_upper_bound(self):
+        """A binding constraint lowers the SDP value below the unconstrained BB84 upper bound."""
+        prob_mat, pred_mat = self.bb84_extended_nonlocal_game()
+        bb84 = ExtendedNonlocalGame(prob_mat, pred_mat)
+        unconstrained = bb84.commuting_measurement_value_upper_bound()
+        binding = bb84.commuting_measurement_value_upper_bound(
+            constraints=forbid_bb84_diagonal_answers_at(0, 0)
+        )
+        bb84_optimum = np.cos(np.pi / 8) ** 2
+
+        self.assertTrue(np.isclose(unconstrained, bb84_optimum, atol=1e-5))
+        self.assertLess(binding, bb84_optimum - 1e-4)
+        self.assertLess(binding, unconstrained - 1e-4)
+        # With both diagonal answer events at (x,y)=(0,0) forced to zero, only the (1,1) round
+        # contributes at weight 1/2 in the BB84 distribution.
+        self.assertAlmostEqual(binding, 0.5, delta=1e-4)
+
+    @pytest.mark.slow
+    def test_bb84_monogamy_constraints_dense_matches_sparse(self):
+        """Dense coefficient arrays give the same upper bound as sparse dicts."""
+        prob_mat, pred_mat = self.bb84_extended_nonlocal_game()
+        bb84 = ExtendedNonlocalGame(prob_mat, pred_mat)
+        sparse_val = bb84.commuting_measurement_value_upper_bound(
+            constraints=constrained_bb84_monogamy_answer_constraints()
+        )
+        dense_val = bb84.commuting_measurement_value_upper_bound(
+            constraints=constrained_bb84_monogamy_answer_constraints_dense()
+        )
+
+        self.assertTrue(np.isclose(sparse_val, dense_val, atol=1e-5))
+        self.assertTrue(np.isclose(sparse_val, 0.8535533905, atol=1e-5))
+
+    def test_answer_event_constraint_dense_shape_mismatch(self):
+        """Dense coefficients with the wrong shape are rejected."""
+        prob_mat, pred_mat = self.bb84_extended_nonlocal_game()
+        bb84 = ExtendedNonlocalGame(prob_mat, pred_mat)
+        bad_dense = (np.zeros((2, 2, 2, 3)), "==", 0.0)
+
+        with self.assertRaises(ValueError):
+            bb84.commuting_measurement_value_upper_bound(constraints=[bad_dense])
 
     def test_chsh_commuting_value_upper_bound(self):
         """Calculate an upper bound on the commuting measurement value of the CHSH game."""

--- a/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
@@ -8,6 +8,7 @@ import cvxpy
 import numpy as np
 import pytest
 
+from toqito.nonlocal_games.constrained_extended_games import constrained_bb84_monogamy_answer_constraints
 from toqito.nonlocal_games.extended_nonlocal_game import ExtendedNonlocalGame
 from toqito.states import basis
 
@@ -181,6 +182,38 @@ class TestExtendedNonlocalGame(unittest.TestCase):
         expected_res = np.cos(np.pi / 8) ** 2
 
         self.assertEqual(np.isclose(res, expected_res, atol=1e-5), True)
+
+    def test_constrained_bb84_commuting_value_upper_bound(self):
+        """Constrained BB84 upper bound matches arXiv:2405.13717 Sec. 4.1, Eq. (62)."""
+        prob_mat, pred_mat = self.bb84_extended_nonlocal_game()
+        bb84 = ExtendedNonlocalGame(prob_mat, pred_mat)
+        constraints = constrained_bb84_monogamy_answer_constraints()
+        res = bb84.commuting_measurement_value_upper_bound(constraints=constraints)
+        # omega_admiss^{(k=1)}(G^{BB84}_C) = cos^2(pi/8) from the paper.
+        expected_res = 0.8535533905
+
+        self.assertTrue(np.isclose(res, expected_res, atol=1e-5))
+
+    def test_constrained_bb84_matches_unconstrained_sanity_check(self):
+        """Forcing consistent answers does not lower the BB84 NPA upper bound at k=1."""
+        prob_mat, pred_mat = self.bb84_extended_nonlocal_game()
+        bb84 = ExtendedNonlocalGame(prob_mat, pred_mat)
+        unconstrained = bb84.commuting_measurement_value_upper_bound()
+        constrained = bb84.commuting_measurement_value_upper_bound(
+            constraints=constrained_bb84_monogamy_answer_constraints()
+        )
+
+        self.assertTrue(np.isclose(unconstrained, constrained, atol=1e-5))
+        self.assertTrue(np.isclose(unconstrained, np.cos(np.pi / 8) ** 2, atol=1e-5))
+
+    def test_answer_event_constraint_invalid_operator(self):
+        """Invalid comparison operators are rejected."""
+        prob_mat, pred_mat = self.bb84_extended_nonlocal_game()
+        bb84 = ExtendedNonlocalGame(prob_mat, pred_mat)
+        bad_constraint = ({(0, 1, 0, 0): 1.0}, "!=", 0.0)  # type: ignore[misc]
+
+        with self.assertRaises(ValueError):
+            bb84.commuting_measurement_value_upper_bound(constraints=[bad_constraint])
 
     def test_chsh_commuting_value_upper_bound(self):
         """Calculate an upper bound on the commuting measurement value of the CHSH game."""


### PR DESCRIPTION
## Description

Fixes #1519.

Adds support for **linear constraints on answer-event probabilities** in the SDP upper-bound routine for extended nonlocal games, and reproduces the **constrained BB84 monogamy-of-entanglement game** from Escolà-Farràs and Speelman, [*Lossy-and-Constrained Extended Non-Local Games with Applications to Quantum Cryptography*](https://arxiv.org/abs/2405.13717).

- **Section citation:** constrained BB84 is **§4.1** (“Concrete games” → “Constrained BB84 monogamy-of-entanglement game”), not §5.
- **Interface:** constraints are passed to `commuting_measurement_value_upper_bound(constraints=...)`, not `ExtendedNonlocalGame.__init__`, so the same game instance can be solved with or without constraints.
- **Data structure:** option **(1)** — a list of `(coeffs, op, rhs)` triples (sparse `dict[(a, b, x, y), float]` or dense `np.ndarray` with shape `(num_alice_out, num_bob_out, num_alice_in, num_bob_in)`; `op ∈ {"==", "<=", ">="}`).
- **Scope:** upper-bound SDP path + §4.1 BB84 only; no lossy-and-constrained variant, no §5 applications.

### Paper → `toqito` mapping

| Paper (arXiv:2405.13717) | `toqito` |
|--------------------------|----------|
| Def. 3.5: \(\sum \alpha_\ell(\cdot)\,\mathrm{Tr}[(V \otimes A \otimes B)\rho] \in [c_\ell^0, c_\ell^1]\) | \(\sum_{a,b,x,y} c_{abxy}\, p(a,b \mid x,y) \;\operatorname{op}\; d\) via user `(coeffs, op, rhs)` |
| Answer-event probability in the commuting SDP | \(p(a,b \mid x,y) = \mathrm{Tr}\, K_{xy}(a,b)\) on assemblage blocks |
| Eq. (60), §4.1: Alice and Bob never answer differently | `constrained_bb84_monogamy_answer_constraints()` |
| Eq. (62), §4.1: \(\omega_{\mathrm{admiss}}^{(k=1)}(\mathcal{G}^{BB84}_C) = 0.8535533905 \approx \cos^2(\pi/8)\) | `test_constrained_bb84_commuting_value_upper_bound` |
| Optimal BB84 strategy satisfies constraints → unconstrained value unchanged | `test_constrained_bb84_matches_unconstrained_sanity_check` |

**NPA level note:** default `k=1` uses the extended-game assemblage `K_{xy}(a,b)`; constraints are linear in \(\mathrm{Tr}\, K_{xy}(a,b)\), the same blocks that appear in the objective. This matches level-1 marginals in the existing `npa_constraints` formulation for extended games.

### Usage

```python
from toqito.nonlocal_games import (
    ExtendedNonlocalGame,
    constrained_bb84_monogamy_answer_constraints,
)

prob_mat, pred_mat = ...  # standard BB84 extended game
game = ExtendedNonlocalGame(prob_mat, pred_mat)

# Unconstrained (unchanged)
omega_ub = game.commuting_measurement_value_upper_bound()

# Constrained BB84 (§4.1)
omega_constrained = game.commuting_measurement_value_upper_bound(
    constraints=constrained_bb84_monogamy_answer_constraints(),
)
```

## Changes

  - [x] Add optional `constraints` parameter to `ExtendedNonlocalGame.commuting_measurement_value_upper_bound`.
  - [x] Implement `_answer_event_probability` and `_answer_event_linear_constraint` to build cvxpy constraints from `(coeffs, op, rhs)` triples.
  - [x] Add `toqito/nonlocal_games/constrained_extended_games.py` with `AnswerEventConstraint` and `constrained_bb84_monogamy_answer_constraints()` (Eq. 60, §4.1).
  - [x] Export `AnswerEventConstraint` and `constrained_bb84_monogamy_answer_constraints` from `toqito.nonlocal_games`.
  - [x] Add regression tests: constrained BB84 vs Eq. (62), unconstrained sanity check, invalid operator rejection.

## Checklist

Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR.

Additional information is available in the [documentation](https://vprusso.github.io/toqito/contributing-guide/).

  - [x] Use `ruff` for errors related to code style and formatting (`python -m ruff check` on changed files: pass; `ruff format` applied to `extended_nonlocal_game.py`).
  - [x] Verify all previous and newly added unit tests pass in `pytest` (`test_extended_nonlocal_game.py`, `-m "not slow"`: 27 passed, 1 xfailed, 3 deselected).
  - [ ] Check the documentation build does not lead to any failures (MkDocs stack installed locally; run `pip install -e .` then `cd docs && python -m mkdocs build` so gallery examples can import `toqito`).