### PR TITLE
feat: add PPT state exclusion support

### DIFF
--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -171,7 +171,7 @@ def state_exclusion(
 
         states = [np.array([[1.], [0.]]), np.array([[1.],[1.]]) / np.sqrt(2)]
 
-        res, _ = state_exclusion(states, primal_dual="primal", strategy="unambiguous", abs_ipm_opt_tol=1e-5)
+        res, _ = state_exclusion(states, primal_dual="primal", strategy="unambiguous", abs_ipm_opt_tol=1e-7)
 
         print(np.around(res, decimals=2))
         ```
@@ -221,6 +221,9 @@ def state_exclusion(
             See https://gitlab.com/picos-api/picos/-/issues/341
 
     """
+    if measurement not in {"positive", "ppt"}:
+        raise ValueError("Argument `measurement` must be either 'positive' or 'ppt'.")
+
     if not has_same_dimension(vectors):
         raise ValueError("Vectors for state distinguishability must all have the same dimension.")
 
@@ -271,9 +274,6 @@ def state_exclusion(
             **kwargs,
         )
 
-    if measurement != "positive":
-        raise ValueError("Argument `measurement` must be either 'positive' or 'ppt'.")
-
     if strategy == "min_error":
         if primal_dual == "primal":
             return _min_error_primal(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
@@ -303,7 +303,7 @@ def _ppt_dual_cone_constraint(
     name: str,
     subsystems: list[int],
     dimensions: list[int],
-) -> None:
+) -> Any:
     r"""Constrain `expr` to lie in the dual PPT cone.
 
     The PPT cone is \(\{M : M \succeq 0, \Gamma(M) \succeq 0\}\). Its dual cone is
@@ -314,7 +314,9 @@ def _ppt_dual_cone_constraint(
     dim = expr.shape[0]
     q_var = picos.HermitianVariable(name, (dim, dim))
     problem.add_constraint(q_var >> 0)
-    problem.add_constraint(expr - picos.partial_transpose(q_var, subsystems=subsystems, dimensions=dimensions) >> 0)
+    return problem.add_constraint(
+        expr - picos.partial_transpose(q_var, subsystems=subsystems, dimensions=dimensions) >> 0
+    )
 
 
 def _min_error_primal(
@@ -402,19 +404,22 @@ def _ppt_min_error_dual(
     """Find the dual problem for minimum-error quantum state exclusion SDP with PPT constraints."""
     problem = picos.Problem()
     y_var = picos.HermitianVariable("Y", (dim, dim))
+    dual_cone_constraints = []
 
     for i, vector in enumerate(vectors):
-        _ppt_dual_cone_constraint(
-            problem=problem,
-            expr=probs[i] * to_density_matrix(vector) - y_var,
-            name=f"Q[{i}]",
-            subsystems=subsystems,
-            dimensions=dimensions,
+        dual_cone_constraints.append(
+            _ppt_dual_cone_constraint(
+                problem=problem,
+                expr=probs[i] * to_density_matrix(vector) - y_var,
+                name=f"Q[{i}]",
+                subsystems=subsystems,
+                dimensions=dimensions,
+            )
         )
 
     problem.set_objective("max", picos.trace(y_var))
     solution = problem.solve(solver=solver, primals=None, **kwargs)
-    measurements = [problem.get_constraint(2 * i + 1).dual for i in range(len(vectors))]
+    measurements = [constraint.dual for constraint in dual_cone_constraints]
 
     return solution.value, measurements
 
@@ -463,6 +468,7 @@ def _ppt_unambiguous_primal(
     n = len(vectors)
     problem = picos.Problem()
     measurements = [picos.HermitianVariable(f"M[{i}]", (dim, dim)) for i in range(n)]
+    # The inconclusive POVM element is determined by completeness once the conclusive elements are chosen.
     inconclusive_measurement = picos.I(dim) - picos.sum(measurements)
 
     problem.add_list_of_constraints([meas >> 0 for meas in measurements])

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -13,6 +13,9 @@ def state_exclusion(
     vectors: list[np.ndarray],
     probs: list[float] | None = None,
     strategy: str = "min_error",
+    measurement: str = "positive",
+    subsystems: list[int] | None = None,
+    dimensions: list[int] | None = None,
     solver: str = "cvxopt",
     primal_dual: str = "dual",
     **kwargs: Any,
@@ -64,6 +67,21 @@ def state_exclusion(
         \end{equation}
     \]
 
+    If `measurement = "ppt"`, the measurement operators are also constrained to be positive under partial transpose on
+    the requested subsystem(s). In the primal minimum-error problem, this adds the constraints
+
+    \[
+        \Gamma_j(M_i) \succeq 0
+    \]
+
+    for every measurement operator \(M_i\) and for the subsystem(s) \(j\) listed in `subsystems`, where \(\Gamma_j\)
+    is the partial transpose map with subsystem dimensions `dimensions`. The corresponding dual uses the dual PPT cone,
+    \(\text{Pos} + \Gamma_j(\text{Pos})\), so the constraints become
+
+    \[
+        p_i\rho_i - Y \in \text{Pos} + \Gamma_j(\text{Pos}).
+    \]
+
     For `strategy = "unambiguous"`, Bob never provides an incorrect answer, although it is
     possible that his answer is inconclusive. This function then yields the probability of an inconclusive outcome.
 
@@ -105,6 +123,11 @@ def state_exclusion(
             probability distribution is assumed.
         strategy: Whether to perform minimal error or unambiguous discrimination task. Possible values are "min_error"
             and "unambiguous". Both strategies support pure and mixed states.
+        measurement: The type of measurement to use. Possible values are "positive" (default) for standard positive
+            measurements and "ppt" for PPT (positive partial transpose) measurements.
+        subsystems: A list of integers specifying which subsystems to transpose for PPT measurements. Required when
+            `measurement="ppt"`.
+        dimensions: A list of integers specifying the dimensions of each subsystem. Required when `measurement="ppt"`.
         solver: Optimization option for `picos` solver. Default option is `solver_option="cvxopt"`.
         primal_dual: Option for the optimization problem.
         kwargs: Additional arguments to pass to picos' solve method.
@@ -148,7 +171,7 @@ def state_exclusion(
 
         states = [np.array([[1.], [0.]]), np.array([[1.],[1.]]) / np.sqrt(2)]
 
-        res, _ = state_exclusion(states, primal_dual="primal", strategy="unambiguous", abs_ipm_opt_tol=1e-7)
+        res, _ = state_exclusion(states, primal_dual="primal", strategy="unambiguous", abs_ipm_opt_tol=1e-5)
 
         print(np.around(res, decimals=2))
         ```
@@ -169,6 +192,27 @@ def state_exclusion(
         print(np.around(res, decimals=2))
         ```
 
+        PPT-constrained minimum-error state exclusion.
+
+        ```python
+        import numpy as np
+        from toqito.state_opt import state_exclusion
+        from toqito.states import bell
+
+        states = [bell(0), bell(1), bell(2)]
+
+        res, _ = state_exclusion(
+            states,
+            measurement="ppt",
+            subsystems=[0],
+            dimensions=[2, 2],
+            primal_dual="primal",
+            cvxopt_kktsolver="ldl",
+        )
+
+        print(np.around(res, decimals=2))
+        ```
+
         !!! Note
             If you encounter a `ZeroDivisionError` or an `ArithmeticError` when using cvxopt as a solver (which is the
             default), you might want to set the `abs_ipm_opt_tol` option to a lower value (the default being `1e-8`) or
@@ -185,6 +229,51 @@ def state_exclusion(
     probs = [1 / n] * n if probs is None else probs
     dim = calculate_vector_matrix_dimension(vectors[0])
 
+    if measurement == "ppt":
+        _validate_ppt_params(dim=dim, subsystems=subsystems, dimensions=dimensions)
+        if strategy == "min_error":
+            if primal_dual == "primal":
+                return _ppt_min_error_primal(
+                    vectors=vectors,
+                    dim=dim,
+                    subsystems=subsystems,
+                    dimensions=dimensions,
+                    probs=probs,
+                    solver=solver,
+                    **kwargs,
+                )
+            return _ppt_min_error_dual(
+                vectors=vectors,
+                dim=dim,
+                subsystems=subsystems,
+                dimensions=dimensions,
+                probs=probs,
+                solver=solver,
+                **kwargs,
+            )
+        if primal_dual == "primal":
+            return _ppt_unambiguous_primal(
+                vectors=vectors,
+                dim=dim,
+                subsystems=subsystems,
+                dimensions=dimensions,
+                probs=probs,
+                solver=solver,
+                **kwargs,
+            )
+        return _ppt_unambiguous_dual(
+            vectors=vectors,
+            dim=dim,
+            subsystems=subsystems,
+            dimensions=dimensions,
+            probs=probs,
+            solver=solver,
+            **kwargs,
+        )
+
+    if measurement != "positive":
+        raise ValueError("Argument `measurement` must be either 'positive' or 'ppt'.")
+
     if strategy == "min_error":
         if primal_dual == "primal":
             return _min_error_primal(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
@@ -194,6 +283,38 @@ def state_exclusion(
         return _unambiguous_primal(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
 
     return _unambiguous_dual(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
+
+
+def _validate_ppt_params(dim: int, subsystems: list[int] | None, dimensions: list[int] | None) -> None:
+    """Validate subsystem information for PPT-constrained measurements."""
+    if subsystems is None or dimensions is None:
+        raise ValueError("The 'subsystems' and 'dimensions' parameters are required for PPT measurements.")
+
+    if np.prod(dimensions) != dim:
+        raise ValueError("The product of `dimensions` must equal the dimension of the states.")
+
+    if any(sys < 0 or sys >= len(dimensions) for sys in subsystems):
+        raise ValueError("Entries of `subsystems` must index into `dimensions`.")
+
+
+def _ppt_dual_cone_constraint(
+    problem: picos.Problem,
+    expr: picos.expressions.ComplexAffineExpression,
+    name: str,
+    subsystems: list[int],
+    dimensions: list[int],
+) -> None:
+    r"""Constrain `expr` to lie in the dual PPT cone.
+
+    The PPT cone is \(\{M : M \succeq 0, \Gamma(M) \succeq 0\}\). Its dual cone is
+    \(\text{Pos} + \Gamma(\text{Pos})\). We model this as `expr - partial_transpose(Q) >> 0`
+    for an auxiliary positive semidefinite variable `Q`.
+
+    """
+    dim = expr.shape[0]
+    q_var = picos.HermitianVariable(name, (dim, dim))
+    problem.add_constraint(q_var >> 0)
+    problem.add_constraint(expr - picos.partial_transpose(q_var, subsystems=subsystems, dimensions=dimensions) >> 0)
 
 
 def _min_error_primal(
@@ -242,6 +363,62 @@ def _min_error_dual(
     return solution.value, measurements
 
 
+def _ppt_min_error_primal(
+    vectors: list[np.ndarray],
+    dim: int,
+    subsystems: list[int],
+    dimensions: list[int],
+    probs: list[float] | None = None,
+    solver: str = "cvxopt",
+    **kwargs,
+) -> tuple[float, list[picos.HermitianVariable]]:
+    """Find the primal problem for minimum-error quantum state exclusion SDP with PPT constraints."""
+    n = len(vectors)
+    problem = picos.Problem()
+    measurements = [picos.HermitianVariable(f"M[{i}]", (dim, dim)) for i in range(n)]
+
+    problem.add_list_of_constraints([meas >> 0 for meas in measurements])
+    problem.add_list_of_constraints(
+        [picos.partial_transpose(meas, subsystems=subsystems, dimensions=dimensions) >> 0 for meas in measurements]
+    )
+    problem.add_constraint(picos.sum(measurements) == picos.I(dim))
+
+    dms = [to_density_matrix(vector) for vector in vectors]
+
+    problem.set_objective("min", np.real(picos.sum([(probs[i] * dms[i] | measurements[i]) for i in range(n)])))
+    solution = problem.solve(solver=solver, **kwargs)
+    return solution.value, measurements
+
+
+def _ppt_min_error_dual(
+    vectors: list[np.ndarray],
+    dim: int,
+    subsystems: list[int],
+    dimensions: list[int],
+    probs: list[float] | None = None,
+    solver: str = "cvxopt",
+    **kwargs,
+) -> tuple[float, list[picos.HermitianVariable]]:
+    """Find the dual problem for minimum-error quantum state exclusion SDP with PPT constraints."""
+    problem = picos.Problem()
+    y_var = picos.HermitianVariable("Y", (dim, dim))
+
+    for i, vector in enumerate(vectors):
+        _ppt_dual_cone_constraint(
+            problem=problem,
+            expr=probs[i] * to_density_matrix(vector) - y_var,
+            name=f"Q[{i}]",
+            subsystems=subsystems,
+            dimensions=dimensions,
+        )
+
+    problem.set_objective("max", picos.trace(y_var))
+    solution = problem.solve(solver=solver, primals=None, **kwargs)
+    measurements = [problem.get_constraint(2 * i + 1).dual for i in range(len(vectors))]
+
+    return solution.value, measurements
+
+
 def _unambiguous_primal(
     vectors: list[np.ndarray],
     dim: int,
@@ -268,6 +445,41 @@ def _unambiguous_primal(
     problem.add_list_of_constraints(m | rho == 0 for (m, rho) in zip(measurements, unnormalized_dms))
 
     problem.set_objective("min", picos.trace(sums_of_unnormalized_dms * inconclusive_measurement))
+    solution = problem.solve(solver=solver, **kwargs)
+
+    return solution.value, measurements + [inconclusive_measurement]
+
+
+def _ppt_unambiguous_primal(
+    vectors: list[np.ndarray],
+    dim: int,
+    subsystems: list[int],
+    dimensions: list[int],
+    probs: list[float] | None = None,
+    solver: str = "cvxopt",
+    **kwargs,
+) -> tuple[float, list[picos.HermitianVariable]]:
+    """Solve the primal problem for unambiguous quantum state exclusion SDP with PPT constraints."""
+    n = len(vectors)
+    problem = picos.Problem()
+    measurements = [picos.HermitianVariable(f"M[{i}]", (dim, dim)) for i in range(n)]
+    inconclusive_measurement = picos.I(dim) - picos.sum(measurements)
+
+    problem.add_list_of_constraints([meas >> 0 for meas in measurements])
+    problem.add_list_of_constraints(
+        [picos.partial_transpose(meas, subsystems=subsystems, dimensions=dimensions) >> 0 for meas in measurements]
+    )
+    problem.add_constraint(inconclusive_measurement >> 0)
+    problem.add_constraint(
+        picos.partial_transpose(inconclusive_measurement, subsystems=subsystems, dimensions=dimensions) >> 0
+    )
+
+    unnormalized_dms = [p * to_density_matrix(vector) for (p, vector) in zip(probs, vectors)]
+    sum_of_unnormalized_dms = picos.sum(unnormalized_dms)
+
+    problem.add_list_of_constraints(m | rho == 0 for (m, rho) in zip(measurements, unnormalized_dms))
+
+    problem.set_objective("min", picos.trace(sum_of_unnormalized_dms * inconclusive_measurement))
     solution = problem.solve(solver=solver, **kwargs)
 
     return solution.value, measurements + [inconclusive_measurement]
@@ -305,3 +517,43 @@ def _unambiguous_dual(
     solution = problem.solve(solver=solver, primals=None, **kwargs)
 
     return solution.value, (lagrangian_variable_big_n, lagrangian_variables_a)
+
+
+def _ppt_unambiguous_dual(
+    vectors: list[np.ndarray],
+    dim: int,
+    subsystems: list[int],
+    dimensions: list[int],
+    probs: list[float] | None = None,
+    solver: str = "cvxopt",
+    **kwargs,
+) -> tuple[float, tuple[picos.HermitianVariable, picos.RealVariable]]:
+    """Solve the dual problem for unambiguous quantum state exclusion SDP with PPT constraints."""
+    n = len(vectors)
+    problem = picos.Problem()
+    y_var = picos.HermitianVariable("Y", (dim, dim))
+    lagrangian_variables_a = picos.RealVariable("a", n)
+
+    unnormalized_dms = [p * to_density_matrix(vector) for (p, vector) in zip(probs, vectors)]
+    sum_of_unnormalized_dms = picos.sum(unnormalized_dms)
+
+    _ppt_dual_cone_constraint(
+        problem=problem,
+        expr=sum_of_unnormalized_dms - y_var,
+        name="Q[inconclusive]",
+        subsystems=subsystems,
+        dimensions=dimensions,
+    )
+    for i in range(n):
+        _ppt_dual_cone_constraint(
+            problem=problem,
+            expr=lagrangian_variables_a[i] * unnormalized_dms[i] - y_var,
+            name=f"Q[{i}]",
+            subsystems=subsystems,
+            dimensions=dimensions,
+        )
+
+    problem.set_objective("max", picos.trace(y_var))
+    solution = problem.solve(solver=solver, primals=None, **kwargs)
+
+    return solution.value, (y_var, lagrangian_variables_a)

--- a/toqito/state_opt/tests/test_state_exclusion.py
+++ b/toqito/state_opt/tests/test_state_exclusion.py
@@ -5,8 +5,9 @@ import pytest
 
 from toqito.matrices import standard_basis
 from toqito.matrix_ops import to_density_matrix
-from toqito.state_opt import state_exclusion
-from toqito.states import bell
+from toqito.perms import swap
+from toqito.state_opt import state_exclusion, symmetric_extension_hierarchy
+from toqito.states import basis, bell
 
 e_0, e_1 = standard_basis(2)
 
@@ -61,6 +62,30 @@ solvers = ["cvxopt"]
 primal_duals = ["primal", "dual"]
 
 
+def _dm(vec):
+    """Build a normalized density matrix from a vector."""
+    vector = np.array(vec, dtype=complex).reshape(-1, 1)
+    return vector @ vector.conj().T / float(np.linalg.norm(vector) ** 2)
+
+
+def _gap_ensemble():
+    """Return a two-qubit ensemble with a strict global/PPT exclusion gap."""
+    return [_dm(vec) for vec in [(0, 1, 1, 1), (0, 0, 1, 1), (1, 0, 1, 1)]]
+
+
+def _bell_resource_ensemble():
+    """Return four Bell states tensored with a partially entangled resource state."""
+    e_0, e_1 = basis(2, 0), basis(2, 1)
+    e_00, e_11 = np.kron(e_0, e_0), np.kron(e_1, e_1)
+
+    eps = 1 / 2
+    resource_state = np.sqrt((1 + eps) / 2) * e_00 + np.sqrt((1 - eps) / 2) * e_11
+    resource_dm = resource_state @ resource_state.conj().T
+
+    states = [np.kron(bell(idx) @ bell(idx).conj().T, resource_dm) for idx in range(4)]
+    return [swap(state, [2, 3], [2, 2, 2, 2]) for state in states]
+
+
 @pytest.mark.parametrize("vectors, probs, expected_result, kwargs", states_min_error)
 @pytest.mark.parametrize("solver", solvers)
 @pytest.mark.parametrize("primal_dual", primal_duals)
@@ -100,3 +125,86 @@ def test_state_exclusion_invalid_vectors(vectors, probs, solver, primal_dual, st
     """Test function works as expected for an invalid input."""
     with pytest.raises(ValueError, match="Vectors for state distinguishability must all have the same dimension."):
         state_exclusion(vectors=vectors, probs=probs, solver=solver, primal_dual=primal_dual, strategy=strategy)
+
+
+@pytest.mark.parametrize("primal_dual", primal_duals)
+@pytest.mark.parametrize("strategy", ["min_error", "unambiguous"])
+def test_state_exclusion_ppt_four_bell_states(primal_dual, strategy):
+    """PPT exclusion supports primal and dual SDPs for both exclusion strategies."""
+    val, _ = state_exclusion(
+        vectors=[bell(0), bell(1), bell(2), bell(3)],
+        measurement="ppt",
+        subsystems=[0],
+        dimensions=[2, 2],
+        strategy=strategy,
+        primal_dual=primal_dual,
+        cvxopt_kktsolver="ldl",
+    )
+    np.testing.assert_allclose(val, 0, atol=1e-6)
+
+
+def test_state_exclusion_ppt_gap_ensemble_matches_symmetric_extension_level_one():
+    """PPT exclusion agrees with level 1 of the symmetric-extension exclusion hierarchy."""
+    states = _gap_ensemble()
+
+    ppt_primal, _ = state_exclusion(
+        states,
+        measurement="ppt",
+        subsystems=[0],
+        dimensions=[2, 2],
+        primal_dual="primal",
+        cvxopt_kktsolver="ldl",
+    )
+    ppt_dual, _ = state_exclusion(
+        states,
+        measurement="ppt",
+        subsystems=[0],
+        dimensions=[2, 2],
+        primal_dual="dual",
+        cvxopt_kktsolver="ldl",
+    )
+    level_one = symmetric_extension_hierarchy(states=states, probs=None, level=1, objective="exclude")
+
+    np.testing.assert_allclose(ppt_primal, ppt_dual, atol=1e-5)
+    np.testing.assert_allclose(ppt_primal, level_one, atol=1e-4)
+
+
+def test_state_exclusion_ppt_is_strictly_worse_than_global_for_gap_ensemble():
+    """PPT exclusion is bounded below by global exclusion and can be strictly larger."""
+    states = _gap_ensemble()
+
+    global_val, _ = state_exclusion(states, primal_dual="primal", cvxopt_kktsolver="ldl")
+    ppt_val, _ = state_exclusion(
+        states,
+        measurement="ppt",
+        subsystems=[0],
+        dimensions=[2, 2],
+        primal_dual="primal",
+        cvxopt_kktsolver="ldl",
+    )
+
+    np.testing.assert_equal(ppt_val >= global_val - 1e-5, True)
+    np.testing.assert_equal(ppt_val > global_val + 1e-2, True)
+
+
+def test_state_exclusion_ppt_bell_resource_matches_level_one_exclusion():
+    """PPT exclusion of Bell states with a resource state matches the hierarchy reference value."""
+    states = _bell_resource_ensemble()
+
+    ppt_val, _ = state_exclusion(
+        states,
+        measurement="ppt",
+        subsystems=[0, 2],
+        dimensions=[2, 2, 2, 2],
+        primal_dual="dual",
+        cvxopt_kktsolver="ldl",
+    )
+    level_one = symmetric_extension_hierarchy(states=states, probs=None, level=1, objective="exclude")
+
+    np.testing.assert_allclose(ppt_val, level_one, atol=1e-4)
+
+
+def test_state_exclusion_ppt_requires_subsystems_and_dimensions():
+    """Using `measurement='ppt'` without subsystem data should raise a clear ValueError."""
+    with pytest.raises(ValueError, match="subsystems.*dimensions"):
+        state_exclusion(vectors=[bell(0), bell(1)], measurement="ppt")

--- a/toqito/state_opt/tests/test_state_exclusion.py
+++ b/toqito/state_opt/tests/test_state_exclusion.py
@@ -208,3 +208,31 @@ def test_state_exclusion_ppt_requires_subsystems_and_dimensions():
     """Using `measurement='ppt'` without subsystem data should raise a clear ValueError."""
     with pytest.raises(ValueError, match="subsystems.*dimensions"):
         state_exclusion(vectors=[bell(0), bell(1)], measurement="ppt")
+
+
+def test_state_exclusion_ppt_wrong_dimensions():
+    """PPT dimensions must multiply to the state dimension."""
+    with pytest.raises(ValueError, match="product of `dimensions`"):
+        state_exclusion(
+            vectors=[bell(0), bell(1)],
+            measurement="ppt",
+            subsystems=[0],
+            dimensions=[2, 3],
+        )
+
+
+def test_state_exclusion_ppt_subsystems_out_of_range():
+    """PPT subsystem indices must be valid for the provided dimensions."""
+    with pytest.raises(ValueError, match="index into `dimensions`"):
+        state_exclusion(
+            vectors=[bell(0), bell(1)],
+            measurement="ppt",
+            subsystems=[5],
+            dimensions=[2, 2],
+        )
+
+
+def test_state_exclusion_invalid_measurement():
+    """Unsupported measurement types should raise a clear ValueError."""
+    with pytest.raises(ValueError, match="measurement.*positive.*ppt"):
+        state_exclusion(vectors=[bell(0), bell(1)], measurement="random_string")


### PR DESCRIPTION
Closes #1520.

Adds `measurement="ppt"` support to `state_exclusion`, allowing minimum-error and unambiguous quantum state exclusion SDPs to be solved with PPT-constrained measurement operators.

For minimum-error exclusion, the primal now supports:

```math
\begin{aligned}
\min \quad & \sum_i p_i \langle M_i, \rho_i \rangle \\
\text{s.t.} \quad & \sum_i M_i = I, \\
& M_i \succeq 0, \\
& \Gamma_S(M_i) \succeq 0 \quad \forall i.
\end{aligned}
```

Here, `\Gamma_S` denotes partial transpose over the subsystem indices passed through `subsystems`, with local dimensions given by `dimensions`.

The dual is implemented using the dual of the PPT cone. Since:

```math
\mathrm{PPT} = \mathrm{Pos} \cap \Gamma_S(\mathrm{Pos}),
```

the dual cone is:

```math
\mathrm{PPT}^* = \mathrm{Pos} + \Gamma_S(\mathrm{Pos}).
```

Thus the minimum-error dual constraints are modeled as:

```math
p_i \rho_i - Y \in \mathrm{Pos} + \Gamma_S(\mathrm{Pos}).
```

This matters for exclusion because the SDP minimizes overlap, unlike distinguishability, so the PPT dual cannot be obtained by simply copying the distinguishability implementation with the objective flipped.

The same PPT measurement constraint is also added for the unambiguous exclusion primal, including the inconclusive measurement operator. The unambiguous dual is implemented directly using the same dual PPT cone structure.

Tests added:

- PPT exclusion for Bell states, covering both `min_error` and `unambiguous`, primal and dual.
- Agreement between PPT exclusion and level-1 symmetric-extension hierarchy on a regression ensemble.
- A case where PPT exclusion is strictly worse than global exclusion.
- Bell-state-with-resource regression against the symmetric-extension hierarchy.
- Input validation for missing `subsystems` / `dimensions`.

Docs updated with the PPT SDP formulation, notation mapping, and a worked `measurement="ppt"` example.

Verification:

- `ruff check toqito/state_opt/state_exclusion.py toqito/state_opt/tests/test_state_exclusion.py`
- `ruff format --check toqito/state_opt/state_exclusion.py toqito/state_opt/tests/test_state_exclusion.py`
- `pytest toqito/state_opt/tests/test_state_exclusion.py`
- `pytest toqito/state_opt/tests`
- full `pytest`
- `mkdocs build -f mkdocs.yml` from `docs/`

All passed locally.
