### PR TITLE
fix: unbreak strict docs build (kwargs annotation + bibtex citation example)

### DIFF
--- a/docs/content/contributing-guide.md
+++ b/docs/content/contributing-guide.md
@@ -198,7 +198,7 @@ def my_new_function(some_parameter: parameter_type) -> return_type:
 ```
 
 Use `\(\)` for inline math and `\[\]` for display math in docstrings. To cite an entry in `refs.bib` in a docstring, 
-use, for example, <code>\[@johnston2014counting\]</code>.
+use, for example, <code>[&#64;johnston2014counting]</code>.
 
 To add an attribution to a paper or a book, add your reference with
 `some_ref` as the citation key to `docs/content/refs.bib`. All references in

--- a/toqito/channel_metrics/channel_exclusion.py
+++ b/toqito/channel_metrics/channel_exclusion.py
@@ -31,6 +31,8 @@ Careful points (followed in tests and code)
 
 """
 
+from typing import Any
+
 import numpy as np
 import picos as pc
 
@@ -46,7 +48,7 @@ def channel_exclusion(
     strategy: str = "min_error",
     solver: str = "cvxopt",
     primal_dual: str = "dual",
-    **kwargs,
+    **kwargs: Any,
 ) -> tuple[float, list[np.ndarray]]:
     r"""Compute minimum-error channel exclusion for a collection of channels.
 


### PR DESCRIPTION
The `Docs Preview` job (`mkdocs build --strict`) aborts with "Aborted with 1 warnings in strict mode!".

## Actual cause

The single fatal `WARNING` is from griffe:

```
griffe: toqito/channel_metrics/channel_exclusion.py:87: No type or annotation for parameter 'kwargs'
```

`channel_exclusion` documents a `kwargs` entry in its `Args` section, but the signature `**kwargs` had no annotation. Annotating it `**kwargs: Any` (matching the sibling public functions `channel_distinguishability`, `state_exclusion`, etc.) clears the warning. Reproduced locally with griffe + the google docstring parser: the bare signature emits the exact CI message, the annotated one emits nothing.

This warning predates #1581. It only surfaces on PRs that touch `docs/**`, `toqito/**`, or `.github/workflows/docs-preview.yml` (the `Docs Preview` path filter), so most recent PRs skipped the strict build and never hit it. #1581 edits `docs-preview.yml`, which triggered the build.

## Also included

The contributing guide shows `[@johnston2014counting]` as a citation example. `mkdocs-bibtex` matched it (real bib key) and turned it into a footnote, producing an `INFO`-level broken-`fnref` message. That message is not `WARNING`-level so it was never the build-breaker, but the example also rendered with literal backslashes inside `<code>`. Writing the `@` as `&#64;` stops the plugin from processing it while still rendering `[@johnston2014counting]`. Minor cleanup, kept here since it is in the same area.