### PR TITLE
refactor: move BB84 example fixtures out of the nonlocal_games package

### DIFF
--- a/toqito/nonlocal_games/__init__.py
+++ b/toqito/nonlocal_games/__init__.py
@@ -1,12 +1,5 @@
 """A number of nonlocal game-related functions for toqito."""
 
-from toqito.nonlocal_games.constrained_extended_games import (
-    bb84_extended_nonlocal_game,
-    constrained_bb84_monogamy_answer_constraints,
-    constrained_bb84_monogamy_answer_constraints_dense,
-    forbid_bb84_answer_event,
-    forbid_bb84_diagonal_answers_at,
-)
 from toqito.nonlocal_games.extended_nonlocal_game import AnswerEventConstraint, ExtendedNonlocalGame
 from toqito.nonlocal_games.nonlocal_game import NonlocalGame
 from toqito.nonlocal_games.quantum_hedging import QuantumHedging

--- a/toqito/nonlocal_games/tests/_constrained_games_fixtures.py
+++ b/toqito/nonlocal_games/tests/_constrained_games_fixtures.py
@@ -1,7 +1,10 @@
-"""Helpers for constrained extended nonlocal games.
+"""Test fixtures for constrained extended nonlocal games.
 
-Linear constraints follow Escolà-Farràs and Speelman, *Lossy-and-Constrained Extended
+These build the BB84 monogamy-of-entanglement example and its linear answer
+constraints from Escolà-Farràs and Speelman, *Lossy-and-Constrained Extended
 Non-Local Games with Applications to Quantum Cryptography* (arXiv:2405.13717).
+They are example fixtures used only by the test suite, not part of the public
+``toqito.nonlocal_games`` API.
 """
 
 from __future__ import annotations
@@ -67,11 +70,6 @@ def constrained_bb84_monogamy_answer_constraints_dense() -> list[AnswerEventCons
     c_x1[0, 1, 1, 1] = 1.0
     c_x1[1, 0, 1, 1] = 1.0
     return [(c_x0, "==", 0.0), (c_x1, "==", 0.0)]
-
-
-def forbid_bb84_answer_event(a: int, b: int, x: int, y: int) -> list[AnswerEventConstraint]:
-    r"""Return a single equality forcing :math:`p(a, b \mid x, y) = 0`."""
-    return [({(a, b, x, y): 1.0}, "==", 0.0)]
 
 
 def forbid_bb84_diagonal_answers_at(x: int, y: int) -> list[AnswerEventConstraint]:

--- a/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
@@ -8,13 +8,13 @@ import cvxpy
 import numpy as np
 import pytest
 
-from toqito.nonlocal_games.constrained_extended_games import (
+from toqito.nonlocal_games.extended_nonlocal_game import ExtendedNonlocalGame
+from toqito.nonlocal_games.tests._constrained_games_fixtures import (
     bb84_extended_nonlocal_game,
     constrained_bb84_monogamy_answer_constraints,
     constrained_bb84_monogamy_answer_constraints_dense,
     forbid_bb84_diagonal_answers_at,
 )
-from toqito.nonlocal_games.extended_nonlocal_game import ExtendedNonlocalGame
 from toqito.states import basis
 
 


### PR DESCRIPTION
Follow-up to #1571.

## Problem

`toqito/nonlocal_games/constrained_extended_games.py` shipped concrete fixtures for one paper's example (the BB84 monogamy-of-entanglement game and its linear answer constraints from arXiv:2405.13717) and re-exported them from `toqito.nonlocal_games`. That put paper-specific example data into the public API.

The only consumer was the extended-nonlocal-game test suite. The tutorial (`docs/content/examples/extended_nonlocal_games/enlg_bb84.py`) builds its own game inline and does not import these, and `forbid_bb84_answer_event` was unused entirely.

## Change

- Move the four used helpers into a private test fixtures module, `toqito/nonlocal_games/tests/_constrained_games_fixtures.py` (not collected as tests, already excluded from the API docs).
- Drop the unused `forbid_bb84_answer_event`.
- Remove the re-export from `toqito/nonlocal_games/__init__.py`.
- Delete `toqito/nonlocal_games/constrained_extended_games.py`.

The general machinery (`AnswerEventConstraint`, `ExtendedNonlocalGame.commuting_measurement_value_upper_bound`) is unchanged and stays in `extended_nonlocal_game.py`.

## Notes

The fixture-exercising tests pass locally. Four `nonsignaling`/`mub` SDP tests fail in my local environment with a `cvxpy` `KeyError` in cone matrix stuffing; I confirmed they fail identically on clean `master` (unrelated to this change, a local solver/version issue) and they pass in CI.