### PR TITLE
fix: repair vectors_from_gram_matrix docstring and non-PD fallback

### DIFF
--- a/toqito/matrix_ops/tests/test_vectors_from_gram_matrix.py
+++ b/toqito/matrix_ops/tests/test_vectors_from_gram_matrix.py
@@ -22,15 +22,36 @@ def test_vectors_from_gram_matrix(gram, expected_result):
     np.testing.assert_allclose(vectors, expected_result)
 
 
-def test_vectors_from_gram_matrix_not_psd():
-    """Test when matrix is not positive semidefinite."""
-    gram = np.array([[1, -1 / 2, -1 / 2], [-1 / 2, 1, -1 / 2], [-1 / 2, -1 / 2, 1]], dtype=complex)
+@pytest.mark.parametrize(
+    "gram",
+    [
+        # Positive-definite real Gram matrix (Cholesky path).
+        np.array([[2, -1], [-1, 2]], dtype=float),
+        # Positive-definite complex Hermitian Gram matrix (Cholesky path).
+        np.array([[2, 1j], [-1j, 2]], dtype=complex),
+    ],
+)
+def test_vectors_from_gram_matrix_reconstructs(gram):
+    """The returned vectors reconstruct a positive-definite Gram matrix."""
+    mat = np.array(vectors_from_gram_matrix(gram))
+    np.testing.assert_allclose(mat @ mat.conj().T, gram, atol=1e-8)
 
-    vectors = vectors_from_gram_matrix(gram)
 
-    assert np.allclose(vectors[0][0], 1)
-    assert np.allclose(vectors[1][0], -1 / 2)
-    assert np.allclose(vectors[2][0], -1 / 2)
+@pytest.mark.parametrize(
+    "gram",
+    [
+        # Rank-deficient (PSD but not PD) real Gram matrix: Cholesky fails, eigendecomposition fallback is used.
+        np.array([[1, 1], [1, 1]], dtype=float),
+        # Singular trine Gram matrix (eigenvalues 0, 3/2, 3/2).
+        np.array([[1, -1 / 2, -1 / 2], [-1 / 2, 1, -1 / 2], [-1 / 2, -1 / 2, 1]], dtype=complex),
+    ],
+)
+def test_vectors_from_gram_matrix_not_psd(gram):
+    """Vectors from a non-positive-definite (but PSD) Gram matrix reconstruct that matrix."""
+    with pytest.warns(UserWarning):
+        vectors = vectors_from_gram_matrix(gram)
+    mat = np.array(vectors)
+    np.testing.assert_allclose(mat @ mat.conj().T, gram, atol=1e-8)
 
 
 @pytest.mark.parametrize(

--- a/toqito/matrix_ops/vectors_from_gram_matrix.py
+++ b/toqito/matrix_ops/vectors_from_gram_matrix.py
@@ -3,25 +3,24 @@
 import warnings
 
 import numpy as np
-import scipy
 
 
 def vectors_from_gram_matrix(gram: np.ndarray) -> list[np.ndarray]:
     r"""Obtain the corresponding ensemble of states from the Gram matrix [@wikipediagram].
 
     The function attempts to compute the Cholesky decomposition of the given Gram matrix. If the matrix is positive
-    definite, the Cholesky decomposition is returned. If the matrix is not positive definite, the function falls back to
-    eigendecomposition.
+    definite, the (lower-triangular) Cholesky factor is returned. If the matrix is not positive definite, the function
+    falls back to a Hermitian eigendecomposition and returns vectors whose Gram matrix equals the positive-semidefinite
+    part of the input.
+
+    In both cases the returned list of vectors ``v`` satisfies ``np.array(v) @ np.array(v).conj().T == gram`` whenever
+    ``gram`` is positive semidefinite.
 
     Args:
-        gram: A square, symmetric matrix representing the Gram matrix.
+        gram: A square, symmetric (Hermitian) matrix representing the Gram matrix.
 
     Returns:
         A list of vectors (np.ndarray) corresponding to the ensemble of states.
-    =======
-        print(vectors)
-    ```
-    >>>>>>> d965b901 (Fix: Reorder docstring sections in matrix_ops (#1455))
 
     Raises:
         LinAlgError: If the Gram matrix is not square.
@@ -43,10 +42,10 @@ def vectors_from_gram_matrix(gram: np.ndarray) -> list[np.ndarray]:
         import numpy as np
         from toqito.matrix_ops import vectors_from_gram_matrix
 
-        gram_matrix = np.array([[0, 1], [1, 0]])
+        gram_matrix = np.array([[1, 1], [1, 1]])
         vectors = vectors_from_gram_matrix(gram_matrix)
 
-            <<<<<<< HEAD
+        print(vectors)
         ```
 
     """
@@ -54,12 +53,17 @@ def vectors_from_gram_matrix(gram: np.ndarray) -> list[np.ndarray]:
     if gram.shape[0] != gram.shape[1]:
         raise np.linalg.LinAlgError("The Gram matrix must be square.")
 
-    # If matrix is PD, can do Cholesky decomposition:
+    # If the matrix is positive definite, we can use the Cholesky decomposition. The rows of the lower-triangular factor
+    # are the requested vectors, since ``gram == decomp @ decomp.conj().T``.
     try:
         decomp = np.linalg.cholesky(gram)
-        return [decomp[i][:] for i in range(dim)]
-    # Otherwise, need to do eigendecomposition:
+        return [decomp[i, :] for i in range(dim)]
+    # Otherwise, fall back to a Hermitian eigendecomposition. ``eigh`` (not ``eig``) is correct here because a Gram
+    # matrix is Hermitian; it returns real eigenvalues and orthonormal eigenvectors.
     except np.linalg.LinAlgError:
-        warnings.warn("Matrix is not positive semidefinite. Using eigendecomposition as alternative.")
-        d, v = np.linalg.eig(gram)
-        return [scipy.linalg.sqrtm(np.diag(d)) @ v[i].conj().T for i in range(dim)]
+        warnings.warn("Matrix is not positive definite. Using eigendecomposition as alternative.")
+        eig_vals, eig_vecs = np.linalg.eigh(gram)
+        # Clip eigenvalues that are negative (numerical noise, or a genuinely non-PSD input) to zero so the factor is
+        # well-defined. The reconstructed Gram matrix is then the positive-semidefinite part of the input.
+        factor = eig_vecs @ np.diag(np.sqrt(np.clip(eig_vals, 0, None)))
+        return [factor[i, :] for i in range(dim)]


### PR DESCRIPTION
Closes #1591.

## Problem
`toqito/matrix_ops/vectors_from_gram_matrix.py` had two issues found during a repo-wide review:

1. Committed merge-conflict markers (`=======`, `>>>>>>>`, `<<<<<<<`) left in the docstring from #1455, which corrupt the rendered documentation.
2. The non-positive-definite fallback did not reconstruct the Gram matrix. It used `np.linalg.eig` on a Hermitian matrix, indexed the eigenvectors as rows instead of columns, and multiplied the square-root factor on the wrong side.

## Changes
- Remove the merge-conflict markers and clean up the docstring and examples.
- Replace the fallback with a Hermitian eigendecomposition (`eigh`) that clips negative eigenvalues to zero and returns the rows of `eig_vecs @ diag(sqrt(eig_vals))`. The returned vectors `V` now satisfy `V @ V.conj().T == gram` for any positive-semidefinite input (the common case being a rank-deficient Gram matrix, where Cholesky fails but the matrix is still PSD).
- Drop the now-unused scipy import.
- Replace the old non-PSD test (which checked three scalar entries against the previous, incorrect output) with reconstruction-invariant tests over real and complex Hermitian, positive-definite and rank-deficient Gram matrices.

This is the first item addressed from a broader review; the remaining findings are tracked in #1584 through #1602.