### PR TITLE
fix: compute hilbert_schmidt with the Frobenius norm, not the spectral norm

### DIFF
--- a/toqito/state_metrics/hilbert_schmidt.py
+++ b/toqito/state_metrics/hilbert_schmidt.py
@@ -43,4 +43,4 @@ def hilbert_schmidt(rho: np.ndarray, sigma: np.ndarray) -> float | np.floating:
     """
     if not is_density(rho) or not is_density(sigma):
         raise ValueError("Hilbert-Schmidt is only defined for density operators.")
-    return np.linalg.norm(rho - sigma, ord=2) ** 2
+    return np.linalg.norm(rho - sigma, ord="fro") ** 2

--- a/toqito/state_metrics/tests/test_hilbert_schmidt.py
+++ b/toqito/state_metrics/tests/test_hilbert_schmidt.py
@@ -13,7 +13,20 @@ def test_hilbert_schmidt_bell():
 
     res = hilbert_schmidt(rho, sigma)
 
-    np.testing.assert_equal(np.isclose(res, 1), True)
+    # The two Bell states are orthogonal pure states, so rho - sigma has eigenvalues +1 and -1
+    # and Tr((rho - sigma)^2) = 2.
+    np.testing.assert_allclose(res, 2)
+
+
+def test_hilbert_schmidt_matches_trace_formula():
+    r"""Hilbert-Schmidt distance equals Tr((rho - sigma)^2) for non-commuting mixed states."""
+    rho = np.array([[0.6, 0.2], [0.2, 0.4]])
+    sigma = np.array([[0.4, 0.3], [0.3, 0.6]])
+
+    res = hilbert_schmidt(rho, sigma)
+
+    diff = rho - sigma
+    np.testing.assert_allclose(res, np.real(np.trace(diff @ diff)))
 
 
 def test_hilbert_schmidt_non_density_matrix():


### PR DESCRIPTION
Closes #1584.

## Problem
`hilbert_schmidt` computed `np.linalg.norm(rho - sigma, ord=2)`, which numpy interprets as the spectral norm (largest singular value), not the Hilbert-Schmidt distance `Tr((rho - sigma)^2)` defined in the docstring. These are the Schatten infinity and Schatten 2 norms; they differ for any non-rank-1 difference.

For the two orthogonal Bell states in the docstring example, the function returned 1.0 instead of the correct 2.0, and `test_hilbert_schmidt_bell` asserted the wrong value, so the bug was locked in.

## Changes
- Use `ord="fro"` so the result is `Tr((rho - sigma)^2)`.
- Update `test_hilbert_schmidt_bell` to assert 2.
- Add `test_hilbert_schmidt_matches_trace_formula`, which checks the result against `Tr((rho - sigma)^2)` for non-commuting mixed states (the case the old spectral-norm code got wrong).