### PR TITLE
fix: compute trace_distance from the trace norm of the difference

### DIFF
--- a/toqito/state_metrics/tests/test_trace_distance.py
+++ b/toqito/state_metrics/tests/test_trace_distance.py
@@ -21,6 +21,27 @@ def test_trace_distance_same_state():
     np.testing.assert_equal(np.isclose(res, 0), True)
 
 
+def test_trace_distance_orthogonal_pure_states():
+    r"""Trace distance between orthogonal pure states is 1."""
+    e_0, e_1 = basis(2, 0), basis(2, 1)
+    rho = e_0 @ e_0.conj().T
+    sigma = e_1 @ e_1.conj().T
+
+    np.testing.assert_allclose(trace_distance(rho, sigma), 1)
+
+
+def test_trace_distance_non_commuting_states():
+    r"""Trace distance equals half the sum of \|eig(rho - sigma)\| for non-commuting states."""
+    rho = np.array([[0.6, 0.2], [0.2, 0.4]])
+    sigma = np.array([[0.4, 0.3], [0.3, 0.6]])
+
+    res = trace_distance(rho, sigma)
+
+    # The elementwise-abs implementation returned 0.2 here; the correct value is ~0.2236.
+    expected = 0.5 * np.sum(np.abs(np.linalg.eigvalsh(rho - sigma)))
+    np.testing.assert_allclose(res, expected)
+
+
 def test_trace_distance_non_density_matrix():
     r"""Test trace distance on non-density matrix."""
     rho = np.array([[1, 2], [3, 4]])

--- a/toqito/state_metrics/trace_distance.py
+++ b/toqito/state_metrics/trace_distance.py
@@ -64,4 +64,4 @@ def trace_distance(rho: np.ndarray, sigma: np.ndarray) -> float | np.floating:
     """
     if not is_density(rho) or not is_density(sigma):
         raise ValueError("Trace distance only defined for density matrices.")
-    return trace_norm(np.abs(rho - sigma)) / 2
+    return trace_norm(rho - sigma) / 2


### PR DESCRIPTION
Closes #1585.

## Problem
`trace_distance` computed `trace_norm(np.abs(rho - sigma)) / 2`. The elementwise `np.abs` is incorrect: the trace distance is `(1/2) Tr|rho - sigma|`, where `|A| = sqrt(A^dagger A)` is the matrix absolute value, which `trace_norm` (the nuclear norm) already computes from the singular values. Applying elementwise `np.abs` first changes the matrix.

The result was only correct when `rho - sigma` was diagonal with nonnegative entries, which is exactly the same-state (distance 0) case the single test exercised. For example, with `rho=[[.6,.2],[.2,.4]]` and `sigma=[[.4,.3],[.3,.6]]` it returned 0.2 instead of the correct 0.2236.

## Changes
- Use `trace_norm(rho - sigma) / 2`.
- Add `test_trace_distance_orthogonal_pure_states` (distance 1) and `test_trace_distance_non_commuting_states`, which cross-checks against `0.5 * sum(|eig(rho - sigma)|)`.