### PR TITLE
fix: correct antisymmetric_projection sign and partial-projection output

### DIFF
--- a/toqito/perms/antisymmetric_projection.py
+++ b/toqito/perms/antisymmetric_projection.py
@@ -3,6 +3,7 @@
 from itertools import permutations
 
 import numpy as np
+from scipy.linalg import orth
 
 from toqito.perms import perm_sign, permutation_operator
 
@@ -12,8 +13,8 @@ def antisymmetric_projection(dim: int, p_param: int = 2, partial: bool = False) 
 
     Produces the orthogonal projection onto the anti-symmetric subspace of `p_param` copies of
     `dim`-dimensional space. If `partial = True`, then the antisymmetric projection (PA) isn't the
-    orthogonal projection itself, but rather a matrix whose columns form an orthonormal basis for the symmetric subspace
-    (and hence the PA * PA' is the orthogonal projection onto the symmetric subspace.)
+    orthogonal projection itself, but rather a matrix whose columns form an orthonormal basis for the antisymmetric
+    subspace (and hence PA * PA' is the orthogonal projection onto the antisymmetric subspace.)
 
     Args:
         dim: The dimension of the local systems.
@@ -82,9 +83,12 @@ def antisymmetric_projection(dim: int, p_param: int = 2, partial: bool = False) 
 
     anti_proj = np.zeros((dimp, dimp))
     for j in range(p_fac):
-        anti_proj += perm_sign(p_list[j, :]) * permutation_operator(dim * np.ones(p_param), p_list[j, :], False, True)
+        # `perm_sign` expects 1-based permutation labels, while `p_list` is 0-based, so shift by 1.
+        anti_proj += perm_sign(p_list[j, :] + 1) * permutation_operator(
+            dim * np.ones(p_param), p_list[j, :], False, True
+        )
     anti_proj = anti_proj / p_fac
 
     if partial:
-        anti_proj = np.array(np.linalg.qr(anti_proj))
+        anti_proj = orth(anti_proj)
     return anti_proj

--- a/toqito/perms/perm_sign.py
+++ b/toqito/perms/perm_sign.py
@@ -7,14 +7,16 @@ from scipy import linalg
 def perm_sign(perm: np.ndarray | list[int]) -> float:
     r"""Compute the "sign" of a permutation [@wikipediaparity].
 
-    The sign (either -1 or 1) of the permutation `perm` is `-1**inv`, where `inv` is the number of
+    The sign (either -1 or 1) of the permutation `perm` is `(-1)**inv`, where `inv` is the number of
     inversions contained in `perm`.
 
+    The permutation is expected to use 1-based labels, i.e. a permutation of `[1, 2, ..., n]`.
+
     Args:
-        perm: The permutation vector to be checked.
+        perm: The permutation vector (using 1-based labels `1, ..., n`) to be checked.
 
     Returns:
-        The value 1 if the permutation is of even length and the value of -1 if the permutation is of odd length.
+        The value 1 if the permutation is even (an even number of inversions) and -1 if it is odd.
 
     Examples:
         For the following vector
@@ -23,8 +25,8 @@ def perm_sign(perm: np.ndarray | list[int]) -> float:
             [1, 2, 3, 4]
         \]
 
-        the permutation sign is positive as the number of elements in the vector are even. This can be performed in
-        `|toqito⟩` as follows.
+        the permutation sign is positive because it is the identity permutation (no inversions). This can be performed
+        in `|toqito⟩` as follows.
 
         ```python exec="1" source="above" result="text"
         from toqito.perms import perm_sign
@@ -35,11 +37,11 @@ def perm_sign(perm: np.ndarray | list[int]) -> float:
         For the following vector
 
         \[
-            [1, 2, 3, 4, 5]
+            [1, 2, 4, 3, 5]
         \]
 
-        the permutation sign is negative as the number of elements in the vector are odd. This can be performed in
-        `|toqito⟩` as follows.
+        the permutation sign is negative because it contains a single inversion (the pair 4, 3). This can be performed
+        in `|toqito⟩` as follows.
 
         ```python exec="1" source="above" result="text"
         from toqito.perms import perm_sign

--- a/toqito/perms/tests/test_antisymmetric_projection.py
+++ b/toqito/perms/tests/test_antisymmetric_projection.py
@@ -1,36 +1,54 @@
 """Test antisymmetric_projection."""
 
+import math
+
 import numpy as np
 import pytest
 
 from toqito.perms import antisymmetric_projection
 
-# Create a zero vector of length 27
-anti_proj_3_3_partial = np.zeros((27, 1))
-
-# Set specific indices to -0.40824829 and 0.40824829
-anti_proj_3_3_partial[5] = -0.40824829
-anti_proj_3_3_partial[7] = 0.40824829
-anti_proj_3_3_partial[11] = 0.40824829
-anti_proj_3_3_partial[15] = -0.40824829
-anti_proj_3_3_partial[19] = -0.40824829
-anti_proj_3_3_partial[21] = 0.40824829
-
 
 @pytest.mark.parametrize(
-    "dim, p_param, partial, expected_result",
+    "dim, p_param, expected_result",
     [
-        # Dimension is 2 and p is equal to 1.
-        (2, 1, False, np.array([[1, 0], [0, 1]])),
-        # The `p` value is greater than the dimension `d`.
-        (2, 3, False, np.zeros((8, 8))),
-        # The dimension is 2.
-        (2, 2, False, np.array([[0, 0, 0, 0], [0, 0.5, -0.5, 0], [0, -0.5, 0.5, 0], [0, 0, 0, 0]])),
-        # The `dim` is 3, the `p` is 3, and `partial` is True.
-        (3, 3, True, anti_proj_3_3_partial),
+        # Dimension is 2 and p is equal to 1: identity.
+        (2, 1, np.array([[1, 0], [0, 1]])),
+        # The `p` value is greater than the dimension `d`: empty antisymmetric subspace.
+        (2, 3, np.zeros((8, 8))),
+        # The dimension is 2, p is 2: projection onto the (one-dimensional) antisymmetric subspace.
+        (2, 2, np.array([[0, 0, 0, 0], [0, 0.5, -0.5, 0], [0, -0.5, 0.5, 0], [0, 0, 0, 0]])),
     ],
 )
-def test_antisymmetric_projection(dim, p_param, partial, expected_result):
-    """Test function works as expected for a valid input."""
-    proj = antisymmetric_projection(dim=dim, p_param=p_param, partial=partial)
-    assert abs(proj - expected_result).all() <= 1e-3
+def test_antisymmetric_projection_value(dim, p_param, expected_result):
+    """Test the projector matches the known closed form."""
+    proj = antisymmetric_projection(dim=dim, p_param=p_param)
+    np.testing.assert_allclose(proj, expected_result, atol=1e-8)
+
+
+@pytest.mark.parametrize("dim, p_param", [(2, 2), (3, 2), (3, 3), (4, 2), (4, 3)])
+def test_antisymmetric_projection_is_projector(dim, p_param):
+    """The full projection is a Hermitian idempotent whose rank is the antisymmetric subspace dimension."""
+    proj = antisymmetric_projection(dim=dim, p_param=p_param)
+
+    # Idempotent and Hermitian.
+    np.testing.assert_allclose(proj @ proj, proj, atol=1e-8)
+    np.testing.assert_allclose(proj, proj.conj().T, atol=1e-8)
+    # Eigenvalues are 0 or 1 (a genuine orthogonal projection, not its negative).
+    eigvals = np.linalg.eigvalsh(proj)
+    assert eigvals.min() > -1e-8
+    # Rank equals C(dim, p_param), the dimension of the antisymmetric subspace.
+    np.testing.assert_allclose(np.trace(proj), math.comb(dim, p_param), atol=1e-8)
+
+
+@pytest.mark.parametrize("dim, p_param", [(3, 3), (3, 2), (4, 2)])
+def test_antisymmetric_projection_partial(dim, p_param):
+    """The partial form has orthonormal columns that reconstruct the full projector."""
+    basis = antisymmetric_projection(dim=dim, p_param=p_param, partial=True)
+    full = antisymmetric_projection(dim=dim, p_param=p_param)
+
+    # Columns are orthonormal.
+    np.testing.assert_allclose(basis.conj().T @ basis, np.eye(basis.shape[1]), atol=1e-8)
+    # basis @ basis^dagger reconstructs the orthogonal projection.
+    np.testing.assert_allclose(basis @ basis.conj().T, full, atol=1e-8)
+    # The number of basis vectors equals the antisymmetric subspace dimension.
+    assert basis.shape[1] == math.comb(dim, p_param)

--- a/toqito/perms/tests/test_perm_sign.py
+++ b/toqito/perms/tests/test_perm_sign.py
@@ -1,6 +1,7 @@
 """Test perm_sign."""
 
 import numpy as np
+import pytest
 
 from toqito.perms import perm_sign
 
@@ -15,3 +16,23 @@ def test_perm_sign_small_example_odd():
     """Small example when permutation is odd."""
     res = perm_sign([1, 2, 4, 3, 5])
     np.testing.assert_equal(res, -1)
+
+
+@pytest.mark.parametrize(
+    "perm, expected",
+    [
+        # 3-cycle (even number of inversions).
+        ([2, 3, 1], 1),
+        ([3, 1, 2], 1),
+        # Single transposition (odd).
+        ([2, 1, 3], -1),
+        ([1, 3, 2], -1),
+        # Reversal of four elements has six inversions (even).
+        ([4, 3, 2, 1], 1),
+        # A scrambled permutation with three inversions (odd): (4,1), (4,2), (4,3).
+        ([4, 1, 2, 3], -1),
+    ],
+)
+def test_perm_sign_scrambled(perm, expected):
+    """Sign of genuinely scrambled permutations matches the parity of their inversions."""
+    np.testing.assert_allclose(perm_sign(perm), expected)


### PR DESCRIPTION
Closes #1586.

## Problem
`antisymmetric_projection` was not a projector for even `p` (including the default `p=2`). For example `antisymmetric_projection(2, 2)` had an eigenvalue of -1 and satisfied `A @ A = -A`.

Root cause: `perm_sign` computes the sign as `det(eye(n)[:, perm - 1])`, so it expects 1-based permutation labels. `antisymmetric_projection` fed it 0-based permutations from `permutations(np.arange(p))`. The `- 1` turned index 0 into -1 (the last column), injecting a fixed extra cyclic permutation whose sign multiplied every term. `perm_sign` then disagreed with the true sign on all 24 permutations of a 4-element set. For odd `p` the extra cycle has sign +1 and the error cancels, which is why `p=3` looked correct.

Separately, `partial=True` returned `np.array(np.linalg.qr(anti_proj))`, which stacks the `(Q, R)` tuple into a `(2, d, d)` array instead of returning an orthonormal basis.

The existing test used `abs(proj - expected).all() <= 1e-3`, which is always True, so neither bug was caught. (Its own `expected_result` for the `(2, 2)` case was the correct `+1` projector.)

## Changes
- Pass 1-based permutations to `perm_sign` (`p_list[j, :] + 1`).
- Use `scipy.linalg.orth` for the `partial=True` basis, matching `symmetric_projection`.
- Replace the no-op test with exact-value checks plus invariants: the full projection is Hermitian, idempotent, has nonnegative eigenvalues, and has rank `C(dim, p)`; the partial form has orthonormal columns that reconstruct the full projector.
- Add `perm_sign` tests over genuinely scrambled permutations.
- Fix the `perm_sign` docstring, which incorrectly tied the sign to the permutation's length rather than the parity of its inversions, and document the 1-based convention.