### PR TITLE
fix: determine is_pure from matrix rank instead of the largest eigenvalue

### DIFF
--- a/toqito/state_props/is_pure.py
+++ b/toqito/state_props/is_pure.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 
-def is_pure(state: list[np.ndarray] | np.ndarray) -> bool:
+def is_pure(state: list[np.ndarray] | np.ndarray, tol: float | None = None) -> bool:
     r"""Determine if a given state is pure or list of states are pure [@wikipediapurestate].
 
     A state is said to be pure if it is a density matrix with rank equal to 1. Equivalently, the
@@ -16,6 +16,8 @@ def is_pure(state: list[np.ndarray] | np.ndarray) -> bool:
     Args:
         state: The density matrix representing the quantum state or a list of density matrices representing quantum
             states.
+        tol: Tolerance used when computing the matrix rank. If `None` (default), numpy's relative tolerance based on
+            the largest singular value is used.
 
     Returns:
         `True` if state is pure and `False` otherwise.
@@ -65,14 +67,7 @@ def is_pure(state: list[np.ndarray] | np.ndarray) -> bool:
         ```
 
     """
-    # Allow the user to enter a list of states to check.
-    if isinstance(state, list):
-        for rho in state:
-            eigs, _ = np.linalg.eig(rho)
-            if not np.allclose(np.max(np.diag(eigs)), 1):
-                return False
-        return True
-
-    # Otherwise, if the user just put in a single state, check that.
-    eigs, _ = np.linalg.eig(state)
-    return np.allclose(np.max(np.diag(eigs)), 1)
+    # A state is pure if and only if its density matrix has rank one. Check each provided state; allow the user to
+    # enter either a single state or a list of states.
+    states = state if isinstance(state, list) else [state]
+    return all(np.linalg.matrix_rank(rho, tol=tol) == 1 for rho in states)

--- a/toqito/state_props/tests/test_is_pure.py
+++ b/toqito/state_props/tests/test_is_pure.py
@@ -18,6 +18,12 @@ e_0, e_1, e_2 = np.array([[1], [0], [0]]), np.array([[0], [1], [0]]), np.array([
         ([e_0 @ e_0.conj().T, e_1 @ e_1.conj().T, e_2 @ e_2.conj().T], True),
         # Check that non-pure state returns False.
         (np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), False),
+        # A rank-2 mixed diagonal state is not pure (the old max-eigenvalue check wrongly returned True here).
+        (np.diag([1.0, 0.5]), False),
+        # The maximally mixed qubit state is not pure.
+        (np.eye(2) / 2, False),
+        # A rank-1 (unnormalized) projector is pure.
+        (2 * (e_0 @ e_0.conj().T), True),
         # Check that list of non-pure states return False.
         (
             [


### PR DESCRIPTION
Closes #1587.

## Problem
`is_pure` returned True when the largest eigenvalue was approximately 1 (`np.max(np.diag(np.linalg.eig(rho)[0]))`), which does not match its documented definition: a density matrix of rank one. So a rank-2 mixed state like `diag(1, 0.5)` was reported as pure because its largest eigenvalue is 1. It also used the non-Hermitian `np.linalg.eig`.

## Changes
- Compute purity as `np.linalg.matrix_rank(rho) == 1`, which is exactly the documented rank-one criterion and uses numpy's relative tolerance (scaled by the largest singular value).
- Add an optional `tol` parameter forwarded to `matrix_rank`.
- Add regression tests: `diag(1, 0.5)` and the maximally mixed state are not pure; a rank-one (unnormalized) projector is pure.

Existing callers (`is_mixed`, `fidelity_of_separability`) and their tests are unaffected, since rank-one states are still reported pure.