### PR TITLE
fix: use Hermitian eigensolvers in von_neumann_entropy and concurrence

### DIFF
--- a/toqito/state_props/concurrence.py
+++ b/toqito/state_props/concurrence.py
@@ -89,6 +89,9 @@ def concurrence(rho: np.ndarray) -> float:
 
     rho_tilde = sigma_y_y @ rho.conj() @ sigma_y_y
 
-    eig_vals = np.linalg.eigvals(rho @ rho_tilde)
-    eig_vals = np.sort(np.abs(np.sqrt(eig_vals)))[::-1]
-    return max(0, eig_vals[0] - eig_vals[1] - eig_vals[2] - eig_vals[3])
+    # The eigenvalues of rho @ rho_tilde are real and nonnegative in theory, but np.linalg.eigvals can return small
+    # imaginary parts. Take the real part and clip away negative numerical noise before the square root, rather than
+    # using abs(sqrt(.)), which would distort genuinely complex numerical values.
+    eig_vals = np.real(np.linalg.eigvals(rho @ rho_tilde))
+    eig_vals = np.sqrt(np.sort(eig_vals.clip(min=0))[::-1])
+    return float(max(0, eig_vals[0] - eig_vals[1] - eig_vals[2] - eig_vals[3]))

--- a/toqito/state_props/tests/test_concurrence.py
+++ b/toqito/state_props/tests/test_concurrence.py
@@ -16,12 +16,23 @@ e_0, e_1 = np.array([[1], [0]]), np.array([[0], [1]])
         (bell(0) @ bell(0).conj().T, 1),
         # Concurrence of a product state is zero.
         (np.kron(e_0, e_1) @ np.kron(e_0, e_1).conj().T, 0),
+        # Non-maximally entangled pure state cos(t)|00> + sin(t)|11> has concurrence |sin(2t)|.
+        # For t = pi/6 this is sin(pi/3) = sqrt(3)/2.
+        (
+            (
+                (np.cos(np.pi / 6) * np.kron(e_0, e_0) + np.sin(np.pi / 6) * np.kron(e_1, e_1))
+                @ (np.cos(np.pi / 6) * np.kron(e_0, e_0) + np.sin(np.pi / 6) * np.kron(e_1, e_1)).conj().T
+            ),
+            np.sqrt(3) / 2,
+        ),
+        # The maximally mixed two-qubit state is separable, so its concurrence is zero.
+        (np.identity(4) / 4, 0),
     ],
 )
 def test_concurrence(rho, expected_result):
     """Test function works as expected for a valid input."""
     res = concurrence(rho)
-    np.testing.assert_equal(np.isclose(res, expected_result), True)
+    np.testing.assert_allclose(res, expected_result, atol=1e-8)
 
 
 @pytest.mark.parametrize(

--- a/toqito/state_props/tests/test_von_neumann_entropy.py
+++ b/toqito/state_props/tests/test_von_neumann_entropy.py
@@ -14,11 +14,24 @@ from toqito.states import bell, max_mixed
         (bell(0) @ bell(0).conj().T, 0),
         # Von Neumann entropy of the maximally mixed state should be one.
         (max_mixed(2, is_sparse=False), 1),
+        # Rank-deficient state with zero eigenvalues: entropy of diag(1/2, 1/2, 0, 0) is one.
+        (np.diag([0.5, 0.5, 0.0, 0.0]), 1),
     ],
 )
 def test_von_neumann_entropy(rho, expected_result):
     """Test function works as expected for a valid input."""
     np.testing.assert_allclose(von_neumann_entropy(rho), expected_result, atol=1e-5)
+
+
+def test_von_neumann_entropy_complex_hermitian():
+    """Entropy is unitarily invariant; a complex-unitary-rotated state has entropy H(eigenvalues)."""
+    probs = np.array([0.7, 0.3])
+    # A complex 2x2 unitary, so rho is a genuinely non-diagonal Hermitian matrix.
+    v_mat = np.array([[1, 1j], [1j, 1]]) / np.sqrt(2)
+    rho = v_mat @ np.diag(probs) @ v_mat.conj().T
+
+    expected = float(-np.sum(probs * np.log2(probs)))
+    np.testing.assert_allclose(von_neumann_entropy(rho), expected, atol=1e-10)
 
 
 @pytest.mark.parametrize(

--- a/toqito/state_props/von_neumann_entropy.py
+++ b/toqito/state_props/von_neumann_entropy.py
@@ -88,6 +88,8 @@ def von_neumann_entropy(rho: np.ndarray) -> float:
     """
     if not is_density(rho):
         raise ValueError("Von Neumann entropy is only defined for density operators.")
-    eigs, _ = np.linalg.eig(rho)
-    eigs = [eig for eig in eigs if eig > 0]
-    return -np.sum(np.real(eigs * np.log2(eigs)))
+    # A density operator is Hermitian, so use eigvalsh, which returns real eigenvalues and avoids the spurious
+    # imaginary parts that np.linalg.eig can introduce.
+    eigs = np.linalg.eigvalsh(rho)
+    eigs = eigs[eigs > 0]
+    return float(-np.sum(eigs * np.log2(eigs)))


### PR DESCRIPTION
Closes #1588.

## Problem
Both functions used `np.linalg.eig` on operators whose spectra are real, which can introduce spurious imaginary parts:

- `von_neumann_entropy` filtered eigenvalues with `eig > 0` on complex numbers and fed tiny near-zero eigenvalues (carrying imaginary noise) into `log2`, then masked the result with `np.real`.
- `concurrence` computed `np.abs(np.sqrt(eigvals(rho @ rho_tilde)))`. The eigenvalues of `rho @ rho_tilde` are real and nonnegative in theory, so `abs(sqrt(.))` equals the intended `sqrt(Re lambda)` only when the values are near-real and nonnegative; it distorts genuinely complex numerical values.

## Changes
- `von_neumann_entropy`: use `np.linalg.eigvalsh` (real eigenvalues).
- `concurrence`: take the real part of the eigenvalues and clip negative numerical noise to zero before the square root.
- Tests: a complex-unitary-rotated Hermitian state for the entropy (unitarily invariant, so entropy equals `H(eigenvalues)`); a non-maximally entangled pure state `cos(t)|00> + sin(t)|11>` with closed-form concurrence `|sin(2t)|`, and the separable maximally mixed two-qubit state.

`_renyi_utils.py` already follows this pattern (Hermitian solver plus a support threshold). Dependent functions (`entanglement_of_formation`, the Renyi entropies) and their tests are unaffected.