### PR TITLE
fix: stop rounding w_state coefficients to four decimals

### DIFF
--- a/toqito/states/tests/test_w_state.py
+++ b/toqito/states/tests/test_w_state.py
@@ -13,7 +13,9 @@ def test_w_state_3():
     expected_res = 1 / np.sqrt(3) * (tensor(e_1, e_0, e_0) + tensor(e_0, e_1, e_0) + tensor(e_0, e_0, e_1))
 
     res = w_state(3)
-    np.testing.assert_allclose(res, expected_res, atol=0.2)
+    np.testing.assert_allclose(res, expected_res, atol=1e-12)
+    # The returned state is normalized (the previous np.around(., 4) broke this).
+    np.testing.assert_allclose(np.linalg.norm(res), 1.0, atol=1e-12)
 
 
 def test_w_state_generalized():
@@ -32,7 +34,18 @@ def test_w_state_generalized():
 
     coeffs = np.array([1, 2, 3, 4]) / np.sqrt(30)
     res = w_state(4, coeffs)
-    np.testing.assert_allclose(res, expected_res, atol=0.2)
+    np.testing.assert_allclose(res, expected_res, atol=1e-12)
+
+
+def test_w_state_complex_coefficients():
+    """Complex coefficients are preserved (not truncated to real)."""
+    coeffs = np.array([1, 1j, 1, 1j]) / 2
+    res = w_state(4, coeffs)
+
+    assert np.iscomplexobj(res)
+    np.testing.assert_allclose(np.linalg.norm(res), 1.0, atol=1e-12)
+    # Excitation on the last qubit sits at index 1 and carries coeff for that qubit.
+    np.testing.assert_allclose(res[1, 0], coeffs[3])
 
 
 @pytest.mark.parametrize(

--- a/toqito/states/w_state.py
+++ b/toqito/states/w_state.py
@@ -5,7 +5,6 @@ the ground state.
 """
 
 import numpy as np
-from scipy.sparse import csr_array
 
 
 def w_state(num_qubits: int, coeff: list[int] | None = None) -> np.ndarray:
@@ -72,12 +71,13 @@ def w_state(num_qubits: int, coeff: list[int] | None = None) -> np.ndarray:
     if not np.isclose(norm, 1.0):
         coeff_arr = coeff_arr / norm
 
-    # Initialize a state vector of appropriate size.
-    ret_w_state = csr_array((2**num_qubits, 1)).toarray()
+    # Initialize a dense state vector of appropriate size, matching the coefficient dtype so complex coefficients are
+    # preserved.
+    ret_w_state = np.zeros((2**num_qubits, 1), dtype=coeff_arr.dtype)
     # Fill the vector so that the state has the single excitation distributed according to coeff.
     # Note: The ordering assumes that the binary representation corresponds to qubits in little-endian order.
     for i in range(num_qubits):
         # The position for an excitation on qubit i is at index 2**i.
         # We assign the coefficient to the position corresponding to an excitation in that qubit.
         ret_w_state[2**i] = coeff_arr[num_qubits - i - 1]
-    return np.around(ret_w_state, 4)
+    return ret_w_state


### PR DESCRIPTION
Closes #1589.

## Problem
`w_state` returned `np.around(ret_w_state, 4)`, which corrupted the coefficients and broke normalization (for example `1/sqrt(3)` became `0.5774`, giving a vector norm of `1.0000861`). The tests passed only because they asserted with `atol=0.2`.

## Changes
- Return the exact state (drop `np.around`).
- Build the dense vector with `np.zeros` instead of `csr_array(...).toarray()`; the sparse array was immediately densified and bought nothing.
- Take the array dtype from the coefficients, so complex coefficients are preserved rather than truncated.
- Tighten the test tolerances to `1e-12`, assert the state is normalized, and add a complex-coefficient test.