### PR TITLE
fix: annotate channel_relative_entropy **kwargs to unbreak strict docs build

### DIFF
--- a/toqito/channel_metrics/channel_relative_entropy.py
+++ b/toqito/channel_metrics/channel_relative_entropy.py
@@ -1,6 +1,7 @@
 """Quantum relative entropy of channels via semidefinite programming."""
 
 import warnings
+from typing import Any
 
 import cvxpy as cvx
 import numpy as np
@@ -169,7 +170,7 @@ def channel_relative_entropy(
     epsilon_dec: float = 1e-2,
     mean: bool = False,
     solver: str = "SCS",
-    **kwargs,
+    **kwargs: Any,
 ) -> float | tuple[float, float]:
     r"""Estimate the quantum relative entropy of two channels [@kossmann2025channelrelativeentropy].
 


### PR DESCRIPTION
## Problem
`mkdocs build --strict` aborts with:

```
WARNING - griffe: toqito/channel_metrics/channel_relative_entropy.py:201: No type or annotation for parameter 'kwargs'
Aborted with 1 warnings in strict mode!
```

`channel_relative_entropy` documents a `kwargs` entry in its Args section, but the signature's `**kwargs` had no annotation. This was introduced with the function in #1558 and currently fails the Docs Preview check on every open PR (for example the run linked from #1603).

## Changes
Annotate the public function's `**kwargs` as `**kwargs: Any`, matching the same fix applied to `channel_exclusion` in #1582 and the sibling public SDP functions (`completely_bounded_trace_norm`, `channel_distinguishability`, `state_distinguishability`, `state_exclusion`).