### PR TITLE
fix: sample rand generators from Gaussian, not uniform, distributions

### DIFF
--- a/toqito/rand/random_density_matrix.py
+++ b/toqito/rand/random_density_matrix.py
@@ -126,14 +126,18 @@ def random_density_matrix(
     if k_param is None:
         k_param = dim
 
-    # Haar / Hilbert-Schmidt measure.
-    gin = gen.random((dim, k_param))
+    # Haar / Hilbert-Schmidt measure: draw a (complex) Ginibre matrix. The entries must be Gaussian, not uniform, for
+    # rho = gin @ gin^dagger / Tr(.) to follow the Hilbert-Schmidt measure.
+    gin = gen.standard_normal((dim, k_param))
 
     if not is_real:
         gin = gin + 1j * gen.standard_normal((dim, k_param))
 
     if distance_metric == "bures":
-        gin = random_unitary(dim, is_real, seed=seed) + np.identity(dim) @ gin
+        # Bures measure: gin -> (I + U) @ gin with U Haar-random and independent of gin. Derive an independent seed
+        # from the same generator so the result stays reproducible without correlating U with gin.
+        u_seed = int(gen.integers(0, 2**32 - 1))
+        gin = (np.identity(dim) + random_unitary(dim, is_real, seed=u_seed)) @ gin
 
     rho = gin @ gin.conj().T
 

--- a/toqito/rand/random_state_vector.py
+++ b/toqito/rand/random_state_vector.py
@@ -115,12 +115,12 @@ def random_state_vector(
 
         psi = max_entangled(k_param, True, False).toarray()
 
-        a_param = gen.random((dims_pair[0] * k_param, 1))
-        b_param = gen.random((dims_pair[1] * k_param, 1))
+        a_param = gen.standard_normal((dims_pair[0] * k_param, 1))
+        b_param = gen.standard_normal((dims_pair[1] * k_param, 1))
 
         if not is_real:
-            a_param = a_param + 1j * gen.random((dims_pair[0] * k_param, 1))
-            b_param = b_param + 1j * gen.random((dims_pair[1] * k_param, 1))
+            a_param = a_param + 1j * gen.standard_normal((dims_pair[0] * k_param, 1))
+            b_param = b_param + 1j * gen.standard_normal((dims_pair[1] * k_param, 1))
 
         mat_1 = np.kron(psi.conj().T, np.identity(int(np.prod(dims_pair))))
         mat_2 = swap(
@@ -133,7 +133,7 @@ def random_state_vector(
         ret_vec = ret_vec.reshape(-1, 1)
         return np.divide(ret_vec, np.linalg.norm(ret_vec))
 
-    ret_vec = gen.random((total_dim, 1))
+    ret_vec = gen.standard_normal((total_dim, 1))
     if not is_real:
-        ret_vec = ret_vec + 1j * gen.random((total_dim, 1))
+        ret_vec = ret_vec + 1j * gen.standard_normal((total_dim, 1))
     return np.divide(ret_vec, np.linalg.norm(ret_vec))

--- a/toqito/rand/tests/test_random_density_matrix.py
+++ b/toqito/rand/tests/test_random_density_matrix.py
@@ -60,23 +60,37 @@ def test_random_density_matrix(dim, is_real, distance_metric):
             False,
             None,
             "haar",
-            np.array([[0.37758384 + 0.0j, 0.19597419 + 0.19965911j], [0.19597419 - 0.19965911j, 0.62241616 + 0.0j]]),
+            np.array([[0.22986343 + 0.0j, 0.13365203 - 0.20624294j], [0.13365203 + 0.20624294j, 0.77013657 + 0.0j]]),
         ),
         # Generate random real density matrix.
-        (2, True, None, "haar", np.array([[0.45158815, 0.49355259], [0.49355259, 0.54841185]])),
+        (2, True, None, "haar", np.array([[0.13871939, 0.33280544], [0.33280544, 0.86128061]])),
         # Random non-real density matrix according to Bures metric.
         (
             2,
             False,
             None,
             "bures",
-            np.array([[0.31466466 + 0.0j, -0.09170064 + 0.24517065j], [-0.09170064 - 0.24517065j, 0.68533534 + 0.0j]]),
+            np.array([[0.24980937 + 0.0j, 0.19650908 - 0.22450506j], [0.19650908 + 0.22450506j, 0.75019063 + 0.0j]]),
         ),
         # Generate random non-real density matrix all params.
-        (2, True, 2, "haar", np.array([[0.45158815, 0.49355259], [0.49355259, 0.54841185]])),
+        (2, True, 2, "haar", np.array([[0.13871939, 0.33280544], [0.33280544, 0.86128061]])),
     ],
 )
 def test_seed(dim, is_real, k_param, distance_metric, expected):
     """Test that the function produces the expected output using a seed."""
     dm = random_density_matrix(dim, is_real, k_param=k_param, distance_metric=distance_metric, seed=124)
     assert_allclose(dm, expected)
+
+
+@pytest.mark.parametrize("is_real", [False, True])
+def test_random_density_matrix_mean_is_maximally_mixed(is_real):
+    """Averaging Hilbert-Schmidt distributed states approaches I/d.
+
+    With the previous uniform (rather than Gaussian) sampling of the Ginibre matrix the entries were biased toward
+    positive values, so the average had large positive off-diagonal entries and did not converge to I/d.
+    """
+    dim, n_samples = 2, 4000
+    acc = np.zeros((dim, dim), dtype=complex)
+    for s in range(n_samples):
+        acc += random_density_matrix(dim, is_real=is_real, seed=s)
+    np.testing.assert_allclose(acc / n_samples, np.eye(dim) / dim, atol=0.02)

--- a/toqito/rand/tests/test_random_state_vector.py
+++ b/toqito/rand/tests/test_random_state_vector.py
@@ -40,7 +40,7 @@ def test_random_state_vector(dim, is_real, k_param):
             2,
             False,
             0,
-            np.array([[0.91920422 + 0.29684938j], [0.07250293 + 0.24836943j]]),
+            np.array([[-0.59005974 + 0.76831103j], [-0.2194029 + 0.11571532j]]),
         ),
         (
             2,
@@ -48,10 +48,10 @@ def test_random_state_vector(dim, is_real, k_param):
             1,
             np.array(
                 [
-                    [-0.01113702 + 0.61768143j],
-                    [0.07125721 + 0.20424701j],
-                    [-0.68156797 + 0.21116929j],
-                    [-0.19827006 + 0.15202896j],
+                    [-0.2936362 + 0.77427174j],
+                    [-0.29464507 - 0.15255447j],
+                    [-0.04538643 + 0.41699573j],
+                    [-0.1638817 - 0.03728129j],
                 ]
             ),
         ),
@@ -61,10 +61,10 @@ def test_random_state_vector(dim, is_real, k_param):
             1,
             np.array(
                 [
-                    [-0.01113702 + 0.61768143j],
-                    [0.07125721 + 0.20424701j],
-                    [-0.68156797 + 0.21116929j],
-                    [-0.19827006 + 0.15202896j],
+                    [-0.2936362 + 0.77427174j],
+                    [-0.29464507 - 0.15255447j],
+                    [-0.04538643 + 0.41699573j],
+                    [-0.1638817 - 0.03728129j],
                 ]
             ),
         ),
@@ -74,20 +74,35 @@ def test_random_state_vector(dim, is_real, k_param):
             1,
             np.array(
                 [
-                    [0.76458086],
-                    [0.63971337],
-                    [0.06030689],
-                    [0.05045788],
+                    [-0.92684881],
+                    [-0.1395927],
+                    [-0.34463175],
+                    [-0.05190499],
                 ]
             ),
         ),
-        (2, True, 0, np.array([[0.99690375], [0.07863154]])),
+        (2, True, 0, np.array([[-0.93730189], [-0.34851853]])),
     ],
 )
 def test_seed(dim, is_real, k_param, expected):
     """Test that the function returns the expected output when seeded."""
     vec = random_state_vector(dim, is_real=is_real, k_param=k_param, seed=123)
     assert_allclose(vec, expected)
+
+
+@pytest.mark.parametrize("is_real", [False, True])
+def test_random_state_vector_mean_outer_is_maximally_mixed(is_real):
+    """Averaging |psi><psi| over Haar-uniform pure states approaches I/d.
+
+    With the previous uniform (rather than Gaussian) sampling the vectors were confined to the positive orthant, so
+    the average outer product had large positive off-diagonal entries and did not converge to I/d.
+    """
+    dim, n_samples = 2, 4000
+    acc = np.zeros((dim, dim), dtype=complex)
+    for s in range(n_samples):
+        vec = random_state_vector(dim, is_real=is_real, seed=s)
+        acc += vec @ vec.conj().T
+    np.testing.assert_allclose(acc / n_samples, np.eye(dim) / dim, atol=0.02)
 
 
 def test_random_state_vector_negative_k_param():


### PR DESCRIPTION
Closes #1590.

## Problem
`random_density_matrix` and `random_state_vector` drew their real Ginibre entries from `gen.random` (uniform on `[0, 1)`) instead of `gen.standard_normal`. Uniform entries are all nonnegative, so:

- the sampled density matrices were not Hilbert-Schmidt distributed (for `is_real=True` all entries were biased positive),
- the sampled state vectors were confined to the positive orthant rather than uniform on the sphere (`random_state_vector` even documents standard-normal sampling),
- the average of many samples did not converge to `I/d`.

The Bures branch of `random_density_matrix` additionally computed `U + gin` (since `I @ gin == gin`) instead of the intended `(I + U) @ gin`, and reused the same `seed` for the unitary, correlating it with the Ginibre draw.

These were invisible to the tests because a uniform-real-part matrix is still a valid density matrix, and the seeded regression tests froze the wrong output.

## Changes
- Use `gen.standard_normal` for the real (and imaginary) parts in both functions.
- Fix the Bures formula to `(I + U) @ gin`, drawing `U` from an independent seed derived from the same generator (reproducible, uncorrelated).
- Regenerate the seeded regression expectations.
- Add statistical tests that the mean density matrix and the mean of `|psi><psi|` approach `I/d` (deterministic, fixed seeds), which the old uniform sampling failed.

Note: two pre-existing `test_is_abs_ppt.py::test_cvxpy_case` failures show up locally due to a cvxpy version quirk in this environment; they fail on master as well and are unrelated to this change.