### PR TITLE
fix: guard against None solver returns in k-incoherence SDPs

### DIFF
--- a/toqito/matrix_props/is_absolutely_k_incoherent.py
+++ b/toqito/matrix_props/is_absolutely_k_incoherent.py
@@ -118,6 +118,8 @@ def is_absolutely_k_incoherent(mat: np.ndarray, k: int, tol: float = 1e-15) -> b
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", message="Solution may be inaccurate")
                 opt_val = prob.solve(solver=cp.SCS, eps=1e-8, verbose=False)
-            if np.isclose(opt_val, 1.0):
+            # Guard against a failed solve (opt_val is None) so np.isclose does not raise; a feasible solution
+            # (optimal value near 1) means absolute (n-1)-incoherence holds.
+            if opt_val is not None and np.isclose(opt_val, 1.0):
                 return True
     return False

--- a/toqito/matrix_props/is_k_incoherent.py
+++ b/toqito/matrix_props/is_k_incoherent.py
@@ -110,5 +110,9 @@ def is_k_incoherent(mat: np.ndarray, k: int, tol: float = 1e-15) -> bool:
     prob = cp.Problem(cp.Minimize(1), constraints)
     opt_val = prob.solve(solver=cp.SCS, verbose=False)
 
+    # A failed solve returns None; guard against it so this returns False rather than raising a TypeError inside
+    # min(...). An infeasible solve returns +inf, which min(...) handles correctly.
+    if opt_val is None:
+        return False
     # MATLAB sets ikinc = 1 - min(cvx_optval, 1); here we interpret an optimum near 1 as True.
     return np.isclose(1 - min(opt_val, 1), 1.0)

--- a/toqito/matrix_props/tests/test_is_absolutely_k_incoherent.py
+++ b/toqito/matrix_props/tests/test_is_absolutely_k_incoherent.py
@@ -135,3 +135,11 @@ def test_k_equals_n_minus_one_large_eigenvalue():
     """When k = n - 1 and the largest eigenvalue exceeds the bound, return False immediately."""
     mat = np.diag([0.9, 0.05, 0.05, 0.0])
     assert is_absolutely_k_incoherent(mat, 3) is False
+
+
+def test_is_absolutely_k_incoherent_solver_returns_none(monkeypatch):
+    """A failed solve (solver returns None) yields False instead of raising a TypeError."""
+    monkeypatch.setattr(cp.Problem, "solve", lambda self, *a, **k: None)
+    # diag([0.6, 0.2, 0.2, 0]) with k = n - 1 reaches the SDP branch; with the guard it must not raise.
+    mat = np.diag([0.6, 0.2, 0.2, 0.0])
+    assert is_absolutely_k_incoherent(mat, 3) is False

--- a/toqito/matrix_props/tests/test_is_k_incoherent.py
+++ b/toqito/matrix_props/tests/test_is_k_incoherent.py
@@ -243,3 +243,13 @@ def test_hierarchical_recursion_branch():
 
     # Restore the original function reference.
     is_k_incoherent.__globals__["is_k_incoherent"] = orig_is_k_incoherent
+
+
+def test_is_k_incoherent_solver_returns_none(monkeypatch):
+    """A failed solve (solver returns None) yields False instead of raising a TypeError."""
+    monkeypatch.setattr(cp.Problem, "solve", lambda self, *a, **k: None)
+    # This 4x4 matrix reaches the SDP fallback; with the guard it must not raise.
+    mat = np.array(
+        [[0.35, 0.30, 0.0, 0.0], [0.30, 0.25, 0.0, 0.0], [0.0, 0.0, 0.25, 0.05], [0.0, 0.0, 0.05, 0.15]]
+    )
+    assert is_k_incoherent(mat, 3) is False


### PR DESCRIPTION
Addresses part of #1592.

## Problem
`is_k_incoherent` (`min(opt_val, 1)`) and `is_absolutely_k_incoherent` (`np.isclose(opt_val, 1.0)`) use the result of `prob.solve(...)` directly. When the solver fails and returns `None`, both raise a `TypeError` rather than returning the natural "not incoherent" answer.

## Changes
- Guard the solver result in both functions: a `None` return yields `False` / skips the incoherence verdict, while feasible and infeasible solves behave exactly as before.
- Add tests that monkeypatch the solver to return `None` and assert the functions do not raise.

## Scope note
This is the concrete crash-guard subset of #1592. The broader "check solver status everywhere" work is larger and trickier than a single safe PR:

- The `state_opt` SDP solvers (`state_distinguishability`, `state_exclusion`, `optimal_clone`, `symmetric_extension_hierarchy`, `state_exclusion_locc`) use PICOS, with a different status API.
- The cvxpy cone helpers and `xor_game` return `prob.solve()` directly and would benefit from status checks too.
- `is_k_incoherent`'s SDP fallback has a separate logic issue: `1 - min(opt_val, 1)` is always `False` for the constant-objective feasibility SDP, so that branch never reports `True`. Fixing it correctly requires deciding behavior on cone-boundary inputs (the test matrix there sits within ~4e-6 of the boundary and the solver reports `optimal_inaccurate`), so it is intentionally left unchanged here.

I left #1592 open to track the remainder.