### PR TITLE
fix: preserve complex data in functions that used real-dtype arrays

### DIFF
--- a/toqito/matrix_props/is_k_incoherent.py
+++ b/toqito/matrix_props/is_k_incoherent.py
@@ -82,8 +82,10 @@ def is_k_incoherent(mat: np.ndarray, k: int, tol: float = 1e-15) -> bool:
     elif k == 2:
         return False
 
-    # [@johnston2022absolutely] (8): Check if trace(mat^2) <= 1/(d - 1) (for k > 2).
-    if k > 2 and np.trace(mat @ mat) <= 1 / (d - 1):
+    # [@johnston2022absolutely] (8): Check if the purity trace(mat mat^dagger) <= 1/(d - 1) (for k > 2). For a
+    # Hermitian density matrix this equals trace(mat^2); using the conjugate transpose keeps it correct (and real)
+    # for complex inputs.
+    if k > 2 and np.real(np.trace(mat @ mat.conj().T)) <= 1 / (d - 1):
         return True
 
     # Hierarchical recursion: for k >= 2 check incoherence for k-1.

--- a/toqito/matrix_props/mutual_coherence.py
+++ b/toqito/matrix_props/mutual_coherence.py
@@ -40,11 +40,14 @@ def mutual_coherence(vectors: list[np.ndarray]) -> float | np.floating:
     if not all(isinstance(vec, np.ndarray) and vec.ndim == 1 for vec in vectors):
         raise ValueError("All elements in the list must be 1D numpy arrays.")
 
-    # Convert input into a 2D numpy array.
-    vectors = np.column_stack(vectors).astype(float)
+    # Convert input into a 2D numpy array. Use a complex dtype so complex-valued vectors are not truncated.
+    vectors = np.column_stack(vectors).astype(complex)
 
-    # Normalize the vectors.
-    vectors /= np.linalg.norm(vectors, axis=0)
+    # Normalize the vectors, guarding against zero vectors (which would divide by zero).
+    norms = np.linalg.norm(vectors, axis=0)
+    if np.any(np.isclose(norms, 0)):
+        raise ValueError("Vectors must be nonzero to compute mutual coherence.")
+    vectors /= norms
 
     # Calculate the inner product between all pairs of columns.
     inner_products = np.abs(np.conj(vectors.T) @ vectors)

--- a/toqito/matrix_props/tests/test_mutual_coherence.py
+++ b/toqito/matrix_props/tests/test_mutual_coherence.py
@@ -35,9 +35,22 @@ def test_mutual_coherence(vectors, expected_coherence):
             ValueError,
             r"All elements in the list must be 1D numpy arrays\.",
         ),
+        # A zero vector cannot be normalized.
+        (
+            [np.array([0, 0]), np.array([1, 0])],
+            ValueError,
+            r"Vectors must be nonzero to compute mutual coherence\.",
+        ),
     ],
 )
 def test_mutual_coherence_invalid_inputs(vectors, exception, expected_msg):
     """Test that invalid inputs raise the exact ValueError or TypeError message."""
     with pytest.raises(exception, match=expected_msg):
         mutual_coherence(vectors)
+
+
+def test_mutual_coherence_complex_vectors():
+    """Complex vectors are not truncated; orthogonal complex vectors have coherence 0."""
+    # <[1, 1j], [1j, 1]> = conj(1)*1j + conj(1j)*1 = 1j - 1j = 0, so these are orthogonal.
+    result = mutual_coherence([np.array([1, 1j]), np.array([1j, 1])])
+    assert np.isclose(result, 0.0, atol=1e-8)

--- a/toqito/state_opt/optimal_clone.py
+++ b/toqito/state_opt/optimal_clone.py
@@ -105,7 +105,7 @@ def optimal_clone(
     # Construct the following operator:
     #                                ___               ___
     # Q = ∑_{k=1}^N p_k |ψ_k ⊗ ψ_k ⊗ ψ_k> <ψ_k ⊗ ψ_k ⊗ ψ_k|
-    q_a = np.zeros((dim, dim))
+    q_a = np.zeros((dim, dim), dtype=complex)
     for k, state in enumerate(states):
         q_a += probs[k] * tensor(state, state, state.conj()) @ tensor(state, state, state.conj()).conj().T
 

--- a/toqito/states/ghz.py
+++ b/toqito/states/ghz.py
@@ -74,8 +74,8 @@ def ghz(dim: int, num_qubits: int, coeff: list[int] | None = None) -> np.ndarray
     if not np.isclose(norm, 1.0):
         coeff = coeff / norm
 
-    # Initialize the GHZ state vector.
-    ghz_state = np.zeros((dim**num_qubits, 1))
+    # Initialize the GHZ state vector, matching the coefficient dtype so complex coefficients are preserved.
+    ghz_state = np.zeros((dim**num_qubits, 1), dtype=coeff.dtype)
     # Fill the state vector with the corresponding coefficients.
     for i in range(dim):
         # Calculate the index for the tensor product state |i, i, ..., i>.

--- a/toqito/states/tests/test_ghz.py
+++ b/toqito/states/tests/test_ghz.py
@@ -65,6 +65,18 @@ def test_ghz_invalid_input(dim, num_qubits, coeff):
         ghz(dim, num_qubits, coeff)
 
 
+def test_ghz_complex_coefficients():
+    """Complex coefficients are preserved (not truncated to real)."""
+    coeff = np.array([1, 1j]) / np.sqrt(2)
+    res = ghz(2, 2, coeff)
+
+    assert np.iscomplexobj(res)
+    np.testing.assert_allclose(np.linalg.norm(res), 1.0, atol=1e-12)
+    # |00> amplitude is coeff[0]; |11> amplitude (index 3) is coeff[1].
+    np.testing.assert_allclose(res[0, 0], coeff[0])
+    np.testing.assert_allclose(res[3, 0], coeff[1])
+
+
 def test_ghz_non_normalized_coeff_2_3():
     """Test that non-normalized coefficients for a 3-qubit GHZ state are normalized correctly.
 


### PR DESCRIPTION
Closes #1594.

## Problem
Several functions allocated real-dtype arrays (or cast to float) and silently dropped imaginary parts (ComplexWarning), giving wrong results for complex inputs while the real-only tests passed.

## Changes
- `optimal_clone`: `q_a` was `np.zeros((dim, dim))` (real), truncating the complex `tensor(...)` contributions. Build it with `dtype=complex`.
- `ghz`: the state vector was real, dropping complex coefficients. Take the dtype from the coefficients (matching the `w_state` fix).
- `mutual_coherence`: cast inputs to `float`, discarding imaginary parts (which also made the later `np.conj` a no-op). Use a complex dtype, and add a guard against zero vectors, which previously divided by zero and produced inf/nan.
- `is_k_incoherent`: the purity test used `trace(mat @ mat)`. Use `trace(mat @ mat.conj().T)` (the purity `Tr(rho rho^dagger)`), which stays correct and real for complex inputs and is unchanged for a Hermitian density matrix.

Added tests for complex `ghz` coefficients, complex `mutual_coherence` vectors (orthogonal complex vectors give coherence 0), and the zero-vector guard.

Note: `optimal_clone`'s SDP tests fail locally due to a pre-existing cvxpy version quirk in this environment (they fail on master as well); the complex-dtype change is exercised by those existing tests under the pinned CI solver.