### PR TITLE
fix: validate measure completeness unconditionally; clarify single-operator semantics

### DIFF
--- a/toqito/measurement_ops/measure.py
+++ b/toqito/measurement_ops/measure.py
@@ -13,16 +13,22 @@ def measure(
 ) -> float | tuple[float, np.ndarray] | list[float | tuple[float, np.ndarray]]:
     r"""Apply measurement to a quantum state.
 
-    The measurement can be provided as a single operator (POVM element or Kraus operator) or as a
-    list of operators (assumed to be Kraus operators) describing a complete quantum measurement.
+    The measurement can be provided as a single operator or as a list of operators describing a complete quantum
+    measurement.
+
+    A single operator is always treated as a Kraus operator \(K\): the outcome probability is
+    \(\mathrm{Tr}(K \rho K^\dagger) = \mathrm{Tr}(K^\dagger K \rho)\) and the post-measurement state is
+    \(K \rho K^\dagger / \mathrm{Tr}(K \rho K^\dagger)\). For a POVM element \(E\) the Born probability is
+    \(\mathrm{Tr}(E \rho)\); this equals \(\mathrm{Tr}(K \rho K^\dagger)\) only when the operator is a projector
+    (\(E^\dagger E = E\)), so to measure with a non-projector POVM element pass its Kraus operators in the list form.
 
     When a single operator is provided:
 
       - Returns the measurement outcome probability if ``state_update`` is False.
       - Returns a tuple (probability, post_state) if ``state_update`` is True.
 
-    When a list of operators is provided, the function verifies that they satisfy the completeness relation when
-    ``state_update`` is True.
+    When a list of operators is provided, the function verifies that they satisfy the completeness relation (which
+    depends only on the operators, not on the state or ``state_update``).
 
     \[
         \sum_i K_i^\dagger K_i = \mathbb{I},
@@ -125,13 +131,20 @@ def measure(
         return (prob, post_state) if state_update else prob
 
     # List-of-operators case.
-    outcomes: list[float | tuple[float, np.ndarray]] = []
-    probs: list[float] = []
+    if len(measurement) == 0:
+        raise ValueError("At least one measurement operator is required.")
 
+    # The completeness relation depends only on the operators, not on the state or the resulting probabilities, so
+    # validate it unconditionally whenever a list/tuple of Kraus operators is provided.
+    d = state.shape[0]
+    completeness = sum(op.conj().T @ op for op in measurement)
+    if not np.allclose(completeness, np.eye(d), atol=tol):
+        raise ValueError("Kraus operators do not satisfy completeness relation: ∑ Kᵢ†Kᵢ ≠ I.")
+
+    outcomes: list[float | tuple[float, np.ndarray]] = []
     for op in measurement:
         result = op @ state @ op.conj().T
         prob = np.trace(result).real
-        probs.append(prob)
 
         if prob > tol:
             post_state = result / prob
@@ -139,12 +152,5 @@ def measure(
             post_state = np.zeros_like(state)
 
         outcomes.append((prob, post_state) if state_update else prob)
-
-    # Only enforce completeness if we're doing the update AND every outcome was nonzero.
-    if state_update and all(p > tol for p in probs):
-        d = state.shape[0]
-        completeness = sum(op.T.conj() @ op for op in measurement)
-        if not np.allclose(completeness, np.eye(d), atol=tol):
-            raise ValueError("Kraus operators do not satisfy completeness relation: ∑ Kᵢ†Kᵢ ≠ I.")
 
     return outcomes

--- a/toqito/measurement_ops/tests/test_measure.py
+++ b/toqito/measurement_ops/tests/test_measure.py
@@ -105,54 +105,57 @@ def test_measure_zero_operator(state, measurement, state_update):
 
 
 @pytest.mark.parametrize(
-    "measurements, state_update, expected",
+    "state_update, expected",
     [
-        # One zero‑operator and one projector; without update we only get probabilities
+        # A complete measurement {P_0, P_1} on |0><0|: the P_1 outcome has zero probability.
+        (False, [1.0, 0.0]),
         (
-            [np.zeros((2, 2)), np.array([[1, 0], [0, 0]])],
-            False,
-            [0.0, 0.5],
-        ),
-        # Same list, with update=True, so we also get post‑states (zero and projector)
-        (
-            [np.zeros((2, 2)), np.array([[1, 0], [0, 0]])],
             True,
             [
+                (1.0, np.array([[1, 0], [0, 0]])),
                 (0.0, np.zeros((2, 2))),
-                (0.5, np.array([[1, 0], [0, 0]])),
             ],
         ),
     ],
 )
-def test_measure_list_with_zero_operator(measurements, state_update, expected):
-    """Test cases when the measurement operator yields zero probability (with input as list)."""
-    state = np.array([[0.5, 0.5], [0.5, 0.5]])
+def test_measure_list_with_zero_probability_outcome(state_update, expected):
+    """A valid complete measurement with a zero-probability outcome returns zero (and a zero post-state)."""
+    state = np.array([[1, 0], [0, 0]])
+    measurements = [np.array([[1, 0], [0, 0]]), np.array([[0, 0], [0, 1]])]
     result = measure(state, measurements, state_update=state_update)
 
     if state_update:
-        # Expect a list of (prob, post_state) tuples.
         for (res_p, res_post), (exp_p, exp_post) in zip(result, expected):
             assert np.isclose(res_p, exp_p, atol=1e-7)
             np.testing.assert_allclose(res_post, exp_post, rtol=1e-7)
     else:
-        # Expect a list of floats.
         for res, exp in zip(result, expected):
             assert np.isclose(res, exp, atol=1e-7)
 
 
-@pytest.mark.parametrize(
-    "state, measurements",
-    [
-        (
-            np.array([[0.5, 0.5], [0.5, 0.5]]),
-            [np.array([[1, 0], [0, 0]]), np.array([[1, 0], [0, 0]])],
-        ),
-    ],
-)
-def test_measure_completeness_failure(state, measurements):
-    """Test that a list of operators that does not satisfy the completeness relation raises ValueError."""
+@pytest.mark.parametrize("state_update", [True, False])
+def test_measure_completeness_failure(state_update):
+    """A list of operators violating completeness raises ValueError regardless of state_update."""
+    state = np.array([[0.5, 0.5], [0.5, 0.5]])
+    measurements = [np.array([[1, 0], [0, 0]]), np.array([[1, 0], [0, 0]])]
     with pytest.raises(ValueError, match="Kraus operators do not satisfy completeness relation"):
-        measure(state, measurements, state_update=True)
+        measure(state, measurements, state_update=state_update)
+
+
+@pytest.mark.parametrize("state_update", [True, False])
+def test_measure_incomplete_list_with_zero_operator_raises(state_update):
+    """An incomplete list (e.g. a zero operator and a projector) is rejected even though one outcome is zero."""
+    state = np.array([[0.5, 0.5], [0.5, 0.5]])
+    measurements = [np.zeros((2, 2)), np.array([[1, 0], [0, 0]])]
+    with pytest.raises(ValueError, match="Kraus operators do not satisfy completeness relation"):
+        measure(state, measurements, state_update=state_update)
+
+
+def test_measure_empty_list_raises():
+    """An empty measurement list is rejected."""
+    state = np.array([[0.5, 0.5], [0.5, 0.5]])
+    with pytest.raises(ValueError, match="At least one measurement operator is required"):
+        measure(state, [])
 
 
 def test_measure_invalid_density_matrix():


### PR DESCRIPTION
Closes #1595.

## Problem
Two issues in `measure`:

1. The completeness check (`sum_i K_i^dagger K_i = I`) was gated on `state_update is True and all(p > tol)`. Completeness depends only on the operators, so a non-complete measurement was silently accepted whenever `state_update` was False or any outcome had zero probability (common, e.g. a projector onto an unoccupied subspace). The returned probabilities then did not sum to one, contradicting the docstring.
2. The single-operator path computes `Tr(K rho K^dagger)` and a Kraus post-state, but the docstring described the argument as a "POVM element". For a non-projector POVM element `E`, the Born probability is `Tr(E rho)`, which equals `Tr(K rho K^dagger)` only when the operator is a projector.

## Changes
- Validate the completeness relation whenever a list/tuple of operators is provided (independent of `state_update` and the probabilities), and reject an empty list.
- Clarify the docstring: a single operator is always treated as a Kraus operator; for a non-projector POVM element, pass its Kraus operators in list form.
- Update tests: the zero-probability-outcome case now uses a valid complete measurement `{P_0, P_1}`; incomplete lists (a violating pair, and a zero-operator-plus-projector) are asserted to raise regardless of `state_update`; an empty list raises.

No internal callers pass incomplete operator lists, so the stricter validation is contained to the public API contract.