### PR TITLE
chore: gitignore solver license files and local research artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,25 @@ venv/*
 docs/site/
 docs/content/reference/
 docs/content/generated/
+
+# Solver license files (e.g. MOSEK) - never commit, these contain credentials
+*.lic
+
+# LaTeX build artifacts
+*.aux
+*.bbl
+*.blg
+*.log
+*.out
+
+# Local research artifacts (none of these extensions are tracked in the repo)
+*.pdf
+*.csv
+
+# Root-level research sources/figures that share an extension with tracked files
+/refs.bib
+/resource_assisted.tex
+/resource_assisted.bib
+/dual_certificate_note.tex
+/6_vectors_2_learnable.png
+/.codex


### PR DESCRIPTION
Closes #1600.

## Problem
`mosek.lic` (a MOSEK solver license file that contains credentials) was sitting in the repo root, untracked but not gitignored, so a single `git add -A` would stage and commit it. It was never committed (verified via `git log --all -- mosek.lic`).

## Changes
Add `.gitignore` entries for:
- `*.lic` (solver license files / credentials).
- LaTeX build artifacts (`*.aux`, `*.bbl`, `*.blg`, `*.log`, `*.out`).
- Local research outputs (`*.pdf`, `*.csv`) - none of these extensions are tracked.
- Root-anchored stray sources/figures that share an extension with tracked files (`/refs.bib`, `/resource_assisted.tex`, `/resource_assisted.bib`, `/dual_certificate_note.tex`, `/6_vectors_2_learnable.png`, `/.codex`).

Verified that every currently tracked file (the 10 docs figures, 7 paper `.tex` sources, 3 `.bib` files) is still not ignored, so nothing tracked is affected. `scripts/` and `lean/` are left alone since they may be intended content.