### PR TITLE
test: replace vacuous assertions that could never fail

### DIFF
--- a/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
@@ -125,7 +125,8 @@ class TestExtendedNonlocalGame(unittest.TestCase):
         res = bb84.quantum_value_lower_bound()
         expected_res = np.cos(np.pi / 8) ** 2
 
-        self.assertLessEqual(np.isclose(res, expected_res), True)
+        # A lower bound on the quantum value cannot exceed the true value.
+        self.assertLessEqual(res, expected_res + 1e-2)
 
     def test_bb84_nonsignaling_value(self):
         """Calculate the non-signaling value of the BB84 game."""

--- a/toqito/nonlocal_games/tests/test_nonlocal_game.py
+++ b/toqito/nonlocal_games/tests/test_nonlocal_game.py
@@ -92,11 +92,11 @@ class TestNonlocalGame(unittest.TestCase):
         # quantum value (as it may get stuck in a local minimum), but it should
         # never be possible for the lower bound to attain a value higher than
         # the true quantum value.
-        self.assertLessEqual(np.isclose(res, np.cos(np.pi / 8) ** 2, rtol=1e-02), True)
+        self.assertLessEqual(res, np.cos(np.pi / 8) ** 2 + 1e-2)
 
         # Even with 2 qubits each, the lower bound remains the same
         res = chsh.quantum_value_lower_bound(4)
-        self.assertLessEqual(np.isclose(res, np.cos(np.pi / 8) ** 2, rtol=1e-02), True)
+        self.assertLessEqual(res, np.cos(np.pi / 8) ** 2 + 1e-2)
 
     def test_chsh_game_classical_value(self):
         """Classical value for the CHSH game."""
@@ -127,7 +127,7 @@ class TestNonlocalGame(unittest.TestCase):
         bcs_game = self.chsh_bcs_game()
         chsh = NonlocalGame.from_bcs_game(bcs_game)
         res = chsh.quantum_value_lower_bound()
-        self.assertLessEqual(np.isclose(res, np.cos(np.pi / 8) ** 2, rtol=1e-02), True)
+        self.assertLessEqual(res, np.cos(np.pi / 8) ** 2 + 1e-2)
 
     def test_bcs_chsh_game_classical_value(self):
         """Classical value for the converted BCS CHSH game."""
@@ -177,7 +177,8 @@ class TestNonlocalGame(unittest.TestCase):
         ffl = NonlocalGame(prob_mat, pred_mat, 2)
         res = ffl.quantum_value_lower_bound()
         expected_res = 2 / 3
-        self.assertLessEqual(np.isclose(res, expected_res), True)
+        # A lower bound on the quantum value cannot exceed the true value.
+        self.assertLessEqual(res, expected_res + 1e-2)
 
     def test_ffl_game_nonsignaling_value(self):
         """Non-signaling value for the FFL game."""

--- a/toqito/state_ops/tests/test_schmidt_decomposition.py
+++ b/toqito/state_ops/tests/test_schmidt_decomposition.py
@@ -116,9 +116,9 @@ def test_schmidt_decomposition_input_dim(
         calculated_singular_vals, calculated_u_mat, calculated_vt_mat = schmidt_decomposition(
             test_input, dim=input_dim, k_param=input_param
         )
-    assert (calculated_singular_vals - expected_singular_vals).all() <= 0.1
-    assert (calculated_u_mat - expected_u_mat).all() <= 0.1
-    assert (calculated_vt_mat - expected_vt_mat).all() <= 0.1
+    np.testing.assert_allclose(calculated_singular_vals, expected_singular_vals, atol=0.1)
+    np.testing.assert_allclose(calculated_u_mat, expected_u_mat, atol=0.1)
+    np.testing.assert_allclose(calculated_vt_mat, expected_vt_mat, atol=0.1)
 
 
 def test_schmidt_decomp_random_state():


### PR DESCRIPTION
Closes #1599.

## Problem
Several tests asserted nothing meaningful:

- `test_schmidt_decomposition` used `(calculated - expected).all() <= 0.1`. `ndarray.all()` returns a bool, and `bool <= 0.1` never compares the arrays.
- The nonlocal-game and extended-nonlocal-game lower-bound tests used `self.assertLessEqual(np.isclose(res, value), True)`, which is always true (a bool is always `<= True`), so the value was never checked.

## Changes
- `test_schmidt_decomposition`: use `np.testing.assert_allclose` (verified locally).
- nonlocal-game / extended tests: assert the documented invariant, that a see-saw lower bound cannot exceed the true quantum value (`res <= value + 1e-2`). This is non-flaky (these tests do not seed the random restart).

The other vacuous tests named in the issue are fixed in their own PRs: antisymmetric_projection (#1586), w_state (#1589), hilbert_schmidt (#1604), and the rand statistical tests (#1590).

Note: this touches `test_nonlocal_game.py`, which #1593 also edits (it adds a seeded test); the changes are on different lines and should merge cleanly. The nonlocal-game test changes are verified by CI (this environment's cvxpy cannot run the SDPs).