### PR TITLE
ci: align ruff target, run ty for visibility, add a coverage floor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,9 @@ branch = True
 [report]
 show_missing = True
 precision = 2
+# Fail the coverage run if total coverage drops below this floor. Adjust upward toward the codecov target (70..90)
+# as coverage allows.
+fail_under = 80
 omit =
     */__init__.py
     */tests/*

--- a/.github/workflows/build-test-actions.yml
+++ b/.github/workflows/build-test-actions.yml
@@ -22,6 +22,13 @@ jobs:
       - uses: astral-sh/ruff-action@v3
       - run: ruff check --fix
       - run: ruff format
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      # Run the ty type checker for visibility. Non-blocking for now: there is a large backlog of existing
+      # diagnostics, so failing CI on them would require a separate type-annotation cleanup.
+      - name: Type-check with ty (non-blocking)
+        continue-on-error: true
+        run: uv run --group lint ty check toqito
 
   toqito-pytest:
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,8 @@ build-backend = "setuptools.build_meta"
 [tool.ruff]
 exclude = ["__init__.py", "docs/"]
 line-length = 120
-target-version = "py312"
+# Match the minimum supported Python (requires-python = ">=3.11"); py312 would let 3.12-only syntax through.
+target-version = "py311"
 force-exclude = true
 
 [tool.ty.environment]


### PR DESCRIPTION
Closes #1601.

Several configured quality signals were inconsistent or unenforced.

## Changes
- ruff `target-version` was `py312` while `requires-python = ">=3.11"`, so ruff could accept (or rewrite to) 3.12-only syntax that breaks on the supported 3.11 floor. Set `target-version = "py311"` (matches `isort` and `ty`). `ruff check` still passes.
- `ty` was declared in the `lint` group and configured but never run. Add a `ty check` step to the `code-style` job. It is `continue-on-error` for now: `ty check toqito` currently reports ~600 diagnostics, so making it blocking would require a separate type-annotation cleanup. Running it non-blocking surfaces the count and keeps it from growing silently.
- Add `fail_under = 80` to `.coveragerc` so the coverage run fails on a regression below that floor. This is a conservative starting value (the codecov target is 70..90); adjust upward as coverage allows.

## Notes
- I could not measure total coverage locally (this environment's cvxpy cannot run the SDP tests), so the `fail_under` value is a best estimate; if the CI coverage job reports below 80, lower it accordingly.
- Docstring examples already execute on PRs via the docs-preview workflow (`mkdocs build --strict`), so no separate doctest gate is added here.