### PR TITLE
fix: use scale-aware tolerances in null_space, is_rank_one, and is_diagonal

### DIFF
--- a/toqito/matrix_ops/null_space.py
+++ b/toqito/matrix_ops/null_space.py
@@ -42,7 +42,10 @@ def null_space(mat: np.ndarray, tol: float = 1e-08) -> np.ndarray:
         return np.zeros((mat.shape[0], 0), dtype=np.complex128)
 
     _, singular_values, vh = np.linalg.svd(mat, full_matrices=True)
-    rank = np.sum(singular_values > tol)
+    # Use a threshold relative to the largest singular value so the result does not depend on the overall scale of the
+    # matrix (an absolute threshold reports a full null space for, e.g., 1e-9 * I).
+    threshold = tol * singular_values.max() if singular_values.size else tol
+    rank = int(np.sum(singular_values > threshold))
     kernel = vh[rank:].conj().T
     if kernel.size == 0:
         return np.zeros((mat.shape[1], 0), dtype=np.complex128)

--- a/toqito/matrix_ops/tests/test_null_space.py
+++ b/toqito/matrix_ops/tests/test_null_space.py
@@ -35,3 +35,8 @@ def test_null_space_invalid_dimension_raises():
     """Reject one-dimensional inputs that are not matrices."""
     with pytest.raises(ValueError):
         null_space(np.array([1, 2, 3]))
+
+
+def test_null_space_scale_invariant():
+    """A small scalar multiple of a full-rank matrix still has an empty null space."""
+    assert null_space(1e-9 * np.eye(3)).shape[1] == 0

--- a/toqito/matrix_props/is_diagonal.py
+++ b/toqito/matrix_props/is_diagonal.py
@@ -5,16 +5,15 @@ import numpy as np
 from toqito.matrix_props import is_square
 
 
-def is_diagonal(mat: np.ndarray) -> bool:
+def is_diagonal(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
     r"""Determine if a matrix is diagonal [@wikipediadiagonal].
 
-    A matrix is diagonal if the matrix is square and if the diagonal of the matrix is non-zero,
-    while the off-diagonal elements are all zero.
-
-    This quick implementation is given by Daniel F. from StackOverflow in [@so43884189].
+    A matrix is diagonal if the matrix is square and the off-diagonal elements are all (approximately) zero.
 
     Args:
         mat: The matrix to check.
+        rtol: The relative tolerance parameter (default 1e-05).
+        atol: The absolute tolerance parameter (default 1e-08).
 
     Returns:
         Returns `True` if the matrix is diagonal and `False` otherwise.
@@ -75,6 +74,6 @@ def is_diagonal(mat: np.ndarray) -> bool:
     """
     if not is_square(mat):
         return False
-    i, j = mat.shape
-    test = mat.reshape(-1)[:-1].reshape(i - 1, j + 1)
-    return bool(~np.any(test[:, 1:]))
+    # The matrix is diagonal when it equals the matrix of just its diagonal, up to tolerance. This handles
+    # near-zero off-diagonal noise and the 1x1 case, unlike an exact comparison.
+    return bool(np.allclose(mat, np.diag(np.diag(mat)), rtol=rtol, atol=atol))

--- a/toqito/matrix_props/is_rank_one.py
+++ b/toqito/matrix_props/is_rank_one.py
@@ -40,4 +40,6 @@ def is_rank_one(mat: np.ndarray, tol: float = 1e-08) -> bool:
 
     """
     singular_values = np.linalg.svd(mat, compute_uv=False)
-    return np.count_nonzero(singular_values > tol) <= 1
+    # Threshold relative to the largest singular value so the result is independent of the matrix scale.
+    threshold = tol * singular_values.max() if singular_values.size else tol
+    return bool(np.count_nonzero(singular_values > threshold) <= 1)

--- a/toqito/matrix_props/tests/test_is_diagonal.py
+++ b/toqito/matrix_props/tests/test_is_diagonal.py
@@ -21,3 +21,10 @@ def test_is_diagonal_non_square():
     """Test on a non-square matrix."""
     mat = np.array([[1, 0, 0], [0, 1, 0]])
     np.testing.assert_equal(is_diagonal(mat), False)
+
+
+def test_is_diagonal_tolerance_and_edge_cases():
+    """Near-zero off-diagonals and the 1x1 case are handled with tolerance."""
+    assert is_diagonal(np.array([[5.0]])) is True
+    assert is_diagonal(np.array([[1.0, 1e-12], [0.0, 2.0]])) is True
+    assert is_diagonal(np.array([[1.0, 0.5], [0.0, 2.0]])) is False

--- a/toqito/matrix_props/tests/test_is_rank_one.py
+++ b/toqito/matrix_props/tests/test_is_rank_one.py
@@ -31,3 +31,11 @@ def test_small_singular_values_respected_by_tolerance():
     """Ensure the tolerance parameter is honoured."""
     singular_values = np.diag([1.0, 1e-9])
     np.testing.assert_equal(is_rank_one(singular_values, tol=1e-8), True)
+
+
+def test_is_rank_one_scale_invariant():
+    """Rank detection does not depend on the overall scale of the matrix."""
+    # A small scalar multiple of a rank-2 matrix is still rank 2 (the old absolute tolerance reported rank <= 1).
+    assert is_rank_one(1e-9 * np.eye(2)) is False
+    # A small scalar multiple of a rank-1 matrix is still rank 1.
+    assert is_rank_one(1e-9 * np.outer([1, 1], [1, 1])) is True


### PR DESCRIPTION
Addresses the concrete correctness items in #1597.

## Problem
- `null_space` and `is_rank_one` counted singular values above an absolute threshold (`1e-8`), so the result depended on the matrix scale. `null_space(1e-9 * np.eye(3))` returned the entire space as the null space, and `is_rank_one(1e-9 * np.eye(2))` reported rank <= 1.
- `is_diagonal` compared off-diagonal entries to exactly zero (`np.any`), so a `1e-16` residue made it report a diagonal matrix as non-diagonal.

## Changes
- `null_space`, `is_rank_one`: threshold relative to the largest singular value (matching `numpy.linalg.matrix_rank`).
- `is_diagonal`: tolerant `np.allclose` against the diagonal-only matrix, exposing `rtol`/`atol`; this also handles the 1x1 case cleanly.
- Regression tests for scale invariance and the tolerance/edge cases.

## Scope note
#1597 also lists broader tolerance-API consistency across `matrix_props` (exposing `rtol`/`atol` on `is_density`, `is_stochastic`, `is_commuting`, etc., the inverted tolerance in `is_block_positive`, and tolerance/shape handling in `is_permutation`). This PR covers the concrete wrong-result bugs; the remaining items are API-consistency cleanups and can follow under the same issue.