### PR TITLE
fix: accept real-scalar werner alpha and validate isotropic/werner ranges

### DIFF
--- a/toqito/states/isotropic.py
+++ b/toqito/states/isotropic.py
@@ -18,7 +18,7 @@ def isotropic(dim: int, alpha: float) -> np.ndarray:
         \begin{equation}
             \rho_{\alpha} = \frac{1 - \alpha}{d^2} \mathbb{I} \otimes
             \mathbb{I} + \alpha |\psi_+ \rangle \langle \psi_+ | \in
-            \mathbb{C}^d \otimes \mathbb{C}^2
+            \mathbb{C}^d \otimes \mathbb{C}^d
         \end{equation}
     \]
 
@@ -27,7 +27,11 @@ def isotropic(dim: int, alpha: float) -> np.ndarray:
 
     Args:
         dim: The local dimension.
-        alpha: The parameter of the isotropic state.
+        alpha: The parameter of the isotropic state. Must lie in \([-1/(d^2 - 1), 1]\) for the result to be a valid
+            density operator.
+
+    Raises:
+        ValueError: If `alpha` is outside \([-1/(d^2 - 1), 1]\).
 
     Returns:
         Isotropic state of dimension `dim`.
@@ -42,5 +46,9 @@ def isotropic(dim: int, alpha: float) -> np.ndarray:
         ```
 
     """
+    lower = -1 / (dim**2 - 1)
+    if not lower <= alpha <= 1:
+        raise ValueError(f"InvalidAlpha: `alpha` must be in the interval [{lower}, 1] for a valid isotropic state.")
+
     psi = max_entangled(dim, False, False)
     return (1 - alpha) * np.identity(dim**2) / dim**2 + alpha * psi @ psi.conj().T / dim

--- a/toqito/states/tests/test_isotropic.py
+++ b/toqito/states/tests/test_isotropic.py
@@ -1,6 +1,7 @@
 """Test isotropic."""
 
 import numpy as np
+import pytest
 
 from toqito.states import isotropic
 
@@ -23,3 +24,9 @@ def test_isotropic_qutrit():
     """Generate a qutrit isotropic state with `alpha` = 1/2."""
     res = isotropic(3, 1 / 2)
     np.testing.assert_allclose(res, iso_dim_3_alpha_half)
+
+
+def test_isotropic_alpha_out_of_range():
+    """An alpha outside [-1/(d^2-1), 1] does not yield a valid isotropic state."""
+    with pytest.raises(ValueError, match="must be in the interval"):
+        isotropic(3, 2.0)

--- a/toqito/states/tests/test_werner.py
+++ b/toqito/states/tests/test_werner.py
@@ -46,3 +46,15 @@ def test_werner_state_invalid(dim, alpha):
     """Test function works as expected for an invalid input."""
     with pytest.raises(ValueError):
         werner(dim, alpha)
+
+
+def test_werner_integer_alpha():
+    """Integer scalar alpha is accepted; werner(d, 1) is the antisymmetric projector state."""
+    state = werner(3, 1)
+    np.testing.assert_equal(is_density(state), True)
+
+
+def test_werner_bipartite_alpha_out_of_range():
+    """A bipartite alpha outside [-1, 1] is rejected."""
+    with pytest.raises(ValueError, match="must be in the interval"):
+        werner(2, 5)

--- a/toqito/states/werner.py
+++ b/toqito/states/werner.py
@@ -4,6 +4,7 @@ Werner states are mixtures of projectors onto the symmetric and permutation oper
 """
 
 import itertools
+import numbers
 
 import numpy as np
 
@@ -84,9 +85,12 @@ def werner(dim: int, alpha: float | list[float]) -> np.ndarray:
         rho = rho / np.trace(rho)
         return rho
 
-    # Bipartite Werner state (executed only if alpha is a float).
-    if isinstance(alpha, float):
+    # Bipartite Werner state (any real scalar alpha, e.g. werner(d, 1) for the antisymmetric projector). bool is
+    # excluded because it is a subclass of int.
+    if isinstance(alpha, numbers.Real) and not isinstance(alpha, bool):
+        if not -1 <= alpha <= 1:
+            raise ValueError("InvalidAlpha: For a bipartite Werner state, `alpha` must be in the interval [-1, 1].")
         n_fac = 2
         return (np.identity(dim**2) - alpha * swap_operator(dim, True)) / (dim * (dim - alpha))
 
-    raise ValueError("Alpha must be either a float or a list of floats.")
+    raise ValueError("Alpha must be either a real number or a list of floats.")


### PR DESCRIPTION
Addresses the concrete state-construction validation items in #1598.

## Problem
- `werner` guarded the bipartite branch with `isinstance(alpha, float)`, so `werner(d, 1)` (an integer) raised, even though it is a valid density operator (the antisymmetric projector). The existing test even asserted that integer alpha is "not a valid type."
- `isotropic` did no validation, so `isotropic(3, 2.0)` returned a trace-1 operator with a negative eigenvalue (not a density matrix), and its docstring described the space as `C^d (x) C^2` instead of `C^d (x) C^d`.

## Changes
- `werner`: accept any real scalar `alpha` (excluding `bool`) and validate `alpha` in `[-1, 1]` (the density-operator range for the bipartite state). `werner(d, 1)` now works; `werner(2, 5)` still raises, now for being out of range.
- `isotropic`: validate `alpha` in `[-1/(d^2 - 1), 1]`; fix the docstring space.
- Tests for integer-alpha acceptance and out-of-range rejection.

## Scope note
#1598 also lists validation for `probs`/`strategy` in `state_distinguishability`/`state_exclusion` and for `is_povm`/`pretty_good_measurement`/`pretty_bad_measurement`. Those (the `state_opt` ones are PICOS-based and not runnable in this environment) can follow under the same issue.