### PR TITLE
fix: accept the flat Kraus format in is_trace_preserving and is_quantum_channel

### DIFF
--- a/toqito/channel_props/is_quantum_channel.py
+++ b/toqito/channel_props/is_quantum_channel.py
@@ -74,17 +74,16 @@ def is_quantum_channel(
         ```
 
     """
-    # If the variable `phi` is provided as a list, we assume this is a list
-    # of Kraus operators.
-    if not (
-        isinstance(phi, np.ndarray)
-        or (
-            isinstance(phi, list)
-            and all(isinstance(row, list) and all(isinstance(op, np.ndarray) for op in row) for row in phi)
-        )
-    ):
+    # If the variable `phi` is provided as a list, we assume this is a list of Kraus operators. Both the flat
+    # completely-positive format [K1, K2, ...] and the general paired format [[A1, B1], ...] are accepted.
+    is_flat_kraus = isinstance(phi, list) and all(isinstance(op, np.ndarray) for op in phi)
+    is_paired_kraus = isinstance(phi, list) and all(
+        isinstance(row, list) and all(isinstance(op, np.ndarray) for op in row) for row in phi
+    )
+    if not (isinstance(phi, np.ndarray) or is_flat_kraus or is_paired_kraus):
         raise TypeError(
-            "phi must be either a numpy array (Choi matrix) or a list of lists of numpy arrays (Kraus operators)."
+            "phi must be either a numpy array (Choi matrix) or a list of Kraus operators "
+            "(a flat list, or a list of [A, B] pairs)."
         )
     if isinstance(phi, list):
         phi = kraus_to_choi(phi)

--- a/toqito/channel_props/is_trace_preserving.py
+++ b/toqito/channel_props/is_trace_preserving.py
@@ -98,8 +98,14 @@ def is_trace_preserving(
     # If the variable `phi` is provided as a list, we assume this is a list
     # of Kraus operators.
     if isinstance(phi, list):
-        phi_l = [A for A, _ in phi]
-        phi_r = [B for _, B in phi]
+        # Support both the flat completely-positive format [K1, K2, ...] (each element a single Kraus operator) and
+        # the general paired format [[A1, B1], ...]. For the flat form the two sides coincide, so the test reduces to
+        # sum_i K_i^dagger K_i = I.
+        if isinstance(phi[0], np.ndarray):
+            phi_l = phi_r = phi
+        else:
+            phi_l = [A for A, _ in phi]
+            phi_r = [B for _, B in phi]
 
         k_l = np.concatenate(phi_l, axis=0)
         k_r = np.concatenate(phi_r, axis=0)

--- a/toqito/channel_props/tests/test_is_quantum_channel.py
+++ b/toqito/channel_props/tests/test_is_quantum_channel.py
@@ -34,8 +34,6 @@ def test_is_quantum_channel_invalid_input_returns_false():
     [
         # not ndarray or list.
         123,
-        # list but not list of lists.
-        [np.eye(2)],
         # wrong inner type.
         [["not a matrix"]],
         # mixed types.
@@ -46,8 +44,11 @@ def test_is_quantum_channel_invalid_types_raise(bad_phi):
     """Testing invalid input types."""
     with pytest.raises(
         TypeError,
-        match=re.escape(
-            "phi must be either a numpy array (Choi matrix) or a list of lists of numpy arrays (Kraus operators)."
-        ),
+        match=re.escape("phi must be either a numpy array (Choi matrix) or a list of Kraus operators"),
     ):
         is_quantum_channel(bad_phi)
+
+
+def test_is_quantum_channel_flat_kraus_format():
+    """A flat list of Kraus operators is accepted (e.g. the identity channel)."""
+    assert is_quantum_channel([np.eye(2)]) is True

--- a/toqito/channel_props/tests/test_is_trace_preserving.py
+++ b/toqito/channel_props/tests/test_is_trace_preserving.py
@@ -23,3 +23,10 @@ def test_is_trace_preserving_invalid_dim_raises():
     """Ensure that a ValueError is raised when the input matrix has non-square dimension."""
     with pytest.raises(ValueError, match="Cannot infer equal subsystem dimensions. Please provide `dim`."):
         is_trace_preserving(np.eye(3))
+
+
+def test_is_trace_preserving_flat_kraus_format():
+    """The flat Kraus format [K1, K2, ...] is accepted (sum K_i^dagger K_i = I)."""
+    kraus = [np.eye(2) / np.sqrt(2), np.array([[0, 1], [1, 0]]) / np.sqrt(2)]
+    assert is_trace_preserving(kraus) is True
+    assert is_trace_preserving([0.5 * np.eye(2)]) is False


### PR DESCRIPTION
Addresses the flat-Kraus-format part of #1596.

## Problem
`is_trace_preserving` and `is_quantum_channel` rejected or mishandled the flat completely-positive Kraus list `[K1, K2, ...]` that the rest of the package (`apply_channel`, `kraus_to_choi`, `channel_dim`) accepts:

- `is_trace_preserving` did `[A for A, _ in phi]`, unpacking every element as an `[A, B]` pair, so a flat list was destructured row-wise into garbage.
- `is_quantum_channel`'s type guard required a list of lists, so a valid flat channel such as `[np.eye(2)]` (the identity channel) raised `TypeError`.

## Changes
- Detect the flat format (each element is an ndarray). For trace preservation the two Kraus sides coincide, so the check reduces to `sum_i K_i^dagger K_i = I`; the paired/general format is unchanged.
- Accept the flat format in `is_quantum_channel` and update its error message.
- Update the tests that encoded the old over-restriction (`[np.eye(2)]` is now a valid channel, not an invalid type) and add positive flat-format tests.

## Scope note
The remaining #1596 items, dimension inference in `channel_fidelity` (`int(np.log2(...))`) and `completely_bounded_trace_norm`, and non-CP Choi handling in `is_extremal`, are better routed through `channel_dim` and involve the SDP code path (not runnable in this environment); they can follow under the same issue.