### PR TITLE
fix: tolerance handling and rtol/atol exposure in matrix_props predicates

### DIFF
--- a/toqito/matrix_props/is_circulant.py
+++ b/toqito/matrix_props/is_circulant.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 
-def is_circulant(mat: np.ndarray) -> bool:
+def is_circulant(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
     r"""Determine if matrix is circulant [@wikipediacirculant].
 
     A circulant matrix is a square matrix in which all row vectors are composed
@@ -12,6 +12,8 @@ def is_circulant(mat: np.ndarray) -> bool:
 
     Args:
         mat: Matrix to check the circulancy of.
+        rtol: The relative tolerance parameter (default 1e-05).
+        atol: The absolute tolerance parameter (default 1e-08).
 
     Returns:
         Return `True` if `mat` is circulant; `False` otherwise.
@@ -48,6 +50,6 @@ def is_circulant(mat: np.ndarray) -> bool:
     for i in range(n - 1):
         row = mat[i + 1]
         shifted = np.roll(mat[i], 1)
-        if not np.allclose(row, shifted):
+        if not np.allclose(row, shifted, rtol=rtol, atol=atol):
             return False
     return True

--- a/toqito/matrix_props/is_commuting.py
+++ b/toqito/matrix_props/is_commuting.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 
-def is_commuting(mat_1: np.ndarray, mat_2: np.ndarray) -> bool:
+def is_commuting(mat_1: np.ndarray, mat_2: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
     r"""Determine if two linear operators commute with each other [@wikipediacommuting].
 
     For any pair of operators \(X, Y \in \text{L}(\mathcal{X})\), the
@@ -20,6 +20,8 @@ def is_commuting(mat_1: np.ndarray, mat_2: np.ndarray) -> bool:
     Args:
         mat_1: First matrix to check.
         mat_2: Second matrix to check.
+        rtol: The relative tolerance parameter (default 1e-05).
+        atol: The absolute tolerance parameter (default 1e-08).
 
     Returns:
         Return `True` if `mat_1` commutes with `mat_2` and False otherwise.
@@ -80,4 +82,4 @@ def is_commuting(mat_1: np.ndarray, mat_2: np.ndarray) -> bool:
         ```
 
     """
-    return np.allclose(mat_1 @ mat_2 - mat_2 @ mat_1, 0)
+    return bool(np.allclose(mat_1 @ mat_2 - mat_2 @ mat_1, 0, rtol=rtol, atol=atol))

--- a/toqito/matrix_props/is_permutation.py
+++ b/toqito/matrix_props/is_permutation.py
@@ -3,14 +3,15 @@
 import numpy as np
 
 
-def is_permutation(mat: np.ndarray) -> bool:
+def is_permutation(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
     r"""Determine if a matrix is a permutation matrix [@wikipediapermutation].
 
-    A matrix is a permutation matrix if each row and column has a
-    single element of 1 and all others are 0.
+    A matrix is a permutation matrix if it is square, every entry is 0 or 1, and each row and column sums to 1.
 
     Args:
         mat: The matrix to check.
+        rtol: The relative tolerance parameter (default 1e-05).
+        atol: The absolute tolerance parameter (default 1e-08).
 
     Returns:
         Returns `True` if the matrix is a permutation matrix and `False` otherwise.
@@ -61,10 +62,16 @@ def is_permutation(mat: np.ndarray) -> bool:
         ```
 
     """
-    for i in np.nditer(mat):
-        if i not in (0, 1):
-            return False
+    mat = np.asarray(mat)
+    if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
+        return False
 
-    if all(sum(row) == 1 for row in mat):
-        return all(sum(col) == 1 for col in zip(*mat))
-    return False
+    # Every entry must be 0 or 1 (within tolerance).
+    is_zero_or_one = np.isclose(mat, 0, rtol=rtol, atol=atol) | np.isclose(mat, 1, rtol=rtol, atol=atol)
+    if not np.all(is_zero_or_one):
+        return False
+
+    # Each row and each column must sum to 1.
+    rows_ok = np.allclose(mat.sum(axis=1), 1, rtol=rtol, atol=atol)
+    cols_ok = np.allclose(mat.sum(axis=0), 1, rtol=rtol, atol=atol)
+    return bool(rows_ok and cols_ok)

--- a/toqito/matrix_props/is_pseudo_hermitian.py
+++ b/toqito/matrix_props/is_pseudo_hermitian.py
@@ -83,7 +83,7 @@ def is_pseudo_hermitian(mat: np.ndarray, signature: np.ndarray, rtol: float = 1e
         ```
 
     """
-    if not is_hermitian(signature):
+    if not is_hermitian(signature, rtol=rtol, atol=atol):
         raise ValueError("Signature not hermitian matrix.")
 
     if np.linalg.matrix_rank(signature) != signature.shape[0]:

--- a/toqito/matrix_props/tests/test_is_permutation.py
+++ b/toqito/matrix_props/tests/test_is_permutation.py
@@ -45,3 +45,10 @@ def test_is_matrix_with_negative_values_and_unitary_sums():
     """Test a non-permutation matrix with some negative values that passes the unitary sum check."""
     mat = np.array([[2, -1], [-1, 2]])
     np.testing.assert_equal(is_permutation(mat), False)
+
+
+def test_is_permutation_tolerance_and_shape():
+    """Float noise is tolerated; non-square and fractional matrices are rejected."""
+    np.testing.assert_equal(is_permutation(np.array([[0.0, 1.0], [1.0, 0.0]]) + 1e-12), True)
+    np.testing.assert_equal(is_permutation(np.array([[1, 0, 0], [0, 1, 0]])), False)
+    np.testing.assert_equal(is_permutation(np.array([[0.5, 0.5], [0.5, 0.5]])), False)


### PR DESCRIPTION
Closes #1597 (completing the work started in #1620).

## Changes
- `is_permutation`: replaced the exact `in (0, 1)` entry test and `== 1` row/column sum checks (which rejected a permutation matrix carrying float noise) with tolerant, vectorized checks, added a squareness guard, and exposed `rtol`/`atol`.
- `is_pseudo_hermitian`: the signature Hermiticity check used `is_hermitian(signature)` with default tolerances; forward the caller's `rtol`/`atol`.
- `is_commuting`, `is_circulant`: already tolerant via `np.allclose` but did not expose `rtol`/`atol`; added and forwarded the parameters.

## Notes
- `is_block_positive`'s `(1 + rtol)` is **not** an inverted-tolerance bug. The code comment documents it as a deliberate deviation from QETLAB to work around cvxpy numerical inaccuracies (the `(1 - rtol)` form fails for genuinely k-block-positive matrices), so I left it.
- The sign-based predicates (`is_nonnegative`, `is_positive`) keep their exact `>= 0` / `> 0` checks, which are the correct semantics for those properties.