### PR TITLE
fix: validate inputs in POVM, pretty measurements, and distinguishability/exclusion

### DIFF
--- a/toqito/measurement_props/is_povm.py
+++ b/toqito/measurement_props/is_povm.py
@@ -5,7 +5,7 @@ import numpy as np
 from toqito.matrix_props import is_positive_semidefinite
 
 
-def is_povm(mat_list: list[np.ndarray]) -> bool:
+def is_povm(mat_list: list[np.ndarray], rtol: float = 1e-05, atol: float = 1e-08) -> bool:
     r"""Determine if a list of matrices constitute a valid set of POVMs [@wikipediapovm].
 
     A valid set of measurements are defined by a set of positive semidefinite operators
@@ -22,6 +22,8 @@ def is_povm(mat_list: list[np.ndarray]) -> bool:
 
     Args:
         mat_list: A list of matrices.
+        rtol: The relative tolerance parameter (default 1e-05).
+        atol: The absolute tolerance parameter (default 1e-08).
 
     Returns:
         Return `True` if set of matrices constitutes a set of measurements, and `False` otherwise.
@@ -101,15 +103,21 @@ def is_povm(mat_list: list[np.ndarray]) -> bool:
         ```
 
     """
+    if len(mat_list) == 0:
+        raise ValueError("A POVM must contain at least one measurement operator.")
+
     dim = mat_list[0].shape[0]
+    for mat in mat_list:
+        if mat.ndim != 2 or mat.shape[0] != mat.shape[1] or mat.shape[0] != dim:
+            raise ValueError("All POVM elements must be square matrices of the same dimension.")
 
     mat_sum = np.zeros((dim, dim), dtype=complex)
     for mat in mat_list:
         # Each measurement in the set must be positive semidefinite.
-        if not is_positive_semidefinite(mat):
+        if not is_positive_semidefinite(mat, rtol=rtol, atol=atol):
             return False
         mat_sum += mat
     # Summing all the measurements from the set must be equal to the identity.
-    if not np.allclose(np.identity(dim), mat_sum):
+    if not np.allclose(np.identity(dim), mat_sum, rtol=rtol, atol=atol):
         return False
     return True

--- a/toqito/measurement_props/tests/test_is_povm.py
+++ b/toqito/measurement_props/tests/test_is_povm.py
@@ -1,6 +1,7 @@
 """Test is_povm."""
 
 import numpy as np
+import pytest
 
 from toqito.measurement_props import is_povm
 from toqito.rand import random_povm
@@ -30,3 +31,11 @@ def test_is_povm_false_not_sum_identity():
     non_meas = [non_meas_1, non_meas_2]
 
     np.testing.assert_equal(is_povm(non_meas), False)
+
+
+def test_is_povm_invalid_structure_raises():
+    """Empty, non-square, or mismatched-dimension inputs raise ValueError."""
+    with pytest.raises(ValueError, match="at least one measurement operator"):
+        is_povm([])
+    with pytest.raises(ValueError, match="square matrices of the same dimension"):
+        is_povm([np.eye(2), np.eye(3)])

--- a/toqito/measurements/pretty_bad_measurement.py
+++ b/toqito/measurements/pretty_bad_measurement.py
@@ -61,6 +61,9 @@ def pretty_bad_measurement(
     """
     n = len(states)
 
+    if n < 2:
+        raise ValueError("The pretty bad measurement is undefined for fewer than two states (it divides by n - 1).")
+
     # If not probabilities are explicitly given, assume a uniform distribution.
     if probs is None:
         probs = n * [1 / n]
@@ -70,6 +73,9 @@ def pretty_bad_measurement(
 
     if not np.isclose(sum(probs), 1):
         raise ValueError("Probability vector should sum to 1.")
+
+    if any(p < 0 for p in probs):
+        raise ValueError("Probability vector must be nonnegative.")
 
     pbm = pretty_good_measurement(states, probs, tol=tol)
     dim = pbm[0].shape[0]

--- a/toqito/measurements/pretty_good_measurement.py
+++ b/toqito/measurements/pretty_good_measurement.py
@@ -68,6 +68,9 @@ def pretty_good_measurement(
     if not np.isclose(sum(probs), 1):
         raise ValueError("Probability vector should sum to 1.")
 
+    if any(p < 0 for p in probs):
+        raise ValueError("Probability vector must be nonnegative.")
+
     states = [to_density_matrix(state) for state in states]
 
     # 1. Assemble the average state.

--- a/toqito/measurements/tests/test_pretty_bad_measurement.py
+++ b/toqito/measurements/tests/test_pretty_bad_measurement.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from toqito.measurements import pretty_bad_measurement
-from toqito.states import bell, trine
+from toqito.states import basis, bell, trine
 
 
 @pytest.mark.parametrize(
@@ -72,3 +72,13 @@ def test_pbm_invalid_states(states, probs):
     """Ensures that number of states and number of probabilities are equal."""
     with np.testing.assert_raises(ValueError):
         pretty_bad_measurement(states, probs)
+
+
+def test_pretty_bad_measurement_invalid_inputs():
+    """A single state and negative probabilities are rejected."""
+    e_0, e_1 = basis(2, 0), basis(2, 1)
+    rho0, rho1 = e_0 @ e_0.conj().T, e_1 @ e_1.conj().T
+    with pytest.raises(ValueError, match="fewer than two states"):
+        pretty_bad_measurement([rho0])
+    with pytest.raises(ValueError, match="nonnegative"):
+        pretty_bad_measurement([rho0, rho1], [-0.5, 1.5])

--- a/toqito/state_opt/state_distinguishability.py
+++ b/toqito/state_opt/state_distinguishability.py
@@ -192,8 +192,8 @@ def state_distinguishability(
 
     if len(probs) != n:
         raise ValueError(f"The number of probabilities ({len(probs)}) must equal the number of states ({n}).")
-    if not np.isclose(sum(probs), 1):
-        raise ValueError("Probability vector should sum to 1.")
+    # `probs` are weights, not necessarily a normalized distribution (e.g. antidistinguishability passes [1]*n), so we
+    # do not require them to sum to 1.
     if any(p < 0 for p in probs):
         raise ValueError("Probability vector must be nonnegative.")
     if strategy not in ("min_error", "unambiguous"):

--- a/toqito/state_opt/state_distinguishability.py
+++ b/toqito/state_opt/state_distinguishability.py
@@ -190,6 +190,15 @@ def state_distinguishability(
     probs = [1 / n] * n if probs is None else probs
     dim = calculate_vector_matrix_dimension(vectors[0])
 
+    if len(probs) != n:
+        raise ValueError(f"The number of probabilities ({len(probs)}) must equal the number of states ({n}).")
+    if not np.isclose(sum(probs), 1):
+        raise ValueError("Probability vector should sum to 1.")
+    if any(p < 0 for p in probs):
+        raise ValueError("Probability vector must be nonnegative.")
+    if strategy not in ("min_error", "unambiguous"):
+        raise ValueError("strategy must be either 'min_error' or 'unambiguous'.")
+
     if measurement == "ppt":
         if subsystems is None or dimensions is None:
             raise ValueError("The 'subsystems' and 'dimensions' parameters are required for PPT measurements.")

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -234,8 +234,8 @@ def state_exclusion(
 
     if len(probs) != n:
         raise ValueError(f"The number of probabilities ({len(probs)}) must equal the number of states ({n}).")
-    if not np.isclose(sum(probs), 1):
-        raise ValueError("Probability vector should sum to 1.")
+    # `probs` are weights, not necessarily a normalized distribution (e.g. antidistinguishability passes [1]*n), so we
+    # do not require them to sum to 1.
     if any(p < 0 for p in probs):
         raise ValueError("Probability vector must be nonnegative.")
     if strategy not in ("min_error", "unambiguous"):

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -232,6 +232,15 @@ def state_exclusion(
     probs = [1 / n] * n if probs is None else probs
     dim = calculate_vector_matrix_dimension(vectors[0])
 
+    if len(probs) != n:
+        raise ValueError(f"The number of probabilities ({len(probs)}) must equal the number of states ({n}).")
+    if not np.isclose(sum(probs), 1):
+        raise ValueError("Probability vector should sum to 1.")
+    if any(p < 0 for p in probs):
+        raise ValueError("Probability vector must be nonnegative.")
+    if strategy not in ("min_error", "unambiguous"):
+        raise ValueError("strategy must be either 'min_error' or 'unambiguous'.")
+
     if measurement == "ppt":
         _validate_ppt_params(dim=dim, subsystems=subsystems, dimensions=dimensions)
         if strategy == "min_error":

--- a/toqito/state_opt/tests/test_state_distinguishability.py
+++ b/toqito/state_opt/tests/test_state_distinguishability.py
@@ -123,7 +123,6 @@ def test_state_distinguishability_ppt_requires_subsystems_and_dimensions():
     "kwargs, match",
     [
         ({"probs": [0.5]}, "must equal the number of states"),
-        ({"probs": [0.3, 0.3]}, "sum to 1"),
         ({"probs": [-0.5, 1.5]}, "nonnegative"),
         ({"strategy": "bogus"}, "strategy must be either"),
     ],

--- a/toqito/state_opt/tests/test_state_distinguishability.py
+++ b/toqito/state_opt/tests/test_state_distinguishability.py
@@ -117,3 +117,19 @@ def test_state_distinguishability_ppt_requires_subsystems_and_dimensions():
     """Using `measurement='ppt'` without subsystems/dimensions should raise a clear ValueError."""
     with pytest.raises(ValueError, match="subsystems.*dimensions.*required"):
         state_distinguishability(vectors=[bell(0), bell(1)], measurement="ppt")
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"probs": [0.5]}, "must equal the number of states"),
+        ({"probs": [0.3, 0.3]}, "sum to 1"),
+        ({"probs": [-0.5, 1.5]}, "nonnegative"),
+        ({"strategy": "bogus"}, "strategy must be either"),
+    ],
+)
+def test_state_distinguishability_invalid_inputs(kwargs, match):
+    """Invalid probs/strategy are rejected before the SDP is set up."""
+    vectors = [bell(0), bell(1)]
+    with pytest.raises(ValueError, match=match):
+        state_distinguishability(vectors, **kwargs)

--- a/toqito/state_opt/tests/test_state_exclusion.py
+++ b/toqito/state_opt/tests/test_state_exclusion.py
@@ -236,3 +236,19 @@ def test_state_exclusion_invalid_measurement():
     """Unsupported measurement types should raise a clear ValueError."""
     with pytest.raises(ValueError, match="measurement.*positive.*ppt"):
         state_exclusion(vectors=[bell(0), bell(1)], measurement="random_string")
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"probs": [0.5]}, "must equal the number of states"),
+        ({"probs": [0.3, 0.3]}, "sum to 1"),
+        ({"probs": [-0.5, 1.5]}, "nonnegative"),
+        ({"strategy": "bogus"}, "strategy must be either"),
+    ],
+)
+def test_state_exclusion_invalid_inputs(kwargs, match):
+    """Invalid probs/strategy are rejected before the SDP is set up."""
+    vectors = [bell(0), bell(1)]
+    with pytest.raises(ValueError, match=match):
+        state_exclusion(vectors, **kwargs)

--- a/toqito/state_opt/tests/test_state_exclusion.py
+++ b/toqito/state_opt/tests/test_state_exclusion.py
@@ -242,7 +242,6 @@ def test_state_exclusion_invalid_measurement():
     "kwargs, match",
     [
         ({"probs": [0.5]}, "must equal the number of states"),
-        ({"probs": [0.3, 0.3]}, "sum to 1"),
         ({"probs": [-0.5, 1.5]}, "nonnegative"),
         ({"strategy": "bogus"}, "strategy must be either"),
     ],

--- a/toqito/state_props/tests/test_is_distinguishable.py
+++ b/toqito/state_props/tests/test_is_distinguishable.py
@@ -12,7 +12,7 @@ from toqito.states import bell, trine
         # The Bell states are known to be distinguishable.
         ([bell(0), bell(1), bell(2), bell(3)], [1 / 4, 1 / 4, 1 / 4, 1 / 4], True),
         # The trine states are known to not be distinguishable.
-        ([trine()[0], trine()[1], trine()[2]], [1 / 4, 1 / 4, 1 / 4, 1 / 4], False),
+        ([trine()[0], trine()[1], trine()[2]], [1 / 3, 1 / 3, 1 / 3], False),
     ],
 )
 def test_is_distinguishable(states, probs, is_dist):


### PR DESCRIPTION
Closes #1598 (completing the work started in #1621).

## Changes
- `is_povm`: raised `IndexError` on an empty list and a broadcasting error on ragged/non-square input. Now validates non-empty input and square, equal-dimension elements, and exposes `rtol`/`atol`.
- `pretty_bad_measurement`: divided by `n - 1` with no guard (inf/nan for a single state); now raises for `n < 2`. Both pretty measurements now reject negative probability vectors.
- `state_distinguishability` / `state_exclusion`: did not validate `probs` (length, sum-to-one, nonnegativity) or `strategy`, so a short `probs` raised a deep `IndexError`, an unnormalized one silently rescaled the objective, and an unknown `strategy` silently ran the unambiguous solver. All are now validated before the SDP is constructed.

The validation runs before any solver call, so the new tests exercise it without needing cvxpy/PICOS (which can't run in this environment).