### PR TITLE
fix: guard non-CP Choi in is_extremal and fix channel_fidelity dimension inference

### DIFF
--- a/toqito/channel_metrics/channel_fidelity.py
+++ b/toqito/channel_metrics/channel_fidelity.py
@@ -85,7 +85,11 @@ def channel_fidelity(choi_1: np.ndarray, choi_2: np.ndarray, eps: float = 1e-7) 
         raise ValueError("The Choi matrix provided must be square.")
 
     choi_dim = choi_dim_x
-    dim = int(np.log2(choi_dim))
+    # The Choi matrix of a channel with equal input/output dimension d is d^2 by d^2, so the subsystem dimension is
+    # sqrt(choi_dim). The previous int(log2(choi_dim)) only coincided with this for d <= 4 and was wrong for larger d.
+    dim = int(round(np.sqrt(choi_dim)))
+    if dim * dim != choi_dim:
+        raise ValueError("The Choi matrix dimension must be a perfect square (equal input and output dimensions).")
 
     lam = cvxpy.Variable(nonneg=True)
     q_var = cvxpy.Variable((choi_dim, choi_dim), complex=True)

--- a/toqito/channel_metrics/tests/test_channel_fidelity.py
+++ b/toqito/channel_metrics/tests/test_channel_fidelity.py
@@ -42,3 +42,10 @@ def test_channel_fidelity_raises_error(input1, input2, expected_msg):
     """Test functions works as expected for valid inputs."""
     with pytest.raises(ValueError, match=expected_msg):
         channel_fidelity(input1, input2)
+
+
+def test_channel_fidelity_non_perfect_square_dim_raises():
+    """A Choi matrix whose dimension is not a perfect square is rejected before the SDP."""
+    mat = np.eye(6, dtype=complex)
+    with pytest.raises(ValueError, match="perfect square"):
+        channel_fidelity(mat, mat)

--- a/toqito/channel_props/is_extremal.py
+++ b/toqito/channel_props/is_extremal.py
@@ -57,6 +57,11 @@ def is_extremal(phi: np.ndarray | list[np.ndarray | list[np.ndarray]], tol: floa
     # If input is a Choi matrix, convert to a (flat) list of Kraus operators.
     if isinstance(phi, np.ndarray):
         kraus_ops = choi_to_kraus(phi)
+        # For a non-completely-positive (or non-Hermitian) Choi matrix, choi_to_kraus returns operators in the paired
+        # [[A, B], ...] form. Extremality is only defined for completely positive channels, so reject that case with a
+        # clear error instead of crashing on A.conj().T below.
+        if any(not isinstance(op, np.ndarray) for op in kraus_ops):
+            raise ValueError("is_extremal requires a completely positive channel (the Choi matrix must be PSD).")
     elif isinstance(phi, list):
         # If the first element is a list, assume nested list of Kraus operators.
         if len(phi) == 0:

--- a/toqito/channel_props/tests/test_is_extremal.py
+++ b/toqito/channel_props/tests/test_is_extremal.py
@@ -94,7 +94,5 @@ def test_is_extremal_value_errors(phi, error_message):
 
 def test_is_extremal_non_cp_choi_raises():
     """A non-completely-positive Choi matrix (e.g. the swap operator) raises a clear error."""
-    from toqito.perms import swap_operator
-
     with pytest.raises(ValueError, match="completely positive"):
         is_extremal(swap_operator(2))

--- a/toqito/channel_props/tests/test_is_extremal.py
+++ b/toqito/channel_props/tests/test_is_extremal.py
@@ -5,6 +5,7 @@ import pytest
 
 from toqito.channel_ops.kraus_to_choi import kraus_to_choi
 from toqito.channel_props.is_extremal import is_extremal
+from toqito.perms import swap_operator
 
 
 # Consolidated test for all extremal cases.
@@ -89,3 +90,11 @@ def test_is_extremal_value_errors(phi, error_message):
     """Ensure ValueErrors are raised correctly for invalid inputs."""
     with pytest.raises(ValueError, match=error_message):
         is_extremal(phi)
+
+
+def test_is_extremal_non_cp_choi_raises():
+    """A non-completely-positive Choi matrix (e.g. the swap operator) raises a clear error."""
+    from toqito.perms import swap_operator
+
+    with pytest.raises(ValueError, match="completely positive"):
+        is_extremal(swap_operator(2))


### PR DESCRIPTION
Continues #1596 (the dimension/format items beyond the flat-Kraus fix in #1622).

## Changes
- `is_extremal`: crashed with `AttributeError` on a non-completely-positive Choi matrix, because `choi_to_kraus` returns operators in the paired `[[A, B], ...]` form for a non-CP/non-Hermitian Choi, which the `A.conj().T` step can't handle. Extremality is only defined for CP channels, so detect that case and raise a clear `ValueError`.
- `channel_fidelity`: inferred the subsystem dimension as `int(np.log2(choi_dim))`, which only coincides with the true `sqrt(choi_dim)` for `d <= 4` and is wrong for larger dimensions (e.g. `d=6` gives 5). Use `round(sqrt(choi_dim))` and validate the Choi dimension is a perfect square.

The `channel_fidelity` dimension value is unchanged for `d <= 4` (so existing tests pass), and the perfect-square guard runs before the SDP, so the new test exercises it without cvxpy.

## Remaining in #1596
`completely_bounded_trace_norm` rectangular-dimension handling (routing through `channel_dim`) is the remaining item; it is deeper in the SDP path and best done separately. I'll leave #1596 open for it.