### PR TITLE
fix: check solver status in cvxpy-based SDP helpers

### DIFF
--- a/toqito/cones/lieb_ando.py
+++ b/toqito/cones/lieb_ando.py
@@ -131,12 +131,18 @@ def lieb_ando(
                 mat_a_kron, mat_b_kron, T, t, fullhyp=False, hermitian=is_cplx
             )
             problem = cvxpy.Problem(cvxpy.Maximize(obj), cons)
-            return problem.solve()
+            result = problem.solve()
+            if problem.status not in (cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE):
+                raise ValueError(f"The SDP did not solve successfully (status: {problem.status}).")
+            return result
         elif (t >= -1 and t <= 0) or (t >= 1 and t <= 2):
             cons = geometric_mean_epi_cone(
                 mat_a_kron, mat_b_kron, T, t, hermitian=is_cplx
             )
             problem = cvxpy.Problem(cvxpy.Minimize(obj), cons)
-            return problem.solve()
+            result = problem.solve()
+            if problem.status not in (cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE):
+                raise ValueError(f"The SDP did not solve successfully (status: {problem.status}).")
+            return result
         else:
             raise ValueError("t must be between -1 and 2.")

--- a/toqito/cones/ln_quantum_entropy.py
+++ b/toqito/cones/ln_quantum_entropy.py
@@ -97,4 +97,7 @@ def ln_quantum_entropy(
     if is_cplx:
         obj = cvxpy.real(obj)
     prob = cvxpy.Problem(cvxpy.Maximize(obj), cons)
-    return prob.solve(solver=cvxpy.SCS, verbose=False)
+    result = prob.solve(solver=cvxpy.SCS, verbose=False)
+    if prob.status not in (cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE):
+        raise ValueError(f"The SDP did not solve successfully (status: {prob.status}).")
+    return result

--- a/toqito/cones/trace_matrix_log.py
+++ b/toqito/cones/trace_matrix_log.py
@@ -116,4 +116,7 @@ def trace_matrix_log(
     if is_cplx:
         obj = cvxpy.real(obj)
     prob = cvxpy.Problem(cvxpy.Maximize(obj), cons)
-    return prob.solve(solver=cvxpy.SCS, verbose=False)
+    result = prob.solve(solver=cvxpy.SCS, verbose=False)
+    if prob.status not in (cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE):
+        raise ValueError(f"The SDP did not solve successfully (status: {prob.status}).")
+    return result

--- a/toqito/cones/trace_matrix_power.py
+++ b/toqito/cones/trace_matrix_power.py
@@ -105,9 +105,15 @@ def trace_matrix_power(
                 cvxpy.Constant(np.eye(n)), mat_a, T, t, fullhyp=False, hermitian=is_cplx
             )
             problem = cvxpy.Problem(cvxpy.Maximize(obj), cons)
-            return problem.solve()
+            result = problem.solve()
+            if problem.status not in (cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE):
+                raise ValueError(f"The SDP did not solve successfully (status: {problem.status}).")
+            return result
         cons = geometric_mean_epi_cone(
             cvxpy.Constant(np.eye(n)), mat_a, T, t, hermitian=is_cplx
         )
         problem = cvxpy.Problem(cvxpy.Minimize(obj), cons)
-        return problem.solve()
+        result = problem.solve()
+        if problem.status not in (cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE):
+            raise ValueError(f"The SDP did not solve successfully (status: {problem.status}).")
+        return result

--- a/toqito/nonlocal_games/xor_game.py
+++ b/toqito/nonlocal_games/xor_game.py
@@ -240,6 +240,9 @@ class XORGame:
         problem = cvxpy.Problem(objective, constraints)
         problem.solve(verbose=False)
 
+        if problem.value is None:
+            raise ValueError(f"The XOR game SDP did not solve successfully (status: {problem.status}).")
+
         if self.reps == 1:
             return np.real(problem.value) / 4 + 1 / 2
         # It holds from (https://arxiv.org/abs/quant-ph/0608146) that the


### PR DESCRIPTION
Closes #1592 (completing the cvxpy paths; the matrix_props crash guards were #1612).

## Changes
- `xor_game.quantum_value`: used `np.real(problem.value)` without checking the solve. On a solver failure `problem.value` is `None` and `np.real(None)` raised a confusing `TypeError`; now raises a clear `ValueError` with the status.
- Cone helpers (`trace_matrix_log`, `ln_quantum_entropy`, `lieb_ando`, `trace_matrix_power`): returned `prob.solve()` directly, so an infeasible/failed solve leaked `inf`/`None` to the caller. Now raise on a non-optimal status.

## Note on the PICOS state_opt solvers
The review flagged the PICOS-based `state_opt` solvers (`state_distinguishability`, `state_exclusion`, `optimal_clone`, `symmetric_extension_hierarchy`, `state_exclusion_locc`) for the same issue, but that was a false premise: PICOS raises a `SolutionFailure` on an infeasible/failed solve rather than silently returning a bad value (verified locally), so there is no silent-failure bug to fix there.

## is_k_incoherent
The dead-code SDP fallback in `is_k_incoherent` (always returns False) is intentionally left as-is per discussion; its correct behavior on cone-boundary inputs is ambiguous and is tracked separately.

These paths use cvxpy, which cannot run in this local environment (a `KeyError` in cone_matrix_stuffing), so the changes are verified by CI.