### PR TITLE
fix: correct POVM usage in channel_measured_relative_entropy test

### DIFF
--- a/toqito/channel_metrics/tests/test_channel_measured_relative_entropy.py
+++ b/toqito/channel_metrics/tests/test_channel_measured_relative_entropy.py
@@ -6,7 +6,6 @@ import pytest
 from toqito.channel_metrics.channel_measured_relative_entropy import channel_measured_relative_entropy
 from toqito.channel_ops import partial_channel
 from toqito.channels import depolarizing, partial_trace
-from toqito.measurement_ops import measure
 from toqito.perms import swap_operator
 from toqito.rand import random_density_matrix, random_povm
 
@@ -83,10 +82,15 @@ def _monto_carlo_lower_bound(
                 num_outputs=povm_num_outputs,
                 seed=rng.integers(2**32 - 1),
             )
-            povm = list(povms[0])
+            # random_povm returns shape (d, d, num_inputs, num_outputs); the POVM elements are the (d, d) slices over
+            # the last axis (list(povms[0]) was extracting rows, not operators).
+            povm = [povms[:, :, 0, k] for k in range(povm_num_outputs)]
 
-            p = np.asarray(measure(rho_RB_1, povm), dtype=float)
-            q = np.asarray(measure(rho_RB_2, povm), dtype=float)
+            # Born-rule outcome probabilities for the POVM: p_i = Tr(M_i rho). (measure() treats a list as Kraus
+            # operators and would both compute Tr(M rho M^dagger) and require sum M^dagger M = I, neither of which is
+            # the POVM semantics needed here.)
+            p = np.array([np.real(np.trace(m @ rho_RB_1)) for m in povm], dtype=float)
+            q = np.array([np.real(np.trace(m @ rho_RB_2)) for m in povm], dtype=float)
 
             # Numerical cleanup
             p = np.maximum(p, 0.0)


### PR DESCRIPTION
## Problem
The `toqito-pytest` jobs are failing on master (`test_channel_measured_relative_entropy.py::test_sdp_lower_bound` and `::test_convergence`) with:

```
ValueError: Kraus operators do not satisfy completeness relation: ∑ Kᵢ†Kᵢ ≠ I.
```

The `_monto_carlo_lower_bound` helper passes a POVM (from `random_povm`) to `measure()`. A POVM satisfies `∑ M_i = I`, not the Kraus completeness `∑ M_i† M_i = I` that `measure()` validates after #1595, so it now raises. (This was force-merged earlier without a full CI run, so it only surfaced now.)

Two further problems in the helper, masked until now:
- `povm = list(povms[0])` extracts **rows** of the `(d, d, 1, k)` array, not the `(d, d)` POVM operators.
- `measure()` on a list computes `Tr(M ρ M†)` (Kraus update), not the POVM Born probability `Tr(M ρ)`.

It "passed" before only because the unvalidated row-vectors produced finite, meaningless numbers that happened to sit below the SDP value.

## Fix
Extract the POVM elements correctly (`povms[:, :, 0, k]`) and compute the Born-rule probabilities `p_i = Tr(M_i ρ)` directly; drop the now-unused `measure` import. `measure()` itself is unchanged, and the library function `channel_measured_relative_entropy` never used it.

The corrected `lb` is a genuine measured-relative-entropy lower bound, so the loose assertions (`sdp + tol >= lb`) hold. Verified locally that the extraction yields valid POVM elements (sum to I) and normalized probabilities; the SDP assertions run under CI (cvxpy is not runnable in my local environment).