### PR TITLE
perf: vectorize Gram-matrix and frame-operator construction

### DIFF
--- a/toqito/matrix_ops/vectors_to_gram_matrix.py
+++ b/toqito/matrix_ops/vectors_to_gram_matrix.py
@@ -73,10 +73,7 @@ def vectors_to_gram_matrix(vectors: list[np.ndarray]) -> np.ndarray:
         # Compute Gram matrix using vectorized operations
         return np.dot(stacked_vectors.conj().T, stacked_vectors)
     else:
-        # Mixed states: compute Tr(ρᵢ ρⱼ)
-        n = len(vectors)
-        gram = np.zeros((n, n), dtype=complex)
-        for i in range(n):
-            for j in range(n):
-                gram[i, j] = np.trace(vectors[i] @ vectors[j])
-        return gram
+        # Mixed states: compute G[i, j] = Tr(ρᵢ ρⱼ). Stacking the density matrices and contracting with einsum avoids
+        # the O(n^2) Python loop and the full ρᵢ ρⱼ products (only the trace is needed).
+        stacked = np.stack(vectors)
+        return np.einsum("ikl,jlk->ij", stacked, stacked)

--- a/toqito/matrix_props/is_tight_frame.py
+++ b/toqito/matrix_props/is_tight_frame.py
@@ -58,11 +58,9 @@ def is_tight_frame(vectors: list[np.ndarray], tol: float = 1e-8) -> bool:
     if any(v.shape[0] != dim for v in vectors):
         raise ValueError("All vectors must have the same dimension.")
 
-    # Compute the frame operator: S = sum_i v_i v_i^*
-    frame_op = np.zeros((dim, dim), dtype=complex)
-    for v in vectors:
-        v_col = v.reshape(-1, 1)
-        frame_op += v_col @ v_col.conj().T
+    # Compute the frame operator S = sum_i v_i v_i^* = V V^* where V stacks the vectors as columns.
+    v_mat = np.column_stack([v.reshape(-1) for v in vectors])
+    frame_op = v_mat @ v_mat.conj().T
 
     # A tight frame requires S = A * I for some scalar A > 0.
     # The frame bound A is trace(S) / d.


### PR DESCRIPTION
Closes #1632.

## Changes
- `vectors_to_gram_matrix` (mixed-state path): replaced the `O(n^2)` Python double loop computing `Tr(rho_i rho_j)` (which formed the full `rho_i @ rho_j` product only to trace it) with `np.einsum("ikl,jlk->ij", R, R)` over the stacked density matrices.
- `is_tight_frame`: replaced the Python loop building `sum_i v_i v_i^*` with `V @ V.conj().T` where `V` stacks the vectors as columns.

Both are mathematically identical to the previous loops (verified: the new Gram matrix matches the old element-by-element result on random mixed states; existing tests pass).