### PR TITLE
refactor: small output-preserving cleanups

### DIFF
--- a/toqito/channel_metrics/channel_measured_relative_entropy.py
+++ b/toqito/channel_metrics/channel_measured_relative_entropy.py
@@ -147,8 +147,7 @@ def channel_measured_relative_entropy(
 
 def _gauss_legendre_on_01(m: int) -> tuple[np.ndarray, np.ndarray]:
     """m-point Gauss legendre quadrature weights on the interval [0,1]."""
-    x = np.polynomial.legendre.leggauss(m)[0]
-    w = np.polynomial.legendre.leggauss(m)[1]
+    x, w = np.polynomial.legendre.leggauss(m)
     node = 0.5 * (x + 1)
     weight = 0.5 * w
     return node, weight

--- a/toqito/channels/dephasing.py
+++ b/toqito/channels/dephasing.py
@@ -100,6 +100,6 @@ def dephasing(dim: int, param_p: float = 0) -> np.ndarray:
     """
     # Compute the Choi matrix of the dephasing channel.
 
-    # Gives a sparse non-normalized state.
     psi = max_entangled(dim=dim, is_sparse=False, is_normalized=False)
-    return (1 - param_p) * np.diag(np.diag(psi @ psi.conj().T)) + param_p * (psi @ psi.conj().T)
+    psi_proj = psi @ psi.conj().T
+    return (1 - param_p) * np.diag(np.diag(psi_proj)) + param_p * psi_proj

--- a/toqito/channels/reduction.py
+++ b/toqito/channels/reduction.py
@@ -1,7 +1,6 @@
 """Generates the reduction channel."""
 
 import numpy as np
-from scipy.sparse import identity
 
 from toqito.states import max_entangled
 
@@ -40,5 +39,4 @@ def reduction(dim: int, k: int = 1) -> np.ndarray:
 
     """
     psi = max_entangled(dim, False, False)
-    identity_matrix = identity(dim**2)
-    return k * identity_matrix.toarray() - psi @ psi.conj().T
+    return k * np.eye(dim**2) - psi @ psi.conj().T

--- a/toqito/rand/random_povm.py
+++ b/toqito/rand/random_povm.py
@@ -88,8 +88,7 @@ def random_povm(dim: int, num_inputs: int, num_outputs: int, seed: int | None = 
         output_povms = []
         for output_block in input_block:
             partial = np.array(output_block, dtype=complex).dot(u_mat).dot(np.diag(d_mat ** (-1 / 2.0)))
-            internal = partial.dot(np.diag(np.ones(dim)) ** (1 / 2.0))
-            output_povms.append(internal.T.conj() @ internal)
+            output_povms.append(partial.T.conj() @ partial)
         povms.append(output_povms)
 
     # This allows us to index the POVMs as [dim, dim, num_inputs, num_outputs].


### PR DESCRIPTION
Addresses #1636 (the safe, output-preserving subset).

## Changes
- `dephasing`: compute `psi @ psi^dagger` once instead of twice.
- `reduction`: use `np.eye(dim**2)` instead of building a `scipy.sparse` identity and immediately `.toarray()`-ing it; drop the now-unused import.
- `random_povm`: remove a no-op multiply by `np.diag(np.ones(dim)) ** 0.5` (i.e. by the identity). The generated POVMs are unchanged (seeded regression tests still pass).
- `channel_measured_relative_entropy`: call `np.polynomial.legendre.leggauss(m)` once and unpack, rather than invoking it twice.

All four are behavior-preserving; existing tests pass.

## Deferred (noted in the issue)
`random_psd_operator`'s redundant QR (removing it changes the sampled output, so it needs regenerated seed expectations), the `diamond_distance` circular-import workaround (better fixed at the package `__init__` level), and the `measure()` `state_update=False` micro-optimization (avoiding re-touching a recently-fixed function) are left for follow-ups.