### PR TITLE
perf: skip the unused environment-dimension computation in channel metrics

### DIFF
--- a/toqito/channel_metrics/channel_distinguishability.py
+++ b/toqito/channel_metrics/channel_distinguishability.py
@@ -92,9 +92,10 @@ def channel_distinguishability(
         ```
 
     """
-    # Get the input, output and environment dimensions of phi and psi.
-    d_in_phi, d_out_phi, d_e = channel_dim(phi, dim=dim)
-    d_in_psi, d_out_psi, d_e = channel_dim(psi, dim=dim)
+    # Get the input and output dimensions of phi and psi. The environment dimension is not used here, so skip the
+    # extra matrix_rank computation it would require.
+    d_in_phi, d_out_phi, _ = channel_dim(phi, dim=dim, compute_env_dim=False)
+    d_in_psi, d_out_psi, _ = channel_dim(psi, dim=dim, compute_env_dim=False)
 
     # If the variable `phi` and/or `psi` are provided as a list, we assume this is a list
     # of Kraus operators. We convert to choi matrices if not provided as choi matrix.

--- a/toqito/channel_metrics/channel_exclusion.py
+++ b/toqito/channel_metrics/channel_exclusion.py
@@ -130,7 +130,8 @@ def channel_exclusion(
     choi_channels: list[np.ndarray] = []
     channel_dims = []
     for channel in channels:
-        dim_in, dim_out, _ = channel_dim(channel)
+        # The environment dimension is unused here, so skip its matrix_rank computation.
+        dim_in, dim_out, _ = channel_dim(channel, compute_env_dim=False)
         channel_dims.append(np.array([dim_in, dim_out]))
         choi_channels.append(kraus_to_choi(channel) if isinstance(channel, list) else channel)
 


### PR DESCRIPTION
Closes #1634.

## Changes
`channel_distinguishability` and `channel_exclusion` called `channel_dim(...)` with the default `compute_env_dim=True`, which runs a `matrix_rank` (SVD) on each Choi matrix to compute the environment dimension. That value is never used (in `channel_distinguishability`, `d_e` was assigned twice and discarded; in `channel_exclusion` it was `_`).

Pass `compute_env_dim=False` to skip the redundant SVD. Verified the returned input/output dimensions are unchanged, so the SDP setup is identical.