### PR TITLE
perf: build the Pauli-channel Choi with a single kraus_to_choi call

### DIFF
--- a/toqito/channels/pauli_channel.py
+++ b/toqito/channels/pauli_channel.py
@@ -4,7 +4,6 @@ import itertools
 import warnings
 
 import numpy as np
-from scipy import sparse
 
 from toqito.channel_ops.kraus_to_choi import kraus_to_choi
 from toqito.matrices.pauli import pauli
@@ -12,7 +11,7 @@ from toqito.matrices.pauli import pauli
 
 def pauli_channel(
     prob: int | np.ndarray, return_kraus_ops: bool = False, input_mat: np.ndarray | None = None
-) -> np.ndarray | sparse.csc_matrix | tuple:
+) -> np.ndarray | tuple:
     r"""Return the Choi matrix of a Pauli channel.
 
     The Pauli channel is defined by a set of Pauli operators weighted by a probability vector.
@@ -46,7 +45,7 @@ def pauli_channel(
             `apply_channel(input_mat, pauli_channel(...))` instead.
 
     Returns:
-        The Choi matrix of the Pauli channel as a sparse matrix. When the deprecated
+        The Choi matrix of the Pauli channel. When the deprecated
         ``input_mat`` / ``return_kraus_ops`` arguments are used, a tuple including the output
         matrix and/or Kraus operators is returned for backward compatibility.
 
@@ -90,14 +89,12 @@ def pauli_channel(
     if len(prob) != 4**q:
         raise ValueError("The length of the probability vector must be 4^q for some integer q (number of qubits).")
 
-    Phi = sparse.csc_matrix((4**q, 4**q), dtype=complex)
-
-    kraus_operators = []
-
-    for j, ind in enumerate(itertools.product(range(4), repeat=q)):
-        pauli_op = pauli(list(ind))
-        kraus_operators.append(np.sqrt(prob[j]) * pauli_op)
-        Phi += prob[j] * kraus_to_choi([[pauli_op, pauli_op.conj().T]])
+    # The channel's Kraus operators are sqrt(prob_j) * P_j, so its Choi matrix is the Choi of this flat (completely
+    # positive) Kraus list. Building it with a single kraus_to_choi call avoids one conversion per Pauli (4^q calls).
+    kraus_operators = [
+        np.sqrt(prob[j]) * pauli(list(ind)) for j, ind in enumerate(itertools.product(range(4), repeat=q))
+    ]
+    Phi = kraus_to_choi(kraus_operators)
 
     if input_mat is not None:
         warnings.warn(


### PR DESCRIPTION
Closes #1630.

## Problem
`pauli_channel` built the Choi matrix by calling `kraus_to_choi([[P_j, P_j^dagger]])` once per Pauli operator inside a loop over all `4^q` operators, each call paying the full Kraus->Choi conversion cost.

## Changes
The channel's Kraus operators are `sqrt(prob_j) * P_j`, so its Choi matrix is the Choi of that flat completely-positive Kraus list. Build it with a single `kraus_to_choi(kraus_operators)` call instead of `4^q` calls.

Also removed the `scipy.sparse` accumulator (the result was already densified by the in-loop additions), so the return is a dense ndarray (matching the previous effective return type); the docstring/annotation are updated accordingly.

Output is unchanged: verified the new Choi equals the previous per-operator weighted sum to ~1e-16, and the existing `pauli_channel` tests pass.