### PR TITLE
perf: direct Choi construction in kraus_to_choi for default sys

### DIFF
--- a/toqito/channel_ops/kraus_to_choi.py
+++ b/toqito/channel_ops/kraus_to_choi.py
@@ -58,6 +58,22 @@ def kraus_to_choi(kraus_ops: list[np.ndarray] | list[list[np.ndarray]], sys: int
     if sys < 0:
         raise ValueError("The `sys` parameter must be non-negative.")
 
+    if sys == 2:
+        # Fast path for the default convention (apply the channel to the second subsystem of the unnormalized
+        # maximally entangled state). The Choi matrix is then sum_i vec(A_i) vec(B_i)^dagger, where vec stacks the
+        # columns of an operator. This avoids building the entangled state and the dense Kronecker products that the
+        # general partial_channel path uses. For a flat completely-positive list [K_1, ...], B_i = A_i.
+        if isinstance(kraus_ops[0], np.ndarray):
+            left = right = np.stack([np.asarray(k, dtype=complex) for k in kraus_ops])
+        else:
+            left = np.stack([np.asarray(pair[0], dtype=complex) for pair in kraus_ops])
+            right = np.stack([np.asarray(pair[1], dtype=complex) for pair in kraus_ops])
+        # Column-major vectorization of each operator: transpose to (r, d_in, d_out) then flatten the last two axes.
+        v_left = left.transpose(0, 2, 1).reshape(left.shape[0], -1)
+        v_right = right.transpose(0, 2, 1).reshape(right.shape[0], -1)
+        return v_left.T @ v_right.conj()
+
+    # General fallback for other `sys` values.
     dim_in, _, _ = channel_dim(kraus_ops)
     dim_op_1, dim_op_2 = dim_in
 


### PR DESCRIPTION
Closes #1629

For the default convention (`sys=2`) the Choi matrix of a list of Kraus operators is

  J = sum_i vec(A_i) vec(B_i)^dagger

where vec stacks the columns of an operator (and B_i = A_i for a flat completely-positive list). This computes it directly by stacking the operators and doing a single matmul, rather than constructing the maximally entangled state and routing through `partial_channel`, which materializes dense Kronecker products.

Behavior:
- Output matches the previous implementation to machine precision. Checked across flat CP (square and rectangular), paired non-CP (transpose map), and rectangular paired operator lists; max abs diff 0 to ~1e-16.
- Non-default `sys` still uses the existing `partial_channel` path, and the `sys < 0` ValueError is unchanged.

Timings (old vs new, mean over repeated calls):

```
r= 4 d= 4: old    0.243 ms  new   0.009 ms  speedup   27.8x
r= 8 d= 8: old   26.714 ms  new   0.033 ms  speedup  819.1x
r= 4 d=16: old   82.810 ms  new   0.960 ms  speedup   86.3x
r= 2 d=32: old  541.003 ms  new   3.961 ms  speedup  136.6x
```

The old path scales poorly because it builds an entangled state of dimension d^2 and dense d^2 x d^2 Kronecker products.