### PR TITLE
docs: render math/code in docstrings and clean up references and citations

### DIFF
--- a/docs/content/refs.bib
+++ b/docs/content/refs.bib
@@ -157,6 +157,11 @@
   url = {https://link.aps.org/doi/10.1103/PhysRevA.61.030301},
 }
 % Keys beginning with C
+@misc{cvxquadlink,
+  author = {Fawzi, Hamza and Saunderson, James},
+  title = {{CVXQUAD}: a toolbox for quantum information theory in {CVX}},
+  url = {https://github.com/hfawzi/cvxquad},
+}
 @article{cabello2002nparticle,
   title = {$N$-Particle $N$-Level Singlet States: Some Properties and
            Applications},
@@ -918,11 +923,11 @@
 }
 
 @misc{johnston2025complexity,
-  title = {The complexity of quantum state classification},
+  title = {The complexity of perfect quantum state classification},
   author = {Johnston, Nathaniel and Lovitz, Benjamin and Russo, Vincent and
             Sikora, Jamie},
   year = {2025},
-  eprint = {X},
+  eprint = {2510.20789},
   archivePrefix = {arXiv},
   primaryClass = {quant-ph},
 }

--- a/docs/content/refs.bib
+++ b/docs/content/refs.bib
@@ -69,8 +69,8 @@
 }
 
 @article{bennett1992communication,
-  title = {Communication via one- and two-particle operators on {E}instein-{P}
-           odolsky-{R}osen states},
+  title = {Communication via one- and two-particle operators on
+           Einstein-Podolsky-Rosen states},
   author = {Bennett, Charles H. and Wiesner, Stephen J.},
   journal = {Phys. Rev. Lett.},
   volume = {69},
@@ -123,7 +123,7 @@
   journal = {Linear algebra and its applications},
   pages = {239--248},
   publisher = {Elsevier},
-  title = {On factor width and symmetric {H}-matrices},
+  title = {On factor width and symmetric H-matrices},
   volume = {405},
   year = {2005},
 }
@@ -1405,7 +1405,7 @@
 
 @article{trefethen2008gauss,
   author = {Trefethen, L. N.},
-  title = {Is {G}auss quadrature better than {C}lenshaw-{C}urtis?},
+  title = {Is Gauss quadrature better than Clenshaw-Curtis?},
   journal = {SIAM Review},
   volume = {50},
   number = {1},
@@ -1634,13 +1634,13 @@
 
 @misc{wikipediagellmann,
   author = "Wikipedia",
-  title = "Gell-{M}ann matrices",
+  title = "Gell-Mann matrices",
   url = {https://en.wikipedia.org/wiki/Gell-Mann_matrices},
 }
 
 @misc{wikipediageneralizedpauli,
   author = "Wikipedia",
-  title = "Generalizations of {P}auli matrices",
+  title = "Generalizations of Pauli matrices",
   url = {https://en.wikipedia.org/wiki/Generalizations_of_Pauli_matrices},
 }
 

--- a/toqito/channel_ops/apply_channel.py
+++ b/toqito/channel_ops/apply_channel.py
@@ -31,7 +31,7 @@ def apply_channel(mat: np.ndarray, phi_op: np.ndarray | list[list[np.ndarray]]) 
     We assume the quantum channel given as `phi_op` is provided as either the Choi matrix
     of the channel or a set of Kraus operators that define the quantum channel.
 
-    This function is adapted from the QETLAB package.
+    This function is adapted from the QETLAB package [@qetlablink].
 
     Args:
         mat: A matrix.

--- a/toqito/channel_ops/kraus_to_choi.py
+++ b/toqito/channel_ops/kraus_to_choi.py
@@ -19,7 +19,7 @@ def kraus_to_choi(kraus_ops: list[np.ndarray] | list[list[np.ndarray]], sys: int
     In case the map is CP (completely positive), it suffices to input a flat list of operators omitting
     their conjugate transpose (i.e. [\(K_1\),..., \(K_n\)]).
 
-    This function was adapted from the QETLAB package.
+    This function was adapted from the QETLAB package [@qetlablink].
 
     Args:
         kraus_ops: A list of Kraus operators.

--- a/toqito/channel_ops/partial_channel.py
+++ b/toqito/channel_ops/partial_channel.py
@@ -28,7 +28,7 @@ def partial_channel(
 
     The input `phi_map` should be provided as a Choi matrix.
 
-    This function is adapted from the QETLAB package.
+    This function is adapted from the QETLAB package [@qetlablink].
 
     Args:
         rho: A matrix.

--- a/toqito/cones/__init__.py
+++ b/toqito/cones/__init__.py
@@ -2,7 +2,7 @@
 
 This package collects operator-monotone matrix functions and the associated
 SDP cones (matrix geometric mean, operator relative entropy, matrix logarithm)
-ported from CVXQUAD (Fawzi--Saunderson). They live here rather than in
+ported from CVXQUAD (Fawzi--Saunderson) [@cvxquadlink]. They live here rather than in
 ``matrix_ops`` because they depend on ``matrix_props`` for input validation;
 keeping ``matrix_ops`` free of that back-edge avoids a load-time import cycle
 with ``state_props`` and ``channels``.

--- a/toqito/cones/geometric_mean.py
+++ b/toqito/cones/geometric_mean.py
@@ -33,7 +33,7 @@ def geometric_mean(mat_a: np.ndarray, mat_b: np.ndarray, t: float) -> np.ndarray
     Raises:
       ValueError: If the matrices are not the same size, not 2D, or not square.
       ValueError: If the matrices are not positive definite.
-      ValueError: If the weight is not in the range [-1, 2].
+      ValueError: If the weight is not in the range `[-1, 2]`.
 
     Returns:
       A matrix with the same shape as the inputs.

--- a/toqito/cones/geometric_mean_epi_cone.py
+++ b/toqito/cones/geometric_mean_epi_cone.py
@@ -32,11 +32,11 @@ def geometric_mean_epi_cone(
         A: A cvxpy expression representing a matrix.
         B: A cvxpy expression representing a matrix.
         T: A cvxpy expression representing a matrix.
-        t: The weight in the range [-1, 0] or [1, 2].
+        t: The weight in the range `[-1, 0]` or `[1, 2]`.
         hermitian: Whether the matrices are Hermitian or symmetric.
 
     Raises:
-        ValueError: If the weight is not in the range [-1, 0] or [1, 2].
+        ValueError: If the weight is not in the range `[-1, 0]` or `[1, 2]`.
         ValueError: If the matrices are not the same size.
         ValueError: If the matrices are not 2D or not square.
 

--- a/toqito/cones/geometric_mean_hypo_cone.py
+++ b/toqito/cones/geometric_mean_hypo_cone.py
@@ -52,7 +52,7 @@ def _geometric_mean_cone_recursion(
         A: A cvxpy expression representing a matrix.
         B: A cvxpy expression representing a matrix.
         T: A cvxpy expression representing a matrix.
-        t: The weight in the range [0, 1].
+        t: The weight in the range `[0, 1]`.
         hermitian: Whether the matrices are Hermitian or symmetric.
 
     Returns:
@@ -123,12 +123,12 @@ def geometric_mean_hypo_cone(
         A: A cvxpy expression representing a matrix.
         B: A cvxpy expression representing a matrix.
         T: A cvxpy expression representing a matrix.
-        t: The weight in the range [0, 1].
+        t: The weight in the range `[0, 1]`.
         fullhyp: Whether to use the full hypograph or the restricted hypograph.
         hermitian: Whether the matrices are Hermitian or symmetric.
 
     Raises:
-        ValueError: If the weight is not in the range [0, 1].
+        ValueError: If the weight is not in the range `[0, 1]`.
         ValueError: If the matrices are not the same size.
         ValueError: If the matrices are not 2D or not square.
 

--- a/toqito/matrix_props/majorizes.py
+++ b/toqito/matrix_props/majorizes.py
@@ -15,7 +15,7 @@ def majorizes(a_var: np.ndarray | list[int], b_var: np.ndarray | list[int]) -> b
 
     for all \(k \in \{1, \ldots, d\}\).
 
-    This function was adapted from the QETLAB package.
+    This function was adapted from the QETLAB package [@qetlablink].
 
     Args:
         a_var: Matrix or vector provided as list or np.array.

--- a/toqito/matrix_props/sk_norm.py
+++ b/toqito/matrix_props/sk_norm.py
@@ -44,7 +44,7 @@ def sk_operator_norm(
     want to devote to computing the bounds by `effort` input argument. Note that if the input matrix is not positive
     semidefinite the output bounds might be quite poor.
 
-    This function was adapted from QETLAB.
+    This function was adapted from QETLAB [@qetlablink].
 
     Args:
         mat: A matrix.

--- a/toqito/nonlocal_games/nonlocal_game.py
+++ b/toqito/nonlocal_games/nonlocal_game.py
@@ -492,7 +492,7 @@ class NonlocalGame:
         """Compute the non-signaling value of the nonlocal game.
 
         Returns:
-            A value between [0, 1] representing the non-signaling value.
+            A value between `[0, 1]` representing the non-signaling value.
 
         """
         alice_out, bob_out, alice_in, bob_in = self.pred_mat.shape

--- a/toqito/nonlocal_games/xor_game.py
+++ b/toqito/nonlocal_games/xor_game.py
@@ -16,7 +16,7 @@ class XORGame:
     The quantum value of an XOR game can be solved via the semidefinite program
     from [@cleve2010consequences].
 
-    This function is adapted from the QETLAB package.
+    This function is adapted from the QETLAB package [@qetlablink].
 
     A tutorial is available in the documentation. Go to
     [Calculating the quantum and classical value of a two-player XOR game]
@@ -213,7 +213,7 @@ class XORGame:
         In other words, \(\pi(x, y)\) corresponds to `prob_mat[x, y]`, and \(f(x,y)\) corresponds to `pred_mat[x, y]`.
 
         Returns:
-            A value between [0, 1] representing the quantum value.
+            A value between `[0, 1]` representing the quantum value.
 
         """
         alice_in, bob_in = self.prob_mat.shape
@@ -253,7 +253,7 @@ class XORGame:
         r"""Compute the classical value of the XOR game.
 
         Returns:
-            A value between [0, 1] representing the classical value.
+            A value between `[0, 1]` representing the classical value.
 
         """
         return self.to_nonlocal_game().classical_value()
@@ -264,7 +264,7 @@ class XORGame:
         Here, the existing function in the `NonlocalGame` class is called.
 
         Returns:
-            A value between [0, 1] representing the nonsignaling value.
+            A value between `[0, 1]` representing the nonsignaling value.
 
         """
         return self.to_nonlocal_game().nonsignaling_value()

--- a/toqito/perms/symmetric_projection.py
+++ b/toqito/perms/symmetric_projection.py
@@ -26,7 +26,7 @@ def symmetric_projection(dim: int, p_val: int = 2, partial: bool = False) -> np.
     whose columns form an orthonormal basis for the symmetric subspace (and hence the PS * PS' is the orthogonal
     projection onto the symmetric subspace).
 
-    This function was adapted from the QETLAB package.
+    This function was adapted from the QETLAB package [@qetlablink].
 
     Args:
         dim: The dimension of the local systems.

--- a/toqito/state_opt/bell_notation_conversions.py
+++ b/toqito/state_opt/bell_notation_conversions.py
@@ -40,7 +40,7 @@ def cg_to_fc(cg_mat: np.ndarray, behavior: bool = False) -> np.ndarray:
         The matrix in Full Correlator notation.
 
     !!! Note
-        This function is adapted from the QETLAB MATLAB package function ``CG2FC``.
+        This function is adapted from the QETLAB MATLAB package function ``CG2FC`` [@qetlablink].
 
     Examples:
         Consider the CHSH inequality in CG notation for a functional:
@@ -145,7 +145,7 @@ def fc_to_cg(fc_mat: np.ndarray, behavior: bool = False) -> np.ndarray:
         The matrix in Collins-Gisin notation.
 
     !!! Note
-        This function is adapted from the QETLAB MATLAB package function ``FC2CG``.
+        This function is adapted from the QETLAB MATLAB package function ``FC2CG`` [@qetlablink].
 
     Examples:
         Consider the CHSH inequality in FC notation for a functional:
@@ -234,7 +234,7 @@ def cg_to_fp(cg_mat: np.ndarray, desc: list[int], behavior: bool = False) -> np.
         The probability tensor \(V[a, b, x, y]\) in Full Probability notation.
 
     !!! Note
-        This function is adapted from the QETLAB MATLAB package function ``CG2FP``.
+        This function is adapted from the QETLAB MATLAB package function ``CG2FP`` [@qetlablink].
 
     Examples:
         Consider the CHSH inequality functional in CG notation:
@@ -501,7 +501,7 @@ def fp_to_cg(v_mat: np.ndarray, behavior: bool = False) -> np.ndarray:
         The matrix in Collins-Gisin notation.
 
     !!! Note
-        This function is adapted from the QETLAB MATLAB package function ``FP2CG``.
+        This function is adapted from the QETLAB MATLAB package function ``FP2CG`` [@qetlablink].
         For ``behavior=True``, it uses the QETLAB convention for calculating marginal probabilities,
         summing over the other party's outcomes for a *fixed* input setting of the other party
         (\(y=0\) for Alice's marginal \(p_A(a|x)\), \(x=0\) for Bob's marginal \(p_B(b|y)\)).
@@ -649,7 +649,7 @@ def fp_to_fc(v_mat: np.ndarray, behavior: bool = False) -> np.ndarray:
         The matrix in Full Correlator notation.
 
     !!! Note
-        This function is adapted from the QETLAB MATLAB package function ``FP2FC``.
+        This function is adapted from the QETLAB MATLAB package function ``FP2FC`` [@qetlablink].
         For ``behavior=True``, it calculates the *average* marginal correlators \(\langle A_x \rangle\)
         and \(\langle B_y \rangle\) by summing over the other party's inputs
         and dividing by the number of inputs (\(ib\) or \(ia\)).

--- a/toqito/state_props/entanglement_of_formation.py
+++ b/toqito/state_props/entanglement_of_formation.py
@@ -15,7 +15,7 @@ def entanglement_of_formation(rho: np.ndarray, dim: list[int] | int | None = Non
     `rho` being a pure state or a 2-qubit state: it is not known how to
     compute the entanglement-of-formation of higher-dimensional mixed states.
 
-    This function was adapted from QETLAB.
+    This function was adapted from QETLAB [@qetlablink].
 
     Args:
         rho: A matrix or vector.

--- a/toqito/state_props/has_symmetric_extension.py
+++ b/toqito/state_props/has_symmetric_extension.py
@@ -25,7 +25,7 @@ def has_symmetric_extension(
     Determining whether an operator possesses a symmetric extension at some level `level`
     can be used as a check to determine if the operator is entangled or not.
 
-    This function was adapted from QETLAB.
+    This function was adapted from QETLAB [@qetlablink].
 
     Args:
         rho: A matrix or vector.

--- a/toqito/state_props/in_separable_ball.py
+++ b/toqito/state_props/in_separable_ball.py
@@ -12,7 +12,7 @@ def in_separable_ball(mat: np.ndarray) -> bool | np.bool_:
 
     This function can be used as a method for separability testing of states in certain scenarios.
 
-    This function is adapted from QETLAB.
+    This function is adapted from QETLAB [@qetlablink].
 
     Args:
         mat: A positive semidefinite matrix or a vector of the eigenvalues of a positive semidefinite matrix.

--- a/toqito/state_props/l1_norm_coherence.py
+++ b/toqito/state_props/l1_norm_coherence.py
@@ -22,7 +22,7 @@ def l1_norm_coherence(rho: np.ndarray) -> float:
     the sum of the absolute values of the off-diagonal entries of the density
     matrix `rho` in the standard basis.
 
-    This function was adapted from QETLAB.
+    This function was adapted from QETLAB [@qetlablink].
 
     Args:
         rho: A matrix or vector.

--- a/toqito/state_props/sk_vec_norm.py
+++ b/toqito/state_props/sk_vec_norm.py
@@ -20,7 +20,7 @@ def sk_vector_norm(rho: np.ndarray, k: int = 1, dim: int | list[int] | None = No
     It's also equal to the Euclidean norm of the vector of \(|v\rangle\)'s
     k largest Schmidt coefficients.
 
-    This function was adapted from QETLAB.
+    This function was adapted from QETLAB [@qetlablink].
 
     Args:
         rho: A vector.

--- a/toqito/states/basis.py
+++ b/toqito/states/basis.py
@@ -17,7 +17,7 @@ def basis(dim: int, pos: int) -> np.ndarray:
         The column vector of dimension `dim` with all entries set to `0` except the entry at `pos` which is set to `1`.
 
     Raises:
-        ValueError: If the input position is not in the range [0, dim - 1].
+        ValueError: If the input position is not in the range `[0, dim - 1]`.
 
     Examples:
         The standard basis ket vectors given as \(|0 \rangle\) and \(|1 \rangle\) where

--- a/toqito/states/basis.py
+++ b/toqito/states/basis.py
@@ -1,6 +1,6 @@
-"""A basis state represents the standard basis vectors of some n-dimensional Hilbert Space.
+r"""A basis state represents the standard basis vectors of some \(n\)-dimensional Hilbert space.
 
-Here, n can be given as a parameter as shown below.
+Here, \(n\) can be given as a parameter as shown below.
 """
 
 import numpy as np

--- a/toqito/states/bell.py
+++ b/toqito/states/bell.py
@@ -25,7 +25,7 @@ def bell(idx: int) -> np.ndarray:
     \]
 
     Args:
-        idx: A parameter in [0, 1, 2, 3]
+        idx: A parameter in `[0, 1, 2, 3]`.
 
     Returns:
         Bell state with index `idx`.

--- a/toqito/states/brauer.py
+++ b/toqito/states/brauer.py
@@ -26,7 +26,7 @@ def brauer(dim: int, p_val: int) -> np.ndarray:
 
     which is the number of columns of the returned matrix.
 
-    This function has been adapted from QETLAB.
+    This function has been adapted from QETLAB [@qetlablink].
 
     Args:
         dim: Dimension of each local subsystem

--- a/toqito/states/breuer.py
+++ b/toqito/states/breuer.py
@@ -16,7 +16,7 @@ def breuer(dim: int, lam: float) -> np.ndarray:
     `lam` parameter describing the weight of the singlet component as described in
     [@breuer2006optimal].
 
-    This function was adapted from the QETLAB package.
+    This function was adapted from the QETLAB package [@qetlablink].
 
     Args:
         dim: Dimension of the Breuer state.

--- a/toqito/states/domino.py
+++ b/toqito/states/domino.py
@@ -31,7 +31,7 @@ def domino(idx: int) -> np.ndarray:
     Returns one of the following nine domino states depending on the value of `idx`.
 
     Args:
-        idx: A parameter in [0, 1, 2, 3, 4, 5, 6, 7, 8]
+        idx: A parameter in `[0, 1, 2, 3, 4, 5, 6, 7, 8]`.
 
     Returns:
         Domino state of index `idx`.

--- a/toqito/states/gisin.py
+++ b/toqito/states/gisin.py
@@ -30,7 +30,7 @@ def gisin(lambda_var: float, theta: float) -> np.ndarray:
     \]
 
     Args:
-        lambda_var: A real parameter in [0, 1].
+        lambda_var: A real parameter in `[0, 1]`.
         theta: A real parameter.
 
     Returns:

--- a/toqito/states/tile.py
+++ b/toqito/states/tile.py
@@ -34,7 +34,7 @@ def tile(idx: int) -> np.ndarray:
     \]
 
     Args:
-        idx: A parameter in [0, 1, 2, 3, 4]
+        idx: A parameter in `[0, 1, 2, 3, 4]`.
 
     Returns:
         Tile state.


### PR DESCRIPTION
Documentation rendering and reference fixes found while reading through the published docs.

Docstrings
- basis: render n as inline math and lowercase "Hilbert space"; make the module docstring raw.
- Code-format plain bracket ranges/sets that were rendering as prose, in Args/Returns/Raises: basis, bell, tile, domino, gisin, xor_game, nonlocal_game, and the geometric-mean cones.
- Add the missing [@qetlablink] citation to the QETLAB adaptation notes across channel_ops, matrix_props, state_props, state_opt, perms, and nonlocal_games.
- Add a CVXQUAD reference (cvxquadlink) and cite it where the cones package docstring attributes the port.

References (docs/content/refs.bib)
- Fix the Einstein-Podolsky-Rosen title: it was wrapped mid-word so BibTeX inserted a space, and the single-letter {X} capitalization braces were rendering verbatim.
- Remove the same verbatim-rendering braces from four more titles (factor width / H-matrices, Gauss / Clenshaw-Curtis, Gell-Mann, Pauli).
- Set the real arXiv id (2510.20789) and corrected title for johnston2025complexity, replacing the eprint = {X} placeholder.