### PR TITLE
refactor: order npa_hierarchy public-first and de-duplicate the identity symbol

### DIFF
--- a/toqito/state_opt/npa_hierarchy.py
+++ b/toqito/state_opt/npa_hierarchy.py
@@ -7,228 +7,8 @@ import cvxpy
 import numpy as np
 
 Symbol = namedtuple("Symbol", ["player", "question", "answer"], defaults=["", None, None])
-IDENTITY_SYMBOL = Symbol("", None, None)  # Explicit identity symbol
+IDENTITY_SYMBOL = Symbol()  # Identity symbol: the namedtuple defaults ("", None, None).
 PLAYERS = ("Alice", "Bob")
-
-
-def _reduce(word: tuple[Symbol, ...]) -> tuple[Symbol, ...]:
-    """Reduce an operator word to its canonical form using NPA rules.
-
-    Identity: I*S = S*I = S, I*I = I
-    Commutation: Alice operators commute with Bob operators. Canonical form: A...AB...B
-    Orthogonality: P_x,a P_x,b = 0 if a != b (for same player x)
-    Idempotence: P_x,a P_x,a = P_x,a (for same player x)
-
-    """
-    if not word:
-        return ()
-
-    # Initial pass to filter out identities IF other ops are present
-    current_list = [s for s in word if s != IDENTITY_SYMBOL]
-    if not current_list:  # Original word was all identities or empty
-        return (IDENTITY_SYMBOL,) if any(s == IDENTITY_SYMBOL for s in word) else ()
-
-    # Canonical player order (Alice then Bob), preserving original relative internal order
-    alice_ops = [s for s in current_list if s.player == "Alice"]
-    bob_ops = [s for s in current_list if s.player == "Bob"]
-    current_list = alice_ops + bob_ops  # This is now a list of Symbol objects
-
-    # Iteratively apply reduction rules until no more changes occur
-    while True:
-        len_before_pass = len(current_list)
-        next_pass_list = []
-        idx = 0
-        made_change_in_pass = False
-
-        while idx < len(current_list):
-            s_x = current_list[idx]
-
-            if idx + 1 < len(current_list):
-                s_y = current_list[idx + 1]
-                # Only apply if s_x and s_y are from the same player.
-                if s_x == s_y and s_x.player in PLAYERS:  # s_x != IDENTITY_SYMBOL
-                    next_pass_list.append(s_x)
-                    idx += 2  # Consumed s_x, s_y; added s_x
-                    made_change_in_pass = True
-                    continue
-                # Rule 2: Orthogonality (S_x,a S_x,b = 0 if a!=b, for same player and question)
-                elif (
-                    s_x.player == s_y.player
-                    and s_x.player in PLAYERS  # Ensure not identity
-                    and s_x.question == s_y.question
-                    and s_x.answer != s_y.answer
-                ):
-                    return ()  # Entire word becomes zero
-                else:
-                    # No reduction for this pair, keep s_x
-                    next_pass_list.append(s_x)
-                    idx += 1
-            else:
-                # Last element, just append it
-                next_pass_list.append(s_x)
-                idx += 1
-
-        current_list = next_pass_list
-        if not made_change_in_pass and len(current_list) == len_before_pass:  # Stable
-            break
-
-    return tuple(current_list) if current_list else ()
-
-
-def _parse(k_str: str) -> tuple[int, set[tuple[int, int]]]:
-    if not k_str:  # Explicitly handle empty string input for k_str
-        raise ValueError("Input string k_str cannot be empty.")
-    parts = k_str.split("+")
-    if not parts[0] or parts[0] == "":  # Check if the first part (base_k) is empty
-        raise ValueError("Base level k must be specified, e.g., '1+ab'")
-    try:
-        base_k = int(parts[0])
-    except ValueError as e:
-        raise ValueError(f"Base level k '{parts[0]}' is not a valid integer: {e}") from e
-
-    conf = set()
-    if len(parts) == 1 and base_k >= 0:  # e.g. "0", "1"
-        pass  # conf remains empty, which is correct.
-
-    for val_content in parts[1:]:  # Process each part after the base_k
-        cnt_a, cnt_b = 0, 0
-        if not val_content:  # Handles "1++ab" -> parts like '', skip these
-            continue
-        # If val_content is an empty string (e.g., from "0+", "1++a"),
-        # cnt_a and cnt_b will remain 0, and (0,0) will be added to conf.
-        for char_val in val_content:  # Loop over empty string does nothing
-            if char_val == "a":
-                cnt_a += 1
-            elif char_val == "b":
-                cnt_b += 1
-            else:
-                raise ValueError(
-                    f"Invalid character '{char_val}' in k string component "
-                    + f"'{val_content}'. Only 'a' or 'b' allowed after base k."
-                )
-        conf.add((cnt_a, cnt_b))
-    return base_k, conf
-
-
-def _gen_words(k: int | str, a_out: int, a_in: int, b_out: int, b_in: int) -> list[tuple[Symbol, ...]]:
-    # Symbols for non-identity measurements (last outcome is dependent)
-    alice_symbols = [Symbol("Alice", x, a) for x in range(a_in) for a in range(a_out - 1)]
-    bob_symbols = [Symbol("Bob", y, b) for y in range(b_in) for b in range(b_out - 1)]
-
-    words = set([(IDENTITY_SYMBOL,)])  # Start with identity operator
-
-    k_int = k
-    configurations = set()
-
-    if isinstance(k, str):
-        k_int, configurations = _parse(k)
-
-    # Loop 1: Generate words up to length k_int from the hierarchy
-    for length in range(0, k_int + 1):  # Lengths 1, ..., k_int
-        for alice_len in range(length + 1):
-            bob_len = length - alice_len
-
-            # Generate Alice's part
-            # If alice_len is 0, product yields one item: ()
-            for word_a_tuple in product(alice_symbols, repeat=alice_len):
-                reduced_a = _reduce(word_a_tuple)
-                # Alice's part (non-empty originally) reduced to zero
-                if reduced_a == () and alice_len > 0:
-                    continue
-
-                # Generate Bob's part
-                # If bob_len is 0, product yields one item: ()
-                for word_b_tuple in product(bob_symbols, repeat=bob_len):
-                    reduced_b = _reduce(word_b_tuple)
-                    # Bob's part (non-empty originally) reduced to zero
-                    if reduced_b == () and bob_len > 0:
-                        continue
-
-                    if not reduced_a and not reduced_b:  # Both parts are empty (e.g. alice_len=0, bob_len=0)
-                        # This means the total length of operators is 0.
-                        final_word = (IDENTITY_SYMBOL,)
-                    else:
-                        # _reduce will put Alice operators before Bob operators if somehow mixed,
-                        # and apply rules. It also handles identity filtering if I was part of word.
-                        # Here, reduced_a + reduced_b is already A...AB...B (or just A...A or B...B).
-                        final_word = _reduce(reduced_a + reduced_b)
-                    words.add(final_word)
-
-    # Loop 2: Add words from specific configurations (e.g., "1+ab" means k_int=1, configurations={(1,1)})
-    for alice_len_conf, bob_len_conf in configurations:
-        if alice_len_conf == 0 and bob_len_conf == 0 and k_int == 0 and (IDENTITY_SYMBOL,) in words:
-            pass  # The set `words` will handle duplicates from k_int loop vs config loop.
-
-        for word_a_tuple in product(alice_symbols, repeat=alice_len_conf):
-            reduced_a = _reduce(word_a_tuple)
-            if reduced_a == () and alice_len_conf > 0:
-                continue
-
-            for word_b_tuple in product(bob_symbols, repeat=bob_len_conf):
-                reduced_b = _reduce(word_b_tuple)
-                if reduced_b == () and bob_len_conf > 0:
-                    continue
-
-                # Combine and add as in the main loop
-                # Both parts are empty (e.g. alice_len_conf=0, bob_len_conf=0)
-                if not reduced_a and not reduced_b:
-                    # Should not happen if _parse filters (0,0) from conf
-                    final_word = (IDENTITY_SYMBOL,)
-
-                else:
-                    final_word = _reduce(reduced_a + reduced_b)
-
-                words.add(final_word)
-
-    # If `words` contains `()`, filter it out before converting to list.
-    words = {w for w in words if w != ()}
-    # Convert set to list, then sort.
-    # Make sure (IDENTITY_SYMBOL,) is always at index 0.
-    list_of_words = list(words)
-    list_of_words.remove((IDENTITY_SYMBOL,))
-    # Sort remaining words: typically by length, then by content.
-    # Sorting tuples of Symbols needs a consistent key.
-    # repr(s) can give a consistent string for sorting.
-    list_of_words.sort(key=lambda w: (len(w), tuple(repr(s) for s in w)))
-    return [(IDENTITY_SYMBOL,)] + list_of_words
-
-
-def _is_zero(word: tuple[Symbol, ...]) -> bool:
-    # An empty tuple after reduction means the operator product is zero.
-    return len(word) == 0
-
-
-def _is_identity(word: tuple[Symbol, ...]) -> bool:
-    return word == (IDENTITY_SYMBOL,)
-
-
-def _is_meas(word: tuple[Symbol, ...]) -> bool:
-    # Expects a reduced word: (Alice_Symbol, Bob_Symbol)
-    if len(word) == 2:
-        s_a, s_b = word
-        return s_a.player == "Alice" and s_b.player == "Bob"
-    return False
-
-
-def _is_meas_on_one_player(word: tuple[Symbol, ...]) -> bool:
-    # Expects a reduced word: (Alice_Symbol,) or (Bob_Symbol,)
-    if len(word) == 1:
-        s = word[0]
-        return s.player in PLAYERS  # Excludes IDENTITY_SYMBOL
-    return False
-
-
-# _get_nonlocal_game_params remains the same as in npa_constraints_fix
-def _get_nonlocal_game_params(
-    assemblage: dict[tuple[int, int], cvxpy.Variable], referee_dim: int = 1
-) -> tuple[int, int, int, int]:
-    a_in, b_in = max(assemblage.keys())
-    a_in += 1
-    b_in += 1
-    operator = next(iter(assemblage.values()))
-    a_out = operator.shape[0] // referee_dim
-    b_out = operator.shape[1] // referee_dim
-    return a_out, a_in, b_out, b_in
 
 
 def npa_constraints(
@@ -441,32 +221,6 @@ def npa_constraints(
     return constraints
 
 
-def _word_to_p_cg_index(word: tuple[Symbol, ...], oa: int, ob: int, ma: int, mb: int) -> int | None:
-    """Map an operator word to its corresponding index in the flattened CG vector."""
-    dim_a = (oa - 1) * ma
-    dim_b = (ob - 1) * mb
-    row_dim = dim_a + 1
-    col_dim = dim_b + 1
-    order = "F"
-    if not word:
-        return 0
-    if len(word) == 1:
-        s = word[0]
-        if s.player == "Alice":
-            row_idx = (oa - 1) * s.question + s.answer + 1
-            return np.ravel_multi_index((row_idx, 0), (row_dim, col_dim), order=order)
-        if s.player == "Bob":
-            col_idx = (ob - 1) * s.question + s.answer + 1
-            return np.ravel_multi_index((0, col_idx), (row_dim, col_dim), order=order)
-    if len(word) == 2:
-        s_a, s_b = word
-        if s_a.player == "Alice" and s_b.player == "Bob":
-            row_idx = (oa - 1) * s_a.question + s_a.answer + 1
-            col_idx = (ob - 1) * s_b.question + s_b.answer + 1
-            return np.ravel_multi_index((row_idx, col_idx), (row_dim, col_dim), order=order)
-    return None
-
-
 def bell_npa_constraints(
     p_var: cvxpy.Variable,
     desc: list[int],
@@ -595,3 +349,248 @@ def bell_npa_constraints(
                 seen_constraints[constraint_key] = (i, j)
 
     return constraints
+
+
+def _reduce(word: tuple[Symbol, ...]) -> tuple[Symbol, ...]:
+    """Reduce an operator word to its canonical form using NPA rules.
+
+    Identity: I*S = S*I = S, I*I = I
+    Commutation: Alice operators commute with Bob operators. Canonical form: A...AB...B
+    Orthogonality: P_x,a P_x,b = 0 if a != b (for same player x)
+    Idempotence: P_x,a P_x,a = P_x,a (for same player x)
+
+    """
+    if not word:
+        return ()
+
+    # Initial pass to filter out identities IF other ops are present
+    current_list = [s for s in word if s != IDENTITY_SYMBOL]
+    if not current_list:  # Original word was all identities or empty
+        return (IDENTITY_SYMBOL,) if any(s == IDENTITY_SYMBOL for s in word) else ()
+
+    # Canonical player order (Alice then Bob), preserving original relative internal order
+    alice_ops = [s for s in current_list if s.player == "Alice"]
+    bob_ops = [s for s in current_list if s.player == "Bob"]
+    current_list = alice_ops + bob_ops  # This is now a list of Symbol objects
+
+    # Iteratively apply reduction rules until no more changes occur
+    while True:
+        len_before_pass = len(current_list)
+        next_pass_list = []
+        idx = 0
+        made_change_in_pass = False
+
+        while idx < len(current_list):
+            s_x = current_list[idx]
+
+            if idx + 1 < len(current_list):
+                s_y = current_list[idx + 1]
+                # Only apply if s_x and s_y are from the same player.
+                if s_x == s_y and s_x.player in PLAYERS:  # s_x != IDENTITY_SYMBOL
+                    next_pass_list.append(s_x)
+                    idx += 2  # Consumed s_x, s_y; added s_x
+                    made_change_in_pass = True
+                    continue
+                # Rule 2: Orthogonality (S_x,a S_x,b = 0 if a!=b, for same player and question)
+                elif (
+                    s_x.player == s_y.player
+                    and s_x.player in PLAYERS  # Ensure not identity
+                    and s_x.question == s_y.question
+                    and s_x.answer != s_y.answer
+                ):
+                    return ()  # Entire word becomes zero
+                else:
+                    # No reduction for this pair, keep s_x
+                    next_pass_list.append(s_x)
+                    idx += 1
+            else:
+                # Last element, just append it
+                next_pass_list.append(s_x)
+                idx += 1
+
+        current_list = next_pass_list
+        if not made_change_in_pass and len(current_list) == len_before_pass:  # Stable
+            break
+
+    return tuple(current_list) if current_list else ()
+
+
+def _parse(k_str: str) -> tuple[int, set[tuple[int, int]]]:
+    if not k_str:  # Explicitly handle empty string input for k_str
+        raise ValueError("Input string k_str cannot be empty.")
+    parts = k_str.split("+")
+    if not parts[0] or parts[0] == "":  # Check if the first part (base_k) is empty
+        raise ValueError("Base level k must be specified, e.g., '1+ab'")
+    try:
+        base_k = int(parts[0])
+    except ValueError as e:
+        raise ValueError(f"Base level k '{parts[0]}' is not a valid integer: {e}") from e
+
+    conf = set()
+    if len(parts) == 1 and base_k >= 0:  # e.g. "0", "1"
+        pass  # conf remains empty, which is correct.
+
+    for val_content in parts[1:]:  # Process each part after the base_k
+        cnt_a, cnt_b = 0, 0
+        if not val_content:  # Handles "1++ab" -> parts like '', skip these
+            continue
+        # If val_content is an empty string (e.g., from "0+", "1++a"),
+        # cnt_a and cnt_b will remain 0, and (0,0) will be added to conf.
+        for char_val in val_content:  # Loop over empty string does nothing
+            if char_val == "a":
+                cnt_a += 1
+            elif char_val == "b":
+                cnt_b += 1
+            else:
+                raise ValueError(
+                    f"Invalid character '{char_val}' in k string component "
+                    + f"'{val_content}'. Only 'a' or 'b' allowed after base k."
+                )
+        conf.add((cnt_a, cnt_b))
+    return base_k, conf
+
+
+def _gen_words(k: int | str, a_out: int, a_in: int, b_out: int, b_in: int) -> list[tuple[Symbol, ...]]:
+    # Symbols for non-identity measurements (last outcome is dependent)
+    alice_symbols = [Symbol("Alice", x, a) for x in range(a_in) for a in range(a_out - 1)]
+    bob_symbols = [Symbol("Bob", y, b) for y in range(b_in) for b in range(b_out - 1)]
+
+    words = set([(IDENTITY_SYMBOL,)])  # Start with identity operator
+
+    k_int = k
+    configurations = set()
+
+    if isinstance(k, str):
+        k_int, configurations = _parse(k)
+
+    # Loop 1: Generate words up to length k_int from the hierarchy
+    for length in range(0, k_int + 1):  # Lengths 1, ..., k_int
+        for alice_len in range(length + 1):
+            bob_len = length - alice_len
+
+            # Generate Alice's part
+            # If alice_len is 0, product yields one item: ()
+            for word_a_tuple in product(alice_symbols, repeat=alice_len):
+                reduced_a = _reduce(word_a_tuple)
+                # Alice's part (non-empty originally) reduced to zero
+                if reduced_a == () and alice_len > 0:
+                    continue
+
+                # Generate Bob's part
+                # If bob_len is 0, product yields one item: ()
+                for word_b_tuple in product(bob_symbols, repeat=bob_len):
+                    reduced_b = _reduce(word_b_tuple)
+                    # Bob's part (non-empty originally) reduced to zero
+                    if reduced_b == () and bob_len > 0:
+                        continue
+
+                    if not reduced_a and not reduced_b:  # Both parts are empty (e.g. alice_len=0, bob_len=0)
+                        # This means the total length of operators is 0.
+                        final_word = (IDENTITY_SYMBOL,)
+                    else:
+                        # _reduce will put Alice operators before Bob operators if somehow mixed,
+                        # and apply rules. It also handles identity filtering if I was part of word.
+                        # Here, reduced_a + reduced_b is already A...AB...B (or just A...A or B...B).
+                        final_word = _reduce(reduced_a + reduced_b)
+                    words.add(final_word)
+
+    # Loop 2: Add words from specific configurations (e.g., "1+ab" means k_int=1, configurations={(1,1)})
+    for alice_len_conf, bob_len_conf in configurations:
+        if alice_len_conf == 0 and bob_len_conf == 0 and k_int == 0 and (IDENTITY_SYMBOL,) in words:
+            pass  # The set `words` will handle duplicates from k_int loop vs config loop.
+
+        for word_a_tuple in product(alice_symbols, repeat=alice_len_conf):
+            reduced_a = _reduce(word_a_tuple)
+            if reduced_a == () and alice_len_conf > 0:
+                continue
+
+            for word_b_tuple in product(bob_symbols, repeat=bob_len_conf):
+                reduced_b = _reduce(word_b_tuple)
+                if reduced_b == () and bob_len_conf > 0:
+                    continue
+
+                # Combine and add as in the main loop
+                # Both parts are empty (e.g. alice_len_conf=0, bob_len_conf=0)
+                if not reduced_a and not reduced_b:
+                    # Should not happen if _parse filters (0,0) from conf
+                    final_word = (IDENTITY_SYMBOL,)
+
+                else:
+                    final_word = _reduce(reduced_a + reduced_b)
+
+                words.add(final_word)
+
+    # If `words` contains `()`, filter it out before converting to list.
+    words = {w for w in words if w != ()}
+    # Convert set to list, then sort.
+    # Make sure (IDENTITY_SYMBOL,) is always at index 0.
+    list_of_words = list(words)
+    list_of_words.remove((IDENTITY_SYMBOL,))
+    # Sort remaining words: typically by length, then by content.
+    # Sorting tuples of Symbols needs a consistent key.
+    # repr(s) can give a consistent string for sorting.
+    list_of_words.sort(key=lambda w: (len(w), tuple(repr(s) for s in w)))
+    return [(IDENTITY_SYMBOL,)] + list_of_words
+
+
+def _is_zero(word: tuple[Symbol, ...]) -> bool:
+    # An empty tuple after reduction means the operator product is zero.
+    return len(word) == 0
+
+
+def _is_identity(word: tuple[Symbol, ...]) -> bool:
+    return word == (IDENTITY_SYMBOL,)
+
+
+def _is_meas(word: tuple[Symbol, ...]) -> bool:
+    # Expects a reduced word: (Alice_Symbol, Bob_Symbol)
+    if len(word) == 2:
+        s_a, s_b = word
+        return s_a.player == "Alice" and s_b.player == "Bob"
+    return False
+
+
+def _is_meas_on_one_player(word: tuple[Symbol, ...]) -> bool:
+    # Expects a reduced word: (Alice_Symbol,) or (Bob_Symbol,)
+    if len(word) == 1:
+        s = word[0]
+        return s.player in PLAYERS  # Excludes IDENTITY_SYMBOL
+    return False
+
+
+def _get_nonlocal_game_params(
+    assemblage: dict[tuple[int, int], cvxpy.Variable], referee_dim: int = 1
+) -> tuple[int, int, int, int]:
+    a_in, b_in = max(assemblage.keys())
+    a_in += 1
+    b_in += 1
+    operator = next(iter(assemblage.values()))
+    a_out = operator.shape[0] // referee_dim
+    b_out = operator.shape[1] // referee_dim
+    return a_out, a_in, b_out, b_in
+
+
+def _word_to_p_cg_index(word: tuple[Symbol, ...], oa: int, ob: int, ma: int, mb: int) -> int | None:
+    """Map an operator word to its corresponding index in the flattened CG vector."""
+    dim_a = (oa - 1) * ma
+    dim_b = (ob - 1) * mb
+    row_dim = dim_a + 1
+    col_dim = dim_b + 1
+    order = "F"
+    if not word:
+        return 0
+    if len(word) == 1:
+        s = word[0]
+        if s.player == "Alice":
+            row_idx = (oa - 1) * s.question + s.answer + 1
+            return np.ravel_multi_index((row_idx, 0), (row_dim, col_dim), order=order)
+        if s.player == "Bob":
+            col_idx = (ob - 1) * s.question + s.answer + 1
+            return np.ravel_multi_index((0, col_idx), (row_dim, col_dim), order=order)
+    if len(word) == 2:
+        s_a, s_b = word
+        if s_a.player == "Alice" and s_b.player == "Bob":
+            row_idx = (oa - 1) * s_a.question + s_a.answer + 1
+            col_idx = (ob - 1) * s_b.question + s_b.answer + 1
+            return np.ravel_multi_index((row_idx, col_idx), (row_dim, col_dim), order=order)
+    return None


### PR DESCRIPTION
Two cleanups in `state_opt/npa_hierarchy.py`.

Stepdown ordering: the public `npa_constraints` and `bell_npa_constraints` were defined below seven private helpers. They now lead the file, with the helpers (`_reduce`, `_parse`, `_gen_words`, the `_is_*` predicates, `_get_nonlocal_game_params`, `_word_to_p_cg_index`) underneath. Pure move, no logic change.

DRY: `Symbol` is a namedtuple declared with `defaults=["", None, None]`, so `Symbol("", None, None)` re-spelled those defaults. Now `IDENTITY_SYMBOL = Symbol()`.