### PR TITLE
fix(states): rename corrupted 'exfootcited' to 'excited' in dicke

### DIFF
--- a/toqito/states/dicke.py
+++ b/toqito/states/dicke.py
@@ -6,12 +6,12 @@ import numpy as np
 import scipy.special
 
 
-def dicke(num_qubit: int, num_exfootcited: int, return_dm: bool = False) -> np.ndarray:
+def dicke(num_qubit: int, num_excited: int, return_dm: bool = False) -> np.ndarray:
     r"""Produce a Dicke state with specified excitations.
 
-    The Dicke state is a quantum state with a fixed number of excitations (i.e., `num_exfootcited`)
+    The Dicke state is a quantum state with a fixed number of excitations (i.e., `num_excited`)
     distributed across the given number of qubits (i.e., `num_qubit`). It is symmetric and represents
-    an equal superposition of all possible states with the specified number of exfootcited qubits.
+    an equal superposition of all possible states with the specified number of excited qubits.
 
     Example
     Consider generating a Dicke state with 3 qubits and 1 excitation:
@@ -34,23 +34,23 @@ def dicke(num_qubit: int, num_exfootcited: int, return_dm: bool = False) -> np.n
 
     Args:
         num_qubit: The total number of qubits in the system.
-        num_exfootcited: The number of qubits that are in the exfootcited state.
+        num_excited: The number of qubits that are in the excited state.
         return_dm: If True, returns the state as a density matrix (default is False).
 
     Returns:
         The Dicke state vector or density matrix as a NumPy array.
 
     """
-    if num_exfootcited > num_qubit:
+    if num_excited > num_qubit:
         raise ValueError("Number of excitations cannot exceed the number of qubits.")
 
-    num_term = int(scipy.special.comb(num_qubit, num_exfootcited))
-    d_base_exfootcited_pos = list(itertools.combinations(range(num_qubit), num_exfootcited))
+    num_term = int(scipy.special.comb(num_qubit, num_excited))
+    d_base_excited_pos = list(itertools.combinations(range(num_qubit), num_excited))
 
-    index_exfootcited_pos = [sum(2**i for i in pos) for pos in d_base_exfootcited_pos]
+    index_excited_pos = [sum(2**i for i in pos) for pos in d_base_excited_pos]
     dicke_state = np.zeros(2**num_qubit, dtype=np.float64)
 
-    for pos in index_exfootcited_pos:
+    for pos in index_excited_pos:
         dicke_state[pos] = 1
     dicke_state /= np.sqrt(num_term)
 

--- a/toqito/states/tests/test_dicke.py
+++ b/toqito/states/tests/test_dicke.py
@@ -7,7 +7,7 @@ from toqito.states import dicke
 
 
 @pytest.mark.parametrize(
-    "num_qubit, num_exfootcited, expected_state",
+    "num_qubit, num_excited, expected_state",
     [
         # Dicke state for 3 qubits and 1 excitation
         (3, 1, np.array([0, 1 / np.sqrt(3), 1 / np.sqrt(3), 0, 1 / np.sqrt(3), 0, 0, 0])),
@@ -38,14 +38,14 @@ from toqito.states import dicke
         ),
     ],
 )
-def test_dicke_state(num_qubit, num_exfootcited, expected_state):
+def test_dicke_state(num_qubit, num_excited, expected_state):
     """Test that dicke_state produces the correct vector state."""
-    result = dicke(num_qubit, num_exfootcited)
+    result = dicke(num_qubit, num_excited)
     assert np.allclose(result, expected_state, atol=1e-6), f"Result: {result} does not match expected: {expected_state}"
 
 
 @pytest.mark.parametrize(
-    "num_qubit, num_exfootcited, expected_dm_shape",
+    "num_qubit, num_excited, expected_dm_shape",
     [
         # Density matrix for 3 qubits and 1 excitation
         (3, 1, (8, 8)),
@@ -53,21 +53,21 @@ def test_dicke_state(num_qubit, num_exfootcited, expected_state):
         (4, 2, (16, 16)),
     ],
 )
-def test_dicke_state_density_matrix(num_qubit, num_exfootcited, expected_dm_shape):
+def test_dicke_state_density_matrix(num_qubit, num_excited, expected_dm_shape):
     """Test that dicke_state returns correct density matrix dimensions."""
-    dm = dicke(num_qubit, num_exfootcited, return_dm=True)
+    dm = dicke(num_qubit, num_excited, return_dm=True)
     assert dm.shape == expected_dm_shape, f"Expected shape: {expected_dm_shape}, but got {dm.shape}"
     assert np.isclose(np.trace(dm), 1), f"Trace of the density matrix is not 1, but {np.trace(dm)}"
 
 
 @pytest.mark.parametrize(
-    "num_qubit, num_exfootcited",
+    "num_qubit, num_excited",
     [
         # Number of excitations exceeds the number of qubits
         (2, 3),
     ],
 )
-def test_dicke_state_invalid_input(num_qubit, num_exfootcited):
+def test_dicke_state_invalid_input(num_qubit, num_excited):
     """Test that dicke_state raises an error for invalid input."""
     with pytest.raises(ValueError):
-        dicke(num_qubit, num_exfootcited)
+        dicke(num_qubit, num_excited)


### PR DESCRIPTION
Closes #1654

A find/replace had mangled "excited" into "exfootcited" across `dicke`, including the public parameter name (`num_exfootcited`) and the docstring prose. This renames the parameter to `num_excited` and fixes the internal variables and docstrings. Callers pass the argument positionally, so this only changes the keyword name.