### PR TITLE
fix(matrix_props): handle column/row vectors in is_orthonormal

### DIFF
--- a/toqito/matrix_props/is_orthonormal.py
+++ b/toqito/matrix_props/is_orthonormal.py
@@ -7,7 +7,7 @@ def is_orthonormal(vectors: list[np.ndarray]) -> bool:
     r"""Check if the vectors are orthonormal.
 
     Args:
-        vectors: A list of `np.ndarray` 1-by-n vectors.
+        vectors: A list of `np.ndarray` vectors, each given as a 1-D array or a column/row vector.
 
     Returns:
         True if vectors are orthonormal; False otherwise.
@@ -44,4 +44,7 @@ def is_orthonormal(vectors: list[np.ndarray]) -> bool:
         ```
 
     """
-    return np.allclose(np.dot(vectors, np.conjugate(vectors).T), np.eye(len(vectors)))
+    # Flatten each vector to 1-D so column vectors (n, 1) and row vectors (1, n) are handled the
+    # same as plain 1-D arrays; the Gram matrix of an orthonormal set is the identity.
+    mat = np.array([np.asarray(vec).reshape(-1) for vec in vectors])
+    return np.allclose(mat @ mat.conj().T, np.eye(len(vectors)))

--- a/toqito/matrix_props/tests/test_is_orthonormal.py
+++ b/toqito/matrix_props/tests/test_is_orthonormal.py
@@ -25,3 +25,15 @@ def test_is_orthonormal():
     vectors = np.array([vec_1, vec_2, vec_3])
 
     assert is_orthonormal(vectors)
+
+
+def test_is_orthonormal_column_vectors():
+    """Column vectors of shape (n, 1) are accepted (the library's standard convention)."""
+    vectors = [np.array([[1], [0]]), np.array([[0], [1]])]
+    assert is_orthonormal(vectors)
+
+
+def test_is_not_orthonormal_column_vectors():
+    """Non-orthonormal column vectors return False rather than raising."""
+    vectors = [np.array([[1], [0]]), np.array([[1], [1]])]
+    assert not is_orthonormal(vectors)


### PR DESCRIPTION
Closes #1655

`is_orthonormal` used `np.dot(vectors, conj(vectors).T)`, which assumes 1-D arrays. Passing the library's standard `(n, 1)` column vectors produced a 3-D array and raised `ValueError: shapes ... not aligned`. Each vector is now flattened before forming the Gram matrix, so 1-D, column, and row vectors all work. Added tests for the column-vector case (both orthonormal and not).