### PR TITLE
fix(state_metrics): regularize singular rho with epsilon*I in matsumoto_fidelity

### DIFF
--- a/toqito/state_metrics/matsumoto_fidelity.py
+++ b/toqito/state_metrics/matsumoto_fidelity.py
@@ -112,8 +112,8 @@ def matsumoto_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float | np.floatin
             sq_rho = scipy.linalg.sqrtm(rho)
             sqinv_rho = scipy.linalg.inv(sq_rho)
         except np.linalg.LinAlgError:
-            sq_rho = scipy.linalg.sqrtm(rho + 1e-7)  # if rho is not invertible, add epsilon=1e-7 to it
-            # note if epsilon=1e-8 or smaller, it leads to test failures.
+            # If rho is singular, regularize by adding epsilon on the diagonal (not to every entry).
+            sq_rho = scipy.linalg.sqrtm(rho + 1e-7 * np.eye(rho.shape[0]))
             sqinv_rho = scipy.linalg.inv(sq_rho)
 
         sq_mfid = sq_rho @ scipy.linalg.sqrtm(sqinv_rho @ sigma @ sqinv_rho) @ sq_rho


### PR DESCRIPTION
Closes #1658

The non-invertible fallback used `scipy.linalg.sqrtm(rho + 1e-7)`, which adds 1e-7 to every entry rather than to the diagonal, distorting the matrix. Changed to `rho + 1e-7 * np.eye(n)`. Verified the singular path still gives sensible values (F(rho, rho) = 1, symmetric).