### PR TITLE
fix(state_metrics): clamp to avoid NaN from fidelity overshoot in bures/sub_fidelity

### DIFF
--- a/toqito/state_metrics/bures_angle.py
+++ b/toqito/state_metrics/bures_angle.py
@@ -72,5 +72,8 @@ def bures_angle(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> flo
     # Perform error checking.
     if not np.all(rho_1.shape == rho_2.shape):
         raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
-    # Round fidelity to only 10 decimals to avoid error when `rho_1 = rho_2`.
-    return np.real(np.arccos(np.sqrt(np.round(fidelity(rho_1, rho_2), decimals))))
+    # Round fidelity to `decimals` places, then clamp to [0, 1]: floating-point error in the
+    # sqrtm-based fidelity can push it just above 1 for near-identical states, which would make
+    # arccos receive an argument greater than 1 and yield NaN.
+    fid = np.clip(np.round(fidelity(rho_1, rho_2), decimals), 0.0, 1.0)
+    return np.real(np.arccos(np.sqrt(fid)))

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -73,5 +73,8 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> 
     # Perform some error checking.
     if not np.all(rho_1.shape == rho_2.shape):
         raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
-    # Round fidelity to only 10 decimals to avoid error when `rho_1 = rho_2`.
-    return np.sqrt(2.0 * (1.0 - np.round(fidelity(rho_1, rho_2), decimals)))
+    # Round fidelity to `decimals` places, then clamp to [0, 1]: floating-point error in the
+    # sqrtm-based fidelity can push it just above 1 for near-identical states, which would make
+    # the radicand negative and yield NaN.
+    fid = np.clip(np.round(fidelity(rho_1, rho_2), decimals), 0.0, 1.0)
+    return np.sqrt(2.0 * (1.0 - fid))

--- a/toqito/state_metrics/sub_fidelity.py
+++ b/toqito/state_metrics/sub_fidelity.py
@@ -77,6 +77,8 @@ def sub_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
     if not is_density(rho) or not is_density(sigma):
         raise ValueError("Sub-fidelity is only defined for density operators.")
 
-    return np.real(
-        np.trace(rho @ sigma) + np.sqrt(2 * (np.trace(rho @ sigma) ** 2 - np.trace(rho @ sigma @ rho @ sigma)))
-    )
+    inner = np.trace(rho @ sigma)
+    # The radicand is non-negative in exact arithmetic, but floating-point error can push it
+    # slightly below zero for pure/near-equal states; clamp it before the square root.
+    radicand = 2 * (inner**2 - np.trace(rho @ sigma @ rho @ sigma))
+    return np.real(inner + np.sqrt(np.maximum(np.real(radicand), 0.0)))


### PR DESCRIPTION
Closes #1659

`bures_distance` and `bures_angle` could return NaN for near-identical states because the sqrtm-based fidelity can overshoot 1 by more than the 10-decimal rounding guards (negative radicand, or `arccos` argument > 1). They now clamp the fidelity to [0, 1] as well. `sub_fidelity` could similarly NaN when its radicand goes slightly negative from floating-point error; it now clamps the radicand to >= 0. Verified identical pure states give 0/0/1 instead of NaN.