### PR TITLE
docs: render the DOI badge via shields.io instead of Zenodo's flaky SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![build status](https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml/badge.svg)](https://github.com/vprusso/toqito/actions/workflows/build-test-actions.yml)
 [![doc status](https://img.shields.io/badge/docs-passing-brightgreen)](https://vprusso.github.io/toqito/)
 [![codecov](https://img.shields.io/codecov/c/github/vprusso/toqito/master)](https://app.codecov.io/gh/vprusso/toqito)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4743211.svg)](https://doi.org/10.5281/zenodo.4743211)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.4743211-blue)](https://doi.org/10.5281/zenodo.4743211)
 [![Downloads](https://static.pepy.tech/personalized-badge/toqito?style=platic&period=total&units=none&left_color=black&right_color=brightgreen&left_text=Downloads)](https://pepy.tech/project/toqito)
 [![Unitary Foundation](https://img.shields.io/badge/Supported%20By-Unitary%20Foundation-FFFF00.svg)](https://unitary.foundation)
 


### PR DESCRIPTION
The DOI badge was the only README badge whose image came from `zenodo.org`. GitHub proxies README images through its Camo proxy with a short fetch timeout; Zenodo's dynamic badge SVG is frequently slow or rate-limited, so Camo times out and the badge shows as a broken image (refreshing retries Camo, which is why a reload fixes it).

This switches to a static shields.io DOI badge (same DOI link target), matching the other badges, which Camo caches reliably.