### PR TITLE
fix(state_props): pass resolved dimensions to is_ppt in is_separable

### DIFF
--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -504,7 +504,10 @@ def is_separable(
         return True, "lies within the Gurvits-Barnum separable ball"
 
     # --- 5. PPT (Peres-Horodecki) Criterion ---
-    is_state_ppt = is_ppt(state, 2, dim, tol)  # sys=2 implies partial transpose on the second system by default
+    # Pass the resolved subsystem dimensions (not the raw `dim`, which may be None or a scalar): for a
+    # non-square split such as 2x3, is_ppt would otherwise re-infer equal dimensions and raise.
+    # sys=2 implies partial transpose on the second system by default.
+    is_state_ppt = is_ppt(state, 2, dims_list, tol)
     if not is_state_ppt:
         # Determined to be entangled via the PPT criterion [@peres1996separability].
         # Also, see Horodecki Theorem in [@guhne2009entanglement].

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -1569,3 +1569,12 @@ def test_is_separable_strength_zero_skips_terhal_witness():
     # At strength=0 execution stops at the PPT pre-checks, so the fake
     # witness never fires — strength=0 cap returns False/inconclusive.
     assert "Terhal" not in str(sep)
+
+
+def test_is_separable_non_square_split_with_inferred_dim():
+    """A 2x3 (dimension-6) state with dim=None must not crash inferring equal 2x2 dims (#1656)."""
+    # Separable mixed state on a 2 (x) 3 system; dim is left as None so it is inferred.
+    rho = np.kron(np.diag([0.6, 0.4]), np.diag([0.2, 0.3, 0.5]))
+    result, reason = is_separable(rho)
+    assert isinstance(result, bool)
+    assert isinstance(reason, str)


### PR DESCRIPTION
Closes #1656

`is_separable` resolves the subsystem dimensions into `dims_list` but passed the raw `dim` (often `None`) to `is_ppt`. For a non-square split such as 2x3, `is_ppt` re-infers equal dimensions (round(sqrt(6))=2) and raises `InvalidDim`. It now passes `dims_list`. Added a regression test that a 2x3 state with `dim=None` does not crash.