### PR TITLE
fix(channel_props): only catch ValueError in is_quantum_channel

### DIFF
--- a/toqito/channel_props/is_quantum_channel.py
+++ b/toqito/channel_props/is_quantum_channel.py
@@ -88,9 +88,11 @@ def is_quantum_channel(
     if isinstance(phi, list):
         phi = kraus_to_choi(phi)
 
-    # A valid quantum channel is a superoperator that is both completely
-    # positive and trace-preserving.
+    # A valid quantum channel is a superoperator that is both completely positive and
+    # trace-preserving. A ValueError here means the input does not have a shape that can describe a
+    # channel (e.g. dimensions that cannot be split), so it is not a quantum channel; other
+    # exceptions indicate genuine problems and should surface rather than be hidden as a False.
     try:
         return is_completely_positive(phi, rtol, atol) and is_trace_preserving(phi, rtol, atol)
-    except Exception:
+    except ValueError:
         return False


### PR DESCRIPTION
Closes #1660

`is_quantum_channel` wrapped its CP/TP checks in `except Exception: return False`, so genuine errors (e.g. a real bug in a downstream check) were hidden as a plain `False`. Narrowed to `except ValueError`, which is the expected signal that the input shape cannot describe a channel; anything else now propagates.