### PR TITLE
fix(channels): validate param_p range in dephasing

### DIFF
--- a/toqito/channels/dephasing.py
+++ b/toqito/channels/dephasing.py
@@ -48,6 +48,9 @@ def dephasing(dim: int, param_p: float = 0) -> np.ndarray:
     Returns:
         The Choi matrix of the partially dephasing channel.
 
+    Raises:
+        ValueError: If `param_p` is outside the interval [0, 1].
+
     Examples:
         The completely dephasing channel (\(p = 0\)) kills everything off the diagonal. Consider
         the following matrix
@@ -98,6 +101,9 @@ def dephasing(dim: int, param_p: float = 0) -> np.ndarray:
         ```
 
     """
+    if param_p < 0 or param_p > 1:
+        raise ValueError("The dephasing parameter must be between 0 and 1.")
+
     # Compute the Choi matrix of the dephasing channel.
 
     psi = max_entangled(dim=dim, is_sparse=False, is_normalized=False)

--- a/toqito/channels/tests/test_dephasing.py
+++ b/toqito/channels/tests/test_dephasing.py
@@ -1,6 +1,9 @@
 """Test dephasing."""
 
+import re
+
 import numpy as np
+import pytest
 
 from toqito.channel_ops import apply_channel
 from toqito.channels import dephasing
@@ -28,3 +31,10 @@ def test_dephasing_partially_dephasing():
 
     bool_mat = np.isclose(expected_res, res)
     np.testing.assert_equal(np.all(bool_mat), True)
+
+
+@pytest.mark.parametrize("param_p", [-0.1, 1.5])
+def test_dephasing_invalid_param_p(param_p):
+    """An out-of-range dephasing parameter raises a clear ValueError."""
+    with pytest.raises(ValueError, match=re.escape("The dephasing parameter must be between 0 and 1.")):
+        dephasing(2, param_p)


### PR DESCRIPTION
Closes #1664

`dephasing` accepted out-of-range `param_p` (e.g. 1.5 or -1.0) and returned a non-physical Choi matrix, while the sibling `depolarizing` validates and is tested for it. Added the `[0, 1]` range check, a Raises docstring entry, and a parametrized test.