### PR TITLE
fix: correct PyPI license classifier from BSD to MIT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "License :: OSI Approved :: BSD License",
+    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 # Runtime dependencies use compatible ranges (floor at the tested version, capped at the next major) rather than


### PR DESCRIPTION
Closes #1670

`pyproject.toml` declared `License :: OSI Approved :: BSD License` while `LICENSE` and the README state MIT, so PyPI advertised the wrong license. Corrected the classifier to MIT.