### PR TITLE
fix(state_opt): use a Hermitian dual variable in unambiguous distinguishability

### DIFF
--- a/toqito/state_opt/state_distinguishability.py
+++ b/toqito/state_opt/state_distinguishability.py
@@ -19,7 +19,7 @@ def state_distinguishability(
     solver: str = "cvxopt",
     primal_dual: str = "dual",
     **kwargs: Any,
-) -> tuple[float, list[picos.HermitianVariable] | list[np.ndarray] | tuple[picos.SymmetricVariable]]:
+) -> tuple[float, list[picos.HermitianVariable] | list[np.ndarray] | tuple[picos.HermitianVariable]]:
     r"""Compute probability of state distinguishability [@eldar2003semidefinite].
 
     The "quantum state distinguishability" problem involves a collection of \(n\) quantum states
@@ -435,7 +435,7 @@ def _unambiguous_dual(
     probs: list[float] | None = None,
     solver: str = "cvxopt",
     **kwargs,
-) -> tuple[float, tuple[picos.SymmetricVariable]]:
+) -> tuple[float, tuple[picos.HermitianVariable]]:
     """Solve the dual problem for unambiguous quantum state distinguishability SDP.
 
     Implemented according to Equation (5) of [@gupta2024unambiguous].
@@ -446,12 +446,14 @@ def _unambiguous_dual(
     problem = picos.Problem()
 
     gram = vectors_to_gram_matrix(vectors)
-    lagrangian_variable_big_z = picos.SymmetricVariable("Z", (n, n))
+    # Z is Hermitian, not merely real symmetric: for complex states the Gram matrix is complex
+    # Hermitian, and a real symmetric Z gives the wrong dual value (a large primal-dual gap).
+    lagrangian_variable_big_z = picos.HermitianVariable("Z", (n, n))
 
     problem.add_constraint(lagrangian_variable_big_z >> 0)
     problem.add_list_of_constraints(lagrangian_variable_big_z[i, i] >= probs[i] for i in range(n))
 
-    problem.set_objective("min", picos.trace(gram * lagrangian_variable_big_z))
+    problem.set_objective("min", picos.trace(gram * lagrangian_variable_big_z).real)
 
     problem.solve(solver=solver, **kwargs)
 

--- a/toqito/state_opt/tests/test_state_distinguishability.py
+++ b/toqito/state_opt/tests/test_state_distinguishability.py
@@ -156,3 +156,13 @@ def test_state_distinguishability_invalid_inputs(kwargs, match):
     vectors = [bell(0), bell(1)]
     with pytest.raises(ValueError, match=match):
         state_distinguishability(vectors, **kwargs)
+
+
+def test_unambiguous_dual_matches_primal_for_complex_states():
+    """The unambiguous dual must equal the primal for complex states (Hermitian dual var, #1657)."""
+    v0 = np.array([[1.0], [0.0]], dtype=complex)
+    v1 = np.array([[1.0], [1.0j]], dtype=complex) / np.sqrt(2)
+    states = [v0, v1]
+    primal, _ = state_distinguishability(states, strategy="unambiguous", primal_dual="primal")
+    dual, _ = state_distinguishability(states, strategy="unambiguous", primal_dual="dual")
+    np.testing.assert_allclose(primal, dual, atol=1e-5)


### PR DESCRIPTION
Closes #1657

`_unambiguous_dual` declared the dual variable `Z` as a real `picos.SymmetricVariable`. For complex states the Gram matrix is complex Hermitian, so a real `Z` produces the wrong dual value (a primal-dual gap). Changed `Z` to `HermitianVariable` and took `.real` of the trace objective. Verified the unambiguous primal and dual now agree exactly for complex states (0.292893 = 1 - 1/sqrt(2)); added a regression test.