### PR TITLE
docs(state_opt): correct the wrong linear-dependence claim in state_exclusion

### DIFF
--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -128,8 +128,11 @@ def state_exclusion(
 
     !!! Note
         This function supports both pure states (vectors) and mixed states (density matrices).
-        It is known that it is always possible to perfectly exclude pure states that are linearly dependent.
-        Thus, calling this function on a set of states with this property will return 0.
+        Linear dependence does not imply perfect exclusion: the identical pair \(|0\rangle, |0\rangle\)
+        is linearly dependent yet cannot be excluded (Bob can never rule out \(|0\rangle\)). A
+        sufficient condition for perfect exclusion (a value of 0) is that the states span a strict
+        subspace of the full space, since then a measurement along a complementary direction excludes
+        with certainty.
 
     The conclusive state exclusion SDP is written explicitly in [@bandyopadhyay2014conclusive]. The problem
     of conclusive state exclusion was also thought about under a different guise in [@pusey2012reality].

--- a/toqito/state_opt/tests/test_state_exclusion.py
+++ b/toqito/state_opt/tests/test_state_exclusion.py
@@ -252,3 +252,10 @@ def test_state_exclusion_invalid_inputs(kwargs, match):
     vectors = [bell(0), bell(1)]
     with pytest.raises(ValueError, match=match):
         state_exclusion(vectors, **kwargs)
+
+
+def test_state_exclusion_identical_states_not_perfectly_excludable():
+    """Linearly-dependent identical states |0>,|0> cannot be excluded (value != 0); see #1563."""
+    states = [np.array([[1.0], [0.0]]), np.array([[1.0], [0.0]])]
+    value, _ = state_exclusion(states, primal_dual="primal")
+    assert value > 1e-6


### PR DESCRIPTION
Closes #1563

The `state_exclusion` note claimed it is "always possible to perfectly exclude pure states that are linearly dependent" and that the function "will return 0" for such inputs. That is false: `|0>, |0>` is linearly dependent yet returns 0.5 (Bob can never exclude `|0>`). The SDP itself is correct (no code path relied on the claim); this fixes the docstring to state the accurate sufficient condition (the states spanning a strict subspace) and adds a regression test that identical states do not return 0.