### PR TITLE
test: tighten vacuous test tolerances so regressions are caught

### DIFF
--- a/toqito/nonlocal_games/tests/test_nonlocal_game.py
+++ b/toqito/nonlocal_games/tests/test_nonlocal_game.py
@@ -201,7 +201,7 @@ class TestNonlocalGame(unittest.TestCase):
         ffl = NonlocalGame(prob_mat, pred_mat)
         res = ffl.nonsignaling_value()
         expected_res = 2 / 3
-        self.assertEqual(np.isclose(res, expected_res, atol=0.5), True)
+        self.assertEqual(np.isclose(res, expected_res, atol=1e-3), True)
 
     def test_ffl_game_nonsignaling_value_rep_2(self):
         """Non-signaling value for the FFL game for 2 reps."""
@@ -210,7 +210,7 @@ class TestNonlocalGame(unittest.TestCase):
         ffl = NonlocalGame(prob_mat, pred_mat, 2)
         res = ffl.nonsignaling_value()
         expected_res = 2 / 3
-        self.assertEqual(np.isclose(res, expected_res, atol=0.5), True)
+        self.assertEqual(np.isclose(res, expected_res, atol=1e-3), True)
 
     def test_chsh_game_nonsignaling_value(self):
         """Non-signaling value for the CHSH game."""
@@ -219,7 +219,7 @@ class TestNonlocalGame(unittest.TestCase):
         chsh = NonlocalGame(prob_mat, pred_mat)
         res = chsh.nonsignaling_value()
         expected_res = 1
-        self.assertEqual(np.isclose(res, expected_res, atol=0.5), True)
+        self.assertEqual(np.isclose(res, expected_res, atol=1e-3), True)
 
     def test_chsh_game_nonsignaling_value_rep_2(self):
         """Non-signaling value for the CHSH game for 2 reps."""
@@ -228,7 +228,7 @@ class TestNonlocalGame(unittest.TestCase):
         chsh = NonlocalGame(prob_mat, pred_mat, 2)
         res = chsh.nonsignaling_value()
         expected_res = 1
-        self.assertEqual(np.isclose(res, expected_res, atol=0.5), True)
+        self.assertEqual(np.isclose(res, expected_res, atol=1e-3), True)
 
     def test_chsh_game_commuting_measurement_value(self):
         """Commuting measurement value for the CHSH game."""
@@ -237,7 +237,7 @@ class TestNonlocalGame(unittest.TestCase):
         chsh = NonlocalGame(prob_mat, pred_mat)
         res = chsh.commuting_measurement_value_upper_bound(k=1)
         expected_res = 0.8535
-        self.assertEqual(np.isclose(res, expected_res, atol=0.5), True)
+        self.assertEqual(np.isclose(res, expected_res, atol=1e-3), True)
 
     def test_ffl_game_commuting_measurement_value(self):
         """Commuting measurement value for the FFL game."""
@@ -246,7 +246,7 @@ class TestNonlocalGame(unittest.TestCase):
         ffl = NonlocalGame(prob_mat, pred_mat)
         res = ffl.commuting_measurement_value_upper_bound(k=1)
         expected_res = 0.666
-        self.assertEqual(np.isclose(res, expected_res, atol=0.5), True)
+        self.assertEqual(np.isclose(res, expected_res, atol=1e-3), True)
 
     def test_unbalanced_nonlocal_game(self):
         """Test nonlocal game where Bob has more outputs than Alice."""

--- a/toqito/state_opt/tests/test_optimal_clone.py
+++ b/toqito/state_opt/tests/test_optimal_clone.py
@@ -31,7 +31,7 @@ def test_optimal_clone(input_states, input_probs, num_reps, input_strategy, expe
     """Test functions work as expected."""
     expected_result = expected**num_reps
     calculated_result = optimal_clone(input_states, input_probs, num_reps, input_strategy)
-    assert pytest.approx(expected_result, 0.1) == calculated_result
+    assert pytest.approx(expected_result, 1e-2) == calculated_result
 
 
 @pytest.mark.parametrize(
@@ -45,4 +45,4 @@ def test_optimal_clone_default_reps_strategy(input_states, input_probs, expected
     """Test functions work as expected."""
     expected_result = expected
     calculated_result = optimal_clone(input_states, input_probs)
-    assert pytest.approx(expected_result, 0.1) == calculated_result
+    assert pytest.approx(expected_result, 1e-2) == calculated_result

--- a/toqito/state_props/tests/test_purity.py
+++ b/toqito/state_props/tests/test_purity.py
@@ -18,7 +18,7 @@ from toqito.states import werner
 )
 def test_purity(rho, expected_result):
     """Test function works as expected for a valid input."""
-    np.testing.assert_allclose(purity(rho), expected_result, atol=4)
+    np.testing.assert_allclose(purity(rho), expected_result, atol=1e-4)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1661

Three tests used tolerances loose enough to pass for almost any in-range output:
- `test_purity` used `atol=4` (purity is in [0,1]); now `1e-4`, matching the precision of the expected literals (verified locally).
- `test_nonlocal_game` checked the commuting-measurement and nonsignaling values with `atol=0.5`; now `1e-3` (the CHSH/FFL values are precise).
- `test_optimal_clone` used `pytest.approx(..., 0.1)` against the exact 3/4 and 9/16; now `1e-2`.

The solver-backed tests run on CI (local cvxpy is broken here); auto-merge gates on green.