### PR TITLE
docs: document the sys indexing convention (swap 1-based vs partial_trace/transpose 0-based)

### DIFF
--- a/toqito/matrix_ops/partial_trace.py
+++ b/toqito/matrix_ops/partial_trace.py
@@ -32,7 +32,8 @@ def partial_trace(
 
     Args:
         input_mat: A square matrix.
-        sys: Scalar or vector specifying the size of the subsystems.
+        sys: The subsystem(s) to trace out, indexed starting from 0 (zero-based); defaults to `[1]`
+            (the second subsystem). Note that `swap` indexes subsystems starting from 1 (one-based).
         dim: Dimension of the subsystems. If `None`, all dimensions are assumed to be equal.
             Accepted types are `int`, `list`, `tuple`, or `numpy.ndarray`.
 

--- a/toqito/matrix_ops/partial_transpose.py
+++ b/toqito/matrix_ops/partial_transpose.py
@@ -46,7 +46,8 @@ def partial_transpose(
 
     Args:
         rho: A matrix.
-        sys: Scalar or vector specifying the size of the subsystems.
+        sys: The subsystem(s) to transpose, indexed starting from 0 (zero-based); defaults to `[1]`
+            (the second subsystem). Note that `swap` indexes subsystems starting from 1 (one-based).
         dim: Dimension of the subsystems. If `None`, all dimensions are assumed to be equal.
 
     Returns:

--- a/toqito/perms/swap.py
+++ b/toqito/perms/swap.py
@@ -25,7 +25,8 @@ def swap(
 
     Args:
         rho: A vector or matrix to have its subsystems swapped.
-        sys: Default: [1, 2]
+        sys: The subsystems to swap, indexed starting from 1 (one-based). Default: [1, 2]. Note that
+            `partial_trace` and `partial_transpose` index subsystems starting from 0 (zero-based).
         dim: Default: `[sqrt(len(X), sqrt(len(X)))]`
         row_only: Default: `False`
 


### PR DESCRIPTION
Closes #1666

`swap` indexes subsystems starting from 1 (one-based, default `[1, 2]`), while `partial_trace` and `partial_transpose` index from 0 (zero-based, default `[1]` = the second subsystem). Same `sys` parameter name, opposite base, which is a silent footgun. Unifying would be a breaking change, so this resolves it the non-breaking way: each docstring now states its indexing base and cross-references the other convention.