### PR TITLE
fix: minor API-consistency nits (tensor, random_states, is_nonnegative/is_stochastic)

### DIFF
--- a/toqito/matrix_ops/tensor.py
+++ b/toqito/matrix_ops/tensor.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 
-def tensor(*args: np.ndarray | int | list[np.ndarray]) -> np.ndarray | None:
+def tensor(*args: np.ndarray | int | list[np.ndarray]) -> np.ndarray:
     r"""Compute the Kronecker tensor product [@wikipediatensor].
 
     Tensor two matrices or vectors together using the standard Kronecker
@@ -124,6 +124,8 @@ def tensor(*args: np.ndarray | int | list[np.ndarray]) -> np.ndarray | None:
 
     # Input is provided as a list of numpy matrices.
     if (len(args) == 1 and isinstance(args[0], list)) or (len(args) == 1 and isinstance(args[0], np.ndarray)):
+        if len(args[0]) == 0:
+            raise ValueError("The `tensor` function requires at least one matrix; the input list is empty.")
         if len(args[0]) == 1:
             return args[0][0]
         if len(args[0]) == 2:

--- a/toqito/matrix_ops/tests/test_tensor.py
+++ b/toqito/matrix_ops/tests/test_tensor.py
@@ -38,8 +38,6 @@ matrix4 = np.array([[7, 8]])
         ((e_0, 3), 2, np.kron(np.kron(e_0, e_0), e_0)),
         # tensor product of vector with n = 3
         ((e_0, 4), 2, np.kron(np.kron(np.kron(e_0, e_0), e_0), e_0)),
-        # tensor product of empty list
-        ([], 1, None),
         # tensor product of list with one item
         ([e_0], 1, e_0),
         # tensor product of list with two items
@@ -78,3 +76,9 @@ def test_tensor_empty_args():
     r"""Test tensor with no arguments."""
     with pytest.raises(ValueError, match="The `tensor` function must take either a matrix or vector."):
         tensor()
+
+
+def test_tensor_empty_list():
+    r"""An empty input list raises ValueError rather than silently returning None."""
+    with pytest.raises(ValueError, match="at least one matrix"):
+        tensor([])

--- a/toqito/matrix_props/is_nonnegative.py
+++ b/toqito/matrix_props/is_nonnegative.py
@@ -22,7 +22,7 @@ def is_nonnegative(input_mat: np.ndarray, mat_type: str = "nonnegative") -> bool
         Return `True` if matrix is nonnegative (or doubly nonnegative if specified), and `False` otherwise.
 
     Raises:
-        TypeError: If something other than `"doubly"` or `"nonnegative"` is used for `mat_type`.
+        ValueError: If something other than `"doubly"` or `"nonnegative"` is used for `mat_type`.
 
     Examples:
         We expect an identity matrix to be nonnegative.
@@ -39,7 +39,7 @@ def is_nonnegative(input_mat: np.ndarray, mat_type: str = "nonnegative") -> bool
     """
     valid_types = {"nonnegative", "doubly"}
     if mat_type not in valid_types:
-        raise TypeError(f"Invalid matrix check type: {mat_type}. Must be one of: {valid_types}.")
+        raise ValueError(f"Invalid matrix check type: {mat_type}. Must be one of: {valid_types}.")
 
     is_entrywise_nonnegative = bool(np.all(input_mat >= 0))
 

--- a/toqito/matrix_props/is_stochastic.py
+++ b/toqito/matrix_props/is_stochastic.py
@@ -22,7 +22,7 @@ def is_stochastic(mat: np.ndarray, mat_type: str) -> bool:
         Returns `True` if the matrix is doubly, right or left stochastic, `False` otherwise.
 
     Raises:
-        TypeError: If something other than `"doubly"`, `"left"`, or `"right"` is used for `mat_type`.
+        ValueError: If something other than `"doubly"`, `"left"`, or `"right"` is used for `mat_type`.
 
     Examples:
         The elements of an identity matrix and a Pauli-X matrix are nonnegative such that the rows and columns
@@ -63,7 +63,7 @@ def is_stochastic(mat: np.ndarray, mat_type: str) -> bool:
 
     """
     if mat_type not in {"left", "right", "doubly"}:
-        raise TypeError("Allowed stochastic matrix types are: left, right, and doubly.")
+        raise ValueError("Allowed stochastic matrix types are: left, right, and doubly.")
 
     if not (is_square(mat) and is_nonnegative(mat)):
         return False

--- a/toqito/matrix_props/tests/test_is_nonnegative.py
+++ b/toqito/matrix_props/tests/test_is_nonnegative.py
@@ -29,7 +29,7 @@ def test_is_nonnegative(mat, mat_type, expected):
 @pytest.mark.parametrize("bad_type", ["l", "r", 1, (), "d"])
 def test_invalid_type_raises(bad_type):
     """Check that invalid matrix types raise a TypeError."""
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         is_nonnegative(np.identity(3), bad_type)
 
 

--- a/toqito/matrix_props/tests/test_is_stochastic.py
+++ b/toqito/matrix_props/tests/test_is_stochastic.py
@@ -25,5 +25,5 @@ def test_non_stochastic_matrices(matrix, mat_type):
 @pytest.mark.parametrize("bad_type", ["l", "r", 1, (), "d"])
 def test_invalid_stochastic_type_raises(matrix, bad_type):
     """Invalid mat_type values should raise a TypeError."""
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         is_stochastic(matrix, bad_type)

--- a/toqito/rand/random_states.py
+++ b/toqito/rand/random_states.py
@@ -1,21 +1,21 @@
-"""Generates random quantum states using Qiskit."""
+"""Generates random quantum states."""
 
 import numpy as np
 
 
-def random_states(n: int, d: int, seed: int | None = None) -> list[np.ndarray]:
+def random_states(n: int, dim: int, seed: int | None = None) -> list[np.ndarray]:
     r"""Generate a list of random quantum states.
 
     This function generates a list of quantum states, each of a specified dimension. The states are
     valid quantum states distributed according to the Haar measure.
 
     Args:
-        n: int The number of random states to generate.
-        d: int The dimension of each quantum state.
-        seed: int | None A seed used to instantiate numpy's random number generator.
+        n: The number of random states to generate.
+        dim: The dimension of each quantum state. (Named `dim` to match the other `random_*` helpers.)
+        seed: A seed used to instantiate numpy's random number generator.
 
     Returns:
-        A list of `n` numpy arrays, each representing a d-dimensional quantum state as a column vector.
+        A list of `n` numpy arrays, each representing a `dim`-dimensional quantum state as a column vector.
 
     Examples:
         Generating three quantum states each of dimension 4.
@@ -51,6 +51,6 @@ def random_states(n: int, d: int, seed: int | None = None) -> list[np.ndarray]:
 
     """
     gen = np.random.default_rng(seed=seed)
-    samples = gen.normal(size=(n, d)) + 1j * gen.normal(size=(n, d))
+    samples = gen.normal(size=(n, dim)) + 1j * gen.normal(size=(n, dim))
     samples /= np.linalg.norm(samples, axis=1)[:, np.newaxis]
     return [sample.reshape(-1, 1) for sample in samples]


### PR DESCRIPTION
Closes #1669

- `tensor([])` silently returned `None`; it now raises `ValueError`, and the `| None` return annotation is dropped.
- `random_states`: the dimension parameter `d` is renamed to `dim` to match the other `random_*` helpers (positionally compatible; no caller uses `d=`). Also dropped the stale "using Qiskit" module docstring.
- `is_nonnegative` / `is_stochastic`: an out-of-range `mat_type` string now raises `ValueError` instead of `TypeError` (it is a value error). Tests updated.