### PR TITLE
fix(docs): annotate **solve_kwargs to unbreak the strict docs build

### DIFF
--- a/toqito/cones/integral_relative_entropy.py
+++ b/toqito/cones/integral_relative_entropy.py
@@ -1,6 +1,7 @@
 r"""Integral-representation SDPs for quantum relative entropy [@kossmann2024optimisingrelativeentropy]."""
 
 import warnings
+from typing import Any
 
 import cvxpy
 import numpy as np
@@ -153,7 +154,7 @@ def evaluate_relative_entropy_integral(
     epsilon_dec: float = 1e-2,
     mean: bool = True,
     solver: str = "SCS",
-    **solve_kwargs,
+    **solve_kwargs: Any,
 ) -> float | tuple[float, float]:
     r"""Estimate \(D(X\|Y)\) via integral SDP lower/upper bounds [@kossmann2024optimisingrelativeentropy].
 

--- a/toqito/state_props/quantum_relative_entropy.py
+++ b/toqito/state_props/quantum_relative_entropy.py
@@ -3,6 +3,8 @@ r"""Quantum relative entropy for positive semidefinite matrices."""
 # Adapted from CVXQUAD (https://github.com/hfawzi/cvxquad), BSD-2-Clause.
 # Original implementation by Fawzi, Saunderson, et al.
 
+from typing import Any
+
 import cvxpy
 import numpy as np
 from scipy.linalg import logm
@@ -26,7 +28,7 @@ def quantum_relative_entropy(
     space_optimized: bool = False,
     epsilon_dec: float = 1e-2,
     solver: str = "SCS",
-    **solve_kwargs,
+    **solve_kwargs: Any,
 ) -> float:
     r"""Compute the quantum relative entropy \(D(X||Y)\) for PSD \(X\) and \(Y\).
 


### PR DESCRIPTION
The strict (`--strict`) docs build aborts on griffe warnings. The `**solve_kwargs` parameters added with the integral relative-entropy SDP (merged in #1644) have no type annotation, producing two griffe warnings that fail the build:

- `cones/integral_relative_entropy.py:176`
- `state_props/quantum_relative_entropy.py:65`

Annotate both as `**solve_kwargs: Any` (matching the repo's prior strict-docs kwargs fix).