### PR TITLE
test: de-vacuous error-path and single-branch tests

### DIFF
--- a/toqito/channel_metrics/tests/test_completely_bounded_spectral_norm.py
+++ b/toqito/channel_metrics/tests/test_completely_bounded_spectral_norm.py
@@ -1,10 +1,12 @@
 """Tests for completely_bounded_spectral_norm."""
 
+import numpy as np
+
 from toqito.channel_metrics import (
     completely_bounded_spectral_norm,
     completely_bounded_trace_norm,
 )
-from toqito.channel_ops import dual_channel
+from toqito.channel_ops import dual_channel, kraus_to_choi
 from toqito.channels import dephasing
 
 
@@ -12,3 +14,9 @@ def test_dual_is_cb_trace_norm():
     """Test CB Spectral norm of a dephasing channel is the same as the CB Trace norm of a dephasing channel."""
     phi = dephasing(2)
     assert completely_bounded_spectral_norm(phi) == completely_bounded_trace_norm(dual_channel(phi))
+
+
+def test_cb_spectral_norm_identity_channel():
+    """A non-tautological check: the CB spectral norm of the identity channel is 1."""
+    identity_choi = kraus_to_choi([np.eye(2)])
+    assert abs(completely_bounded_spectral_norm(identity_choi) - 1.0) <= 1e-4

--- a/toqito/channel_props/tests/test_is_unital.py
+++ b/toqito/channel_props/tests/test_is_unital.py
@@ -57,3 +57,10 @@ def test_is_unital_isometry_true_unspecified_dim():
     choi = kraus_to_choi([v_mat])
     with np.testing.assert_raises(ValueError):
         is_unital(choi)
+
+
+def test_is_unital_non_unital_false():
+    """A non-unital channel (reset-to-|0>) returns False, exercising the False branch."""
+    k0 = np.array([[1.0, 0.0], [0.0, 0.0]])
+    k1 = np.array([[0.0, 1.0], [0.0, 0.0]])
+    np.testing.assert_equal(is_unital([k0, k1]), False)

--- a/toqito/perms/tests/test_symmetric_projection.py
+++ b/toqito/perms/tests/test_symmetric_projection.py
@@ -1,6 +1,9 @@
 """Test symmetric_projection."""
 
+import re
+
 import numpy as np
+import pytest
 
 from toqito.perms import symmetric_projection
 
@@ -121,15 +124,11 @@ def test_symmetric_projection_dim_4_pval_2_partial_true():
 
 def test_symmetric_projection_invalid_dim():
     """Test for invalid dimension."""
-    try:
+    with pytest.raises(ValueError, match=re.escape("InvalidDim: `dim` must be at least 1.")):
         symmetric_projection(dim=0, p_val=2)
-    except ValueError as e:
-        assert str(e) == "InvalidDim: `dim` must be at least 1."
 
 
 def test_symmetric_projection_invalid_pval():
     """Test for invalid p_val."""
-    try:
+    with pytest.raises(ValueError, match=re.escape("InvalidPVal: `p_val` must be at least 1.")):
         symmetric_projection(dim=2, p_val=0)
-    except ValueError as e:
-        assert str(e) == "InvalidPVal: `p_val` must be at least 1."


### PR DESCRIPTION
Closes #1663

- `symmetric_projection`: the two invalid-input tests used `try/except ValueError`, which passes even if the function stops raising. Switched to `pytest.raises`.
- `is_unital`: every test asserted `True`; added a non-unital channel (reset-to-|0>) so the `False` branch is exercised.
- `completely_bounded_spectral_norm`: the sole test asserted the function equals its own implementation (a tautology). Added a non-tautological value check (the identity channel has CB spectral norm 1).