### PR TITLE
Small cleanups in random_psd_operator and measure

### DIFF
--- a/toqito/measurement_ops/measure.py
+++ b/toqito/measurement_ops/measure.py
@@ -122,13 +122,16 @@ def measure(
 
     # Single-operator case.
     if not isinstance(measurement, (list, tuple)):
+        if not state_update:
+            # Only the probability Tr(M rho M^dagger) = Tr(M^dagger M rho) is needed.
+            return np.trace(measurement.conj().T @ measurement @ state).real
         result = measurement @ state @ measurement.conj().T
         prob = np.trace(result).real
         if prob > tol:
             post_state = result / prob
         else:
             post_state = np.zeros_like(state)
-        return (prob, post_state) if state_update else prob
+        return prob, post_state
 
     # List-of-operators case.
     if len(measurement) == 0:

--- a/toqito/rand/random_psd_operator.py
+++ b/toqito/rand/random_psd_operator.py
@@ -115,9 +115,10 @@ def random_psd_operator(
         if not is_real:
             rand_mat = rand_mat + 1j * gen.random((dim, dim))
         rand_mat = (rand_mat.conj().T + rand_mat) / 2
+        # eigh already returns an orthonormal eigenvector matrix, so the extra qr is redundant: it
+        # only flips column signs, which cancel in V diag V^dagger.
         eigenvals, eigenvecs = np.linalg.eigh(rand_mat)
-        q_mat, _ = np.linalg.qr(eigenvecs)
-        return q_mat @ np.diag(np.abs(eigenvals)) @ q_mat.conj().T
+        return eigenvecs @ np.diag(np.abs(eigenvals)) @ eigenvecs.conj().T
 
     if distribution == "wishart":
         if scale is None:


### PR DESCRIPTION
Closes #1636.

random_psd_operator (uniform branch): `np.linalg.eigh` already returns an orthonormal eigenvector matrix, so the follow-up `np.linalg.qr` was redundant. It only flipped column signs, which cancel in the `V diag V^dagger` reconstruction, so the returned operator is unchanged. Now uses the eigenvectors directly.

measure (single-operator case): when `state_update=False`, only the probability is needed, so return `Tr(M^dagger M rho)` instead of forming the full `M rho M^dagger` product and post-measurement state that are immediately discarded.