### PR TITLE
Factor duplicated Kraus-format dispatch into one helper

### DIFF
--- a/toqito/channel_ops/apply_channel.py
+++ b/toqito/channel_ops/apply_channel.py
@@ -1,9 +1,8 @@
 """Applies a quantum channel to an operator."""
 
-import itertools
-
 import numpy as np
 
+from toqito.channel_props._kraus_format import normalize_kraus
 from toqito.perms import swap, vec
 
 
@@ -101,26 +100,8 @@ def apply_channel(mat: np.ndarray, phi_op: np.ndarray | list[list[np.ndarray]]) 
 
     # The superoperator was given as a list of Kraus operators:
     if isinstance(phi_op, list):
-        s_phi_op = [len(phi_op), len(phi_op[0])]
-
-        phi_0_list = []
-        phi_1_list = []
-
-        # Map is completely positive if input is given as:
-        # 1. [K1, K2, .. Kr]
-        # 2. [[K1], [K2], .. [Kr]]
-        # 3. [[K1, K2, .. Kr]] and r > 2
-        if isinstance(phi_op[0], np.ndarray):
-            phi_0_list = phi_op
-        elif s_phi_op[1] == 1 or (s_phi_op[0] == 1 and s_phi_op[1] > 2):
-            phi_0_list = list(itertools.chain(*phi_op))
-        else:
-            # Input is given as: [[A1, B1], [A2, B2], .. [Ar, Br]]
-            phi_0_list = [k_mat[0] for k_mat in phi_op]
-            phi_1_list = [k_mat[1].conj().T for k_mat in phi_op]
-
-        if not phi_1_list:
-            phi_1_list = [k_mat.conj().T for k_mat in phi_0_list]
+        phi_0_list, phi_1_raw, _ = normalize_kraus(phi_op)
+        phi_1_list = [k_mat.conj().T for k_mat in phi_1_raw]
 
         k_1 = np.concatenate(phi_0_list, axis=1)
         k_2 = np.concatenate(phi_1_list, axis=0)

--- a/toqito/channel_ops/partial_channel.py
+++ b/toqito/channel_ops/partial_channel.py
@@ -1,10 +1,9 @@
 """Applies a channel to a subsystem of an operator."""
 
-import itertools
-
 import numpy as np
 
 from toqito.channel_ops import apply_channel
+from toqito.channel_props._kraus_format import normalize_kraus
 from toqito.perms import permute_systems
 from toqito.states import max_entangled
 
@@ -103,20 +102,11 @@ def partial_channel(
 
     if isinstance(phi_map, list):
         # Compute the Kraus operators on the full system.
-        s_phi_1, s_phi_2 = len(phi_map), len(phi_map[0])
-        phi_list = []
-        # Map is completely positive if input is given as:
-        # 1. [K1, K2, .. Kr]
-        # 2. [[K1], [K2], .. [Kr]]
-        # 3. [[K1, K2, .. Kr]] and r > 2
-        if isinstance(phi_map[0], np.ndarray):
-            phi_list = phi_map
-        elif s_phi_2 == 1 or s_phi_1 == 1 and s_phi_2 > 2:
-            phi_list = list(itertools.chain(*phi_map))
+        left_ops, right_ops, is_cp = normalize_kraus(phi_map)
 
-        if phi_list:
+        if is_cp:
             phi = []
-            for m in phi_list:
+            for m in left_ops:
                 phi.append(
                     np.kron(
                         np.kron(np.identity(prod_dim_r1), m),
@@ -126,18 +116,18 @@ def partial_channel(
             phi_x = apply_channel(rho, phi)
         else:
             phi_1 = []
-            for m in phi_map:
+            for m in left_ops:
                 phi_1.append(
                     np.kron(
-                        np.kron(np.identity(prod_dim_r1), m[0]),
+                        np.kron(np.identity(prod_dim_r1), m),
                         np.identity(prod_dim_r2),
                     )
                 )
             phi_2 = []
-            for m in phi_map:
+            for m in right_ops:
                 phi_2.append(
                     np.kron(
-                        np.kron(np.identity(prod_dim_c1), m[1]),
+                        np.kron(np.identity(prod_dim_c1), m),
                         np.identity(prod_dim_c2),
                     )
                 )

--- a/toqito/channel_props/_kraus_format.py
+++ b/toqito/channel_props/_kraus_format.py
@@ -1,0 +1,42 @@
+"""Shared classification of the Kraus-operator list formats accepted across the package."""
+
+import itertools
+
+import numpy as np
+
+
+def normalize_kraus(phi: list) -> tuple[list[np.ndarray], list[np.ndarray], bool]:
+    r"""Classify a list of Kraus operators and return a normalized ``(left, right, is_cp)``.
+
+    A channel supplied as a list of Kraus operators is treated as completely positive when it
+    is given in any of the following forms:
+
+    1. ``[K1, K2, ..., Kr]``               (flat list of operators),
+    2. ``[[K1], [K2], ..., [Kr]]``         (each operator wrapped on its own),
+    3. ``[[K1, K2, ..., Kr]]`` with r > 2  (a single wrapper holding more than two operators).
+
+    Anything else is the general (not necessarily completely positive) paired form
+    ``[[A1, B1], [A2, B2], ..., [Ar, Br]]``.
+
+    Args:
+        phi: A non-empty list of Kraus operators in any of the accepted forms.
+
+    Returns:
+        A tuple ``(left, right, is_cp)``. ``left`` is the list of left operators and ``right`` the
+        list of right operators; for a completely positive map ``right`` is the same list as
+        ``left``. ``is_cp`` is ``True`` for the completely positive forms above and ``False`` for
+        the paired form.
+
+    """
+    if isinstance(phi[0], np.ndarray):
+        left = list(phi)
+        return left, left, True
+
+    rows, cols = len(phi), len(phi[0])
+    if cols == 1 or (rows == 1 and cols > 2):
+        left = list(itertools.chain(*phi))
+        return left, left, True
+
+    left = [pair[0] for pair in phi]
+    right = [pair[1] for pair in phi]
+    return left, right, False

--- a/toqito/channel_props/channel_dim.py
+++ b/toqito/channel_props/channel_dim.py
@@ -1,8 +1,8 @@
 """Channel dimensions coputes and returns the input, output and environment dimensions of a channel."""
 
-import itertools
-
 import numpy as np
+
+from toqito.channel_props._kraus_format import normalize_kraus
 
 
 def channel_dim(
@@ -46,28 +46,16 @@ def channel_dim(
     dim_out = np.zeros(2, dtype=int)
 
     if isinstance(phi, list):
-        sz_phi_op = [len(phi), len(phi[0])]
+        left_ops, right_ops, is_cpt = normalize_kraus(phi)
 
-        # Map is completely positive if input is given as:
-        # 1. [K1, K2, .. Kr]
-        # 2. [[K1], [K2], .. [Kr]]
-        # 3. [[K1, K2, .. Kr]] and r > 2
-        is_cpt = False
-        if isinstance(phi[0], list) and (sz_phi_op[1] == 1 or (sz_phi_op[0] == 1 and sz_phi_op[1] > 2)):
-            # get a flat list of Kraus operators.
-            phi = list(itertools.chain(*phi))
-            is_cpt = True
-
-        dim_e = len(phi)
-        if isinstance(phi[0], np.ndarray):
-            dim_out[0], dim_in[0] = phi[0].shape
+        dim_e = len(left_ops)
+        dim_out[0], dim_in[0] = left_ops[0].shape
+        if is_cpt:
             # input and output are squares.
             dim_in[1] = dim_in[0]
             dim_out[1] = dim_out[0]
-            is_cpt = True
         else:
-            dim_out[0], dim_in[0] = phi[0][0].shape
-            dim_out[1], dim_in[1] = phi[0][1].shape
+            dim_out[1], dim_in[1] = right_ops[0].shape
 
         if dim is None:
             dim = np.vstack([dim_in, dim_out]).T
@@ -80,10 +68,11 @@ def channel_dim(
         if np.any(dim != np.vstack([dim_in, dim_out]).T):
             raise ValueError("The dimensions of PHI do not match those provided in the DIM argument.")
 
-        if (is_cpt and any(k_mat.shape != (dim[0, 1], dim[0, 0]) for k_mat in phi)) or (
+        if (is_cpt and any(k_mat.shape != (dim[0, 1], dim[0, 0]) for k_mat in left_ops)) or (
             not is_cpt
             and any(
-                k_mat[0].shape != (dim[0, 1], dim[0, 0]) or k_mat[1].shape != (dim[1, 1], dim[1, 0]) for k_mat in phi
+                left.shape != (dim[0, 1], dim[0, 0]) or right.shape != (dim[1, 1], dim[1, 0])
+                for left, right in zip(left_ops, right_ops)
             )
         ):
             raise ValueError("The Kraus operators of PHI do not all have the same size.")


### PR DESCRIPTION
Closes #1635.

`apply_channel`, `partial_channel`, and `channel_dim` each repeated the same logic to classify a list of Kraus operators as either a flat completely-positive list or the paired `[A, B]` form, using the same `s_phi_op[1] == 1 or (s_phi_op[0] == 1 and s_phi_op[1] > 2)` incantation and the same 3-case comment.

This moves that classification into `toqito/channel_props/_kraus_format.py` as `normalize_kraus`, which returns `(left_ops, right_ops, is_cp)`, and calls it from all three sites. The helper lives in `channel_props` (the lower module in the dependency direction) so both `channel_ops` and `channel_props` can import it without a cycle.

`dual_channel` was named in the issue but actually uses a simpler list-vs-ndarray dispatch, not the incantation, so it is left unchanged.