### PR TITLE
Fix is_k_incoherent SDP fallback to return feasibility

### DIFF
--- a/toqito/matrix_props/is_k_incoherent.py
+++ b/toqito/matrix_props/is_k_incoherent.py
@@ -110,11 +110,12 @@ def is_k_incoherent(mat: np.ndarray, k: int, tol: float = 1e-15) -> bool:
         P_expr = P_expr + proj.T @ A_j @ proj
     constraints.append(mat == P_expr)
     prob = cp.Problem(cp.Minimize(1), constraints)
-    opt_val = prob.solve(solver=cp.SCS, verbose=False)
+    prob.solve(solver=cp.SCS, verbose=False)
 
-    # A failed solve returns None; guard against it so this returns False rather than raising a TypeError inside
-    # min(...). An infeasible solve returns +inf, which min(...) handles correctly.
-    if opt_val is None:
-        return False
-    # MATLAB sets ikinc = 1 - min(cvx_optval, 1); here we interpret an optimum near 1 as True.
-    return np.isclose(1 - min(opt_val, 1), 1.0)
+    # `mat` is k-incoherent exactly when this feasibility SDP has a solution: a feasible point is a
+    # decomposition of `mat` into PSD operators supported on k-element subsets. So the answer is
+    # whether the SDP is feasible, not the (constant) objective value. The previous
+    # `1 - min(opt_val, 1)` was always 0 for a feasible solve (opt_val == 1) and so always returned
+    # False. OPTIMAL_INACCURATE is treated as feasible; near the boundary of the cone the solver
+    # cannot resolve feasibility exactly, so a definitive answer there is solver-limited.
+    return prob.status in (cp.OPTIMAL, cp.OPTIMAL_INACCURATE)

--- a/toqito/matrix_props/tests/test_is_k_incoherent.py
+++ b/toqito/matrix_props/tests/test_is_k_incoherent.py
@@ -107,13 +107,16 @@ def test_dephasing_condition(mat, k, expected):
             3,
             True,
         ),
-        # Fallback: use an SDP to decide incoherence.
+        # SDP fallback, unambiguously outside the cone: a full-support rank-1 pure state
+        # |psi><psi| with psi = (1, 1, 1, 1)/2 has four nonzero entries, so it is not
+        # 3-incoherent and the feasibility SDP is infeasible.
+        (np.full((4, 4), 0.25), 3, False),
+        # SDP fallback, unambiguously inside the cone: a sum of two rank-1 states each
+        # supported on three coordinates is 3-incoherent by construction (feasible SDP).
         (
-            np.array(
-                [[0.35, 0.30, 0.00, 0.00], [0.30, 0.25, 0.00, 0.00], [0.00, 0.00, 0.25, 0.05], [0.00, 0.00, 0.05, 0.15]]
-            ),
+            (np.outer([1, 1, 1, 0], [1, 1, 1, 0]) + np.outer([0, 1, 1, 1], [0, 1, 1, 1])).astype(float),
             3,
-            False,
+            True,
         ),
     ],
 )
@@ -148,23 +151,16 @@ def test_incoherent_ball_example():
     assert is_k_incoherent(mat, k) is True
 
 
-def test_recursive_and_sdp_branch(monkeypatch):
-    """Check for SDP k-incoherent."""
-    # Choose a 4x4 state that does not trigger earlier branches.
-    X = np.array([[0.3, 0.1, 0.05, 0.05], [0.1, 0.25, 0.05, 0.05], [0.05, 0.05, 0.2, 0.05], [0.05, 0.05, 0.05, 0.2]])
-    X = X / np.trace(X)
+def test_recursive_and_sdp_branch():
+    """The SDP fallback returns True for a feasible (genuinely k-incoherent) instance.
 
-    # Force the hierarchical recursion to be indeterminate by monkeypatching the recursive call to return False.
-    monkeypatch.setattr(
-        "toqito.matrix_props.is_k_incoherent", lambda Y, k_val, tol=1e-15: False if k_val == 2 else False
-    )
-
-    # Force the SDP branch by monkeypatching the solver to return 0.0 so that 1 - min(0.0, 1) equals 1.
-    def fake_solve(self, *args, **kwargs):
-        return 0.0
-
-    monkeypatch.setattr(cp.Problem, "solve", fake_solve)
-    assert is_k_incoherent(X, 3) is True
+    The matrix is a sum of two rank-1 states each supported on three coordinates, so it is
+    3-incoherent by construction. It passes through the earlier branches (its comparison matrix
+    is not PSD and the k=2 recursion is False), so the decision is made by the feasibility SDP,
+    which is feasible here.
+    """
+    mat = (np.outer([1, 1, 1, 0], [1, 1, 1, 0]) + np.outer([0, 1, 1, 1], [0, 1, 1, 1])).astype(float)
+    assert is_k_incoherent(mat, 3) is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1627.

The SDP fallback in `is_k_incoherent` is a constant-objective feasibility problem: `mat` is k-incoherent exactly when it decomposes into PSD operators supported on k-element subsets, which is precisely when the SDP is feasible. The old return value `1 - min(opt_val, 1)` was always 0 for a feasible solve (`opt_val == 1`), so the branch always returned False (dead code). It now returns whether the problem is feasible (status `OPTIMAL` or `OPTIMAL_INACCURATE`).

Per the issue, the boundary test matrix (within ~4e-6 of the 3-incoherent cone, where SCS reports `OPTIMAL_INACCURATE` and the answer is ambiguous) is replaced with two unambiguous cases:

- a full-support rank-1 pure state, which has four nonzero entries and so is not 3-incoherent (infeasible),
- a sum of two rank-1 states each supported on three coordinates, which is 3-incoherent by construction (feasible).

`test_recursive_and_sdp_branch` is rewritten to exercise the real feasible SDP path rather than monkeypatching the solver's return value (which no longer drives the result under the corrected logic). Near the cone boundary a definitive answer is solver-limited; this is noted in the code.