### PR TITLE
Standardize channel constructors on a Choi default with a return_kraus_ops flag

### DIFF
--- a/toqito/channel_metrics/channel_distinguishability.py
+++ b/toqito/channel_metrics/channel_distinguishability.py
@@ -70,8 +70,8 @@ def channel_distinguishability(
         from toqito.channel_ops import kraus_to_choi
         from toqito.channel_metrics import channel_distinguishability
         # Define two amplitude damping channels with gamma=0.25 and gamma=0.5
-        choi_ch_1 = kraus_to_choi(amplitude_damping(gamma=0.25))
-        choi_ch_2 = kraus_to_choi(amplitude_damping(gamma=0.5))
+        choi_ch_1 = kraus_to_choi(amplitude_damping(gamma=0.25, return_kraus_ops=True))
+        choi_ch_2 = kraus_to_choi(amplitude_damping(gamma=0.5, return_kraus_ops=True))
 
         p = [0.5, 0.5]
 
@@ -85,8 +85,8 @@ def channel_distinguishability(
         from toqito.channel_ops import kraus_to_choi
         from toqito.channel_metrics import channel_distinguishability
         # Define two amplitude damping channels with gamma=0.25 and gamma=0.5
-        choi_ch_1 = kraus_to_choi(amplitude_damping(gamma=0.25))
-        choi_ch_2 = kraus_to_choi(amplitude_damping(gamma=0.5))
+        choi_ch_1 = kraus_to_choi(amplitude_damping(gamma=0.25, return_kraus_ops=True))
+        choi_ch_2 = kraus_to_choi(amplitude_damping(gamma=0.5, return_kraus_ops=True))
 
         print(channel_distinguishability(choi_ch_1, choi_ch_2, None, [2, 2], strategy="minimax",primal_dual="primal"))
         ```

--- a/toqito/channel_metrics/tests/test_channel_distinguishability.py
+++ b/toqito/channel_metrics/tests/test_channel_distinguishability.py
@@ -7,16 +7,16 @@ from toqito.channel_ops import kraus_to_choi
 from toqito.channels import amplitude_damping, dephasing, depolarizing, phase_damping
 
 # Creating two amplitude damping channels.
-amp_damp_1 = kraus_to_choi(amplitude_damping(gamma=0.22))
-amp_damp_2 = kraus_to_choi(amplitude_damping(gamma=0.35))
+amp_damp_1 = kraus_to_choi(amplitude_damping(gamma=0.22, return_kraus_ops=True))
+amp_damp_2 = kraus_to_choi(amplitude_damping(gamma=0.35, return_kraus_ops=True))
 
 # In Kraus representation.
 amp_damp_1_kraus = amplitude_damping(gamma=0.22)
 amp_damp_2_kraus = amplitude_damping(gamma=0.35)
 
 # Creating two phase damping channels.
-ph_damp_1 = kraus_to_choi(phase_damping(gamma=0.22))
-ph_damp_2 = kraus_to_choi(phase_damping(gamma=0.35))
+ph_damp_1 = kraus_to_choi(phase_damping(gamma=0.22, return_kraus_ops=True))
+ph_damp_2 = kraus_to_choi(phase_damping(gamma=0.35, return_kraus_ops=True))
 
 
 @pytest.mark.parametrize(

--- a/toqito/channels/amplitude_damping.py
+++ b/toqito/channels/amplitude_damping.py
@@ -4,13 +4,16 @@ import warnings
 
 import numpy as np
 
+from toqito.channel_ops.kraus_to_choi import kraus_to_choi
+
 
 def amplitude_damping(
     input_mat: np.ndarray | None = None,
     gamma: float = 0,
     prob: float = 1,
+    return_kraus_ops: bool = False,
 ) -> np.ndarray | list[np.ndarray]:
-    r"""Return the Kraus operators of the generalized amplitude damping channel.
+    r"""Return the generalized amplitude damping channel.
 
     The generalized amplitude damping channel models energy dissipation in a quantum system,
     where the system can lose energy to its environment with a certain probability. The
@@ -41,13 +44,15 @@ def amplitude_damping(
             `apply_channel(input_mat, amplitude_damping(gamma=..., prob=...))`.
         gamma: The damping rate, a float between 0 and 1. Represents the probability of energy dissipation.
         prob: The probability of energy loss, a float between 0 and 1.
+        return_kraus_ops: If `True`, return the list of Kraus operators instead of the Choi matrix.
 
     Returns:
-        The list of Kraus operators describing the channel. When the deprecated `input_mat`
-        argument is provided, the channel applied to that input is returned instead.
+        The Choi matrix of the channel, or its list of Kraus operators when `return_kraus_ops` is
+        `True`. When the deprecated `input_mat` argument is provided, the channel applied to that
+        input is returned instead.
 
     Examples:
-        Obtain the Kraus operators and apply the channel via `apply_channel`:
+        Apply the channel (returned as a Choi matrix) to a state via `apply_channel`:
 
         ```python exec="1" source="above" result="text"
         import numpy as np
@@ -73,7 +78,8 @@ def amplitude_damping(
     k3 = np.sqrt(1 - prob) * np.sqrt(gamma) * np.array([[0, 0], [1, 0]])
 
     if input_mat is None:
-        return [k0, k1, k2, k3]
+        kraus_ops = [k0, k1, k2, k3]
+        return kraus_ops if return_kraus_ops else kraus_to_choi(kraus_ops)
 
     if input_mat.shape != (2, 2):
         raise ValueError("Input matrix must be 2x2 for the generalized amplitude damping channel.")

--- a/toqito/channels/bitflip.py
+++ b/toqito/channels/bitflip.py
@@ -4,12 +4,15 @@ import warnings
 
 import numpy as np
 
+from toqito.channel_ops.kraus_to_choi import kraus_to_choi
+
 
 def bitflip(
     input_mat: np.ndarray | None = None,
     prob: float = 0,
+    return_kraus_ops: bool = False,
 ) -> np.ndarray | list[np.ndarray]:
-    r"""Return the Kraus operators of the bitflip channel.
+    r"""Return the bitflip channel.
 
     The *bitflip channel* is a quantum channel that flips a qubit from \(|0\rangle\) to \(|1\rangle\)
     and from \(|1\rangle\) to \(|0\rangle\) with probability \(p\).
@@ -37,10 +40,12 @@ def bitflip(
             convenience path will be removed in a future release. Prefer
             `apply_channel(input_mat, bitflip(prob=...))`.
         prob: The probability of a bitflip occurring.
+        return_kraus_ops: If `True`, return the list of Kraus operators instead of the Choi matrix.
 
     Returns:
-        The list of Kraus operators describing the channel. When the deprecated `input_mat`
-        argument is provided, the channel applied to that input is returned instead.
+        The Choi matrix of the channel, or its list of Kraus operators when `return_kraus_ops` is
+        `True`. When the deprecated `input_mat` argument is provided, the channel applied to that
+        input is returned instead.
 
     Examples:
         Obtain the Kraus operators for the bitflip channel with probability 0.3:
@@ -48,7 +53,7 @@ def bitflip(
         ```python exec="1" source="above" result="text"
         from toqito.channels import bitflip
 
-        print(bitflip(prob=0.3))
+        print(bitflip(prob=0.3, return_kraus_ops=True))
         ```
 
 
@@ -71,7 +76,8 @@ def bitflip(
     k1 = np.sqrt(prob) * np.array([[0, 1], [1, 0]])
 
     if input_mat is None:
-        return [k0, k1]
+        kraus_ops = [k0, k1]
+        return kraus_ops if return_kraus_ops else kraus_to_choi(kraus_ops)
 
     if input_mat.shape != (2, 2):
         raise ValueError("Input matrix must be 2x2 for the bitflip channel.")

--- a/toqito/channels/dephasing.py
+++ b/toqito/channels/dephasing.py
@@ -5,7 +5,7 @@ import numpy as np
 from toqito.states import max_entangled
 
 
-def dephasing(dim: int, param_p: float = 0) -> np.ndarray:
+def dephasing(dim: int, param_p: float = 0, return_kraus_ops: bool = False) -> np.ndarray | list[np.ndarray]:
     r"""Produce the partially dephasing channel.
 
     (Section: The Completely Dephasing Channel from [@watrous2018theory]).
@@ -44,9 +44,11 @@ def dephasing(dim: int, param_p: float = 0) -> np.ndarray:
         dim: The dimensionality on which the channel acts.
         param_p: Parameter \(p \in [0, 1]\) that interpolates between the completely dephasing
             channel (\(p = 0\)) and the identity channel (\(p = 1\)). Default 0.
+        return_kraus_ops: If `True`, return a list of Kraus operators instead of the Choi matrix.
 
     Returns:
-        The Choi matrix of the partially dephasing channel.
+        The Choi matrix of the partially dephasing channel, or a list of Kraus operators when
+        `return_kraus_ops` is `True`.
 
     Raises:
         ValueError: If `param_p` is outside the interval [0, 1].
@@ -105,6 +107,20 @@ def dephasing(dim: int, param_p: float = 0) -> np.ndarray:
         raise ValueError("The dephasing parameter must be between 0 and 1.")
 
     # Compute the Choi matrix of the dephasing channel.
+
+    if return_kraus_ops:
+        # Phi_p(rho) = p rho + (1-p) sum_i <i|rho|i> |i><i|, so the Kraus operators are sqrt(p) I
+        # together with sqrt(1-p) |i><i| for each i. Zero-weight operators are omitted.
+        kraus_ops = []
+        if param_p > 0:
+            kraus_ops.append(np.sqrt(param_p) * np.eye(dim))
+        coeff = np.sqrt(1 - param_p)
+        if coeff > 0:
+            for i in range(dim):
+                op = np.zeros((dim, dim))
+                op[i, i] = coeff
+                kraus_ops.append(op)
+        return kraus_ops
 
     psi = max_entangled(dim=dim, is_sparse=False, is_normalized=False)
     psi_proj = psi @ psi.conj().T

--- a/toqito/channels/depolarizing.py
+++ b/toqito/channels/depolarizing.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 
-def depolarizing(dim: int, param_p: float = 0) -> np.ndarray:
+def depolarizing(dim: int, param_p: float = 0, return_kraus_ops: bool = False) -> np.ndarray | list[np.ndarray]:
     r"""Produce the partially depolarizing channel.
 
     (Section: Replacement Channels and the Completely Depolarizing Channel from
@@ -43,9 +43,11 @@ def depolarizing(dim: int, param_p: float = 0) -> np.ndarray:
         dim: The dimensionality on which the channel acts.
         param_p: Parameter \(p \in [0, 1]\) that interpolates between the completely depolarizing
             channel (\(p = 0\)) and the identity channel (\(p = 1\)). Default 0.
+        return_kraus_ops: If `True`, return a list of Kraus operators instead of the Choi matrix.
 
     Returns:
-        The Choi matrix of the partially depolarizing channel.
+        The Choi matrix of the partially depolarizing channel, or a list of Kraus operators when
+        `return_kraus_ops` is `True`.
 
     Raises:
         ValueError: If `param_p` is outside the interval [0,1].
@@ -101,6 +103,22 @@ def depolarizing(dim: int, param_p: float = 0) -> np.ndarray:
     # Compute the Choi matrix of the depolarizing channel.
     if param_p > 1 or param_p < 0:
         raise ValueError("The depolarizing probability must be between 0 and 1.")
+
+    if return_kraus_ops:
+        # Phi_p(rho) = sqrt(p) I rho sqrt(p) I + sum_{i,j} (1-p)/d |i><j| rho |j><i|, so the Kraus
+        # operators are sqrt(p) I together with sqrt((1-p)/d) |i><j| for all i, j. Zero-weight
+        # operators are omitted.
+        kraus_ops = []
+        if param_p > 0:
+            kraus_ops.append(np.sqrt(param_p) * np.eye(dim))
+        coeff = np.sqrt((1 - param_p) / dim)
+        if coeff > 0:
+            for i in range(dim):
+                for j in range(dim):
+                    op = np.zeros((dim, dim))
+                    op[i, j] = coeff
+                    kraus_ops.append(op)
+        return kraus_ops
 
     result = np.zeros((dim**2, dim**2), dtype=np.float64)
     np.fill_diagonal(result, (1 - param_p) / dim)

--- a/toqito/channels/pauli_channel.py
+++ b/toqito/channels/pauli_channel.py
@@ -37,17 +37,15 @@ def pauli_channel(
         prob: Probability vector for Pauli operators. If scalar, generates random probabilities for \(q =\) `prob`
             qubits. The probabilities correspond to Pauli operators in lexicographical order of length strictly equal to
             \(q\), when `prob` is a vector.
-        return_kraus_ops: Deprecated. When ``True``, the Kraus operators are returned in a
-            tuple alongside the Choi matrix. Prefer
-            `choi_to_kraus(pauli_channel(...))` to obtain Kraus operators.
+        return_kraus_ops: If `True`, return the list of Kraus operators instead of the Choi matrix.
         input_mat: Deprecated. When provided, the channel is also applied to this matrix and
             returned in a tuple alongside the Choi matrix. Prefer
             `apply_channel(input_mat, pauli_channel(...))` instead.
 
     Returns:
-        The Choi matrix of the Pauli channel. When the deprecated
-        ``input_mat`` / ``return_kraus_ops`` arguments are used, a tuple including the output
-        matrix and/or Kraus operators is returned for backward compatibility.
+        The Choi matrix of the Pauli channel, or its list of Kraus operators when
+        `return_kraus_ops` is `True`. When the deprecated ``input_mat`` argument is used, a tuple
+        including the output matrix is returned for backward compatibility.
 
     Raises:
         ValueError: If probabilities are negative or don't sum to 1.
@@ -103,19 +101,12 @@ def pauli_channel(
             DeprecationWarning,
             stacklevel=2,
         )
-    if return_kraus_ops:
-        warnings.warn(
-            "The `return_kraus_ops` argument to `pauli_channel` is deprecated; "
-            "use `choi_to_kraus(pauli_channel(...))` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
     output_mat = None
     if input_mat is not None:
         output_mat = sum(k @ input_mat @ k.conj().T for k in kraus_operators)
 
     if return_kraus_ops:
-        return (Phi, output_mat, kraus_operators) if input_mat is not None else (Phi, kraus_operators)
+        return (kraus_operators, output_mat) if input_mat is not None else kraus_operators
 
     return (Phi, output_mat) if input_mat is not None else Phi

--- a/toqito/channels/phase_damping.py
+++ b/toqito/channels/phase_damping.py
@@ -4,12 +4,15 @@ import warnings
 
 import numpy as np
 
+from toqito.channel_ops.kraus_to_choi import kraus_to_choi
+
 
 def phase_damping(
     input_mat: np.ndarray | None = None,
     gamma: float = 0,
+    return_kraus_ops: bool = False,
 ) -> np.ndarray | list[np.ndarray]:
-    r"""Return the Kraus operators of the phase damping channel [@nielsen2011quantum].
+    r"""Return the phase damping channel [@nielsen2011quantum].
 
     The phase damping channel describes how quantum information is lost due to environmental interactions,
     causing dephasing in the computational basis without losing energy.
@@ -26,13 +29,15 @@ def phase_damping(
             convenience path will be removed in a future release. Prefer
             `apply_channel(input_mat, phase_damping(gamma=...))`.
         gamma: The dephasing rate (between 0 and 1), representing the probability of phase decoherence.
+        return_kraus_ops: If `True`, return the list of Kraus operators instead of the Choi matrix.
 
     Returns:
-        The list of Kraus operators describing the channel. When the deprecated `input_mat`
-        argument is provided, the channel applied to that input is returned instead.
+        The Choi matrix of the channel, or its list of Kraus operators when `return_kraus_ops` is
+        `True`. When the deprecated `input_mat` argument is provided, the channel applied to that
+        input is returned instead.
 
     Examples:
-        Obtain the Kraus operators and apply the channel via `apply_channel`:
+        Apply the channel (returned as a Choi matrix) to a state via `apply_channel`:
 
         ```python exec="1" source="above" result="text"
         import numpy as np
@@ -53,7 +58,8 @@ def phase_damping(
     k1 = np.diag([0, np.sqrt(gamma)])
 
     if input_mat is None:
-        return [k0, k1]
+        kraus_ops = [k0, k1]
+        return kraus_ops if return_kraus_ops else kraus_to_choi(kraus_ops)
 
     if input_mat.shape != (2, 2):
         raise ValueError("Input matrix must be 2x2 for the phase damping channel.")

--- a/toqito/channels/tests/test_amplitude_damping.py
+++ b/toqito/channels/tests/test_amplitude_damping.py
@@ -30,7 +30,7 @@ from toqito.channels import amplitude_damping
 def test_amplitude_damping(rho, prob, gamma, expected_kraus):
     """Test amplitude damping for both Kraus operators and application to states."""
     if expected_kraus:
-        result = amplitude_damping(prob=prob, gamma=gamma)
+        result = amplitude_damping(prob=prob, gamma=gamma, return_kraus_ops=True)
         k0_expected = np.sqrt(prob) * np.array([[1, 0], [0, np.sqrt(1 - gamma)]])
         k1_expected = np.sqrt(prob) * np.sqrt(gamma) * np.array([[0, 1], [0, 0]])
         k2_expected = np.sqrt(1 - prob) * np.array([[np.sqrt(1 - gamma), 0], [0, 1]])
@@ -45,7 +45,7 @@ def test_amplitude_damping(rho, prob, gamma, expected_kraus):
             completeness_sum += k.conj().T @ k
         np.testing.assert_almost_equal(completeness_sum, np.eye(2))
     else:
-        kraus_ops = amplitude_damping(prob=prob, gamma=gamma)
+        kraus_ops = amplitude_damping(prob=prob, gamma=gamma, return_kraus_ops=True)
         result = apply_channel(rho, kraus_ops)
 
         expected_output = np.zeros((2, 2), dtype=complex)
@@ -96,7 +96,9 @@ def test_invalid_dimension(rho):
 
 def test_input_and_return_type():
     """Test for input handling and return types."""
-    kraus_ops = amplitude_damping(prob=0.3, gamma=0.4)
+    choi = amplitude_damping(prob=0.3, gamma=0.4)
+    assert choi.shape == (4, 4)
+    kraus_ops = amplitude_damping(prob=0.3, gamma=0.4, return_kraus_ops=True)
     assert len(kraus_ops) == 4
     for op in kraus_ops:
         assert op.shape == (2, 2)

--- a/toqito/channels/tests/test_bitflip.py
+++ b/toqito/channels/tests/test_bitflip.py
@@ -10,7 +10,7 @@ from toqito.channels import bitflip
 @pytest.mark.parametrize("prob", [0.0, 0.3, 0.5, 1.0])
 def test_kraus_operators(prob):
     """Test if the function returns correct Kraus operators for given probability."""
-    kraus_ops = bitflip(prob=prob)
+    kraus_ops = bitflip(prob=prob, return_kraus_ops=True)
     expected_kraus_ops = [
         np.sqrt(1 - prob) * np.eye(2),
         np.sqrt(prob) * np.array([[0, 1], [1, 0]]),

--- a/toqito/channels/tests/test_pauli_channel.py
+++ b/toqito/channels/tests/test_pauli_channel.py
@@ -106,11 +106,10 @@ def test_pauli_channel_choi_matrix_properties(num_qubits):
 
 
 @pytest.mark.parametrize("prob", [np.array([0.1, 0.2, 0.3, 0.4]), np.random.rand(16)])
-def test_pauli_channel_kraus_operators_legacy(prob):
-    """The deprecated `return_kraus_ops=True` path still returns valid Kraus operators."""
+def test_pauli_channel_kraus_operators(prob):
+    """`return_kraus_ops=True` returns the list of valid Kraus operators."""
     prob = prob / np.sum(prob)
-    with pytest.warns(DeprecationWarning, match="choi_to_kraus"):
-        _, kraus_operators = pauli_channel(prob=prob, return_kraus_ops=True)
+    kraus_operators = pauli_channel(prob=prob, return_kraus_ops=True)
 
     assert len(kraus_operators) == len(prob)
 
@@ -130,10 +129,9 @@ def test_pauli_channel_kraus_operators_legacy(prob):
         np.array([0.25, 0.0, 0.25, 0.5]),
     ],
 )
-def test_pauli_channel_zero_probability_legacy(prob):
-    """Deprecated path: when probabilities are zero, the per-index Kraus operator is zero."""
-    with pytest.warns(DeprecationWarning, match="choi_to_kraus"):
-        _, kraus_ops = pauli_channel(prob=prob, return_kraus_ops=True)
+def test_pauli_channel_zero_probability(prob):
+    """When probabilities are zero, the per-index Kraus operator is zero."""
+    kraus_ops = pauli_channel(prob=prob, return_kraus_ops=True)
 
     for i, k in enumerate(kraus_ops):
         if prob[i] == 0:
@@ -150,9 +148,9 @@ def test_pauli_channel_input_mat_is_deprecated():
     np.testing.assert_almost_equal(legacy, np.asarray(modern))
 
 
-def test_pauli_channel_return_kraus_ops_is_deprecated():
-    """Passing `return_kraus_ops=True` still works but emits a DeprecationWarning."""
+def test_pauli_channel_return_kraus_ops():
+    """`return_kraus_ops=True` returns the flat list of Kraus operators (one per probability)."""
     prob = np.array([0.25, 0.25, 0.25, 0.25])
-    with pytest.warns(DeprecationWarning, match="choi_to_kraus"):
-        result = pauli_channel(prob=prob, return_kraus_ops=True)
-    assert len(result) == 2
+    result = pauli_channel(prob=prob, return_kraus_ops=True)
+    assert len(result) == len(prob)
+    assert all(op.shape == (2, 2) for op in result)

--- a/toqito/channels/tests/test_phase_damping.py
+++ b/toqito/channels/tests/test_phase_damping.py
@@ -12,7 +12,7 @@ from toqito.channels import phase_damping
 @pytest.mark.parametrize("gamma", [0.0, 0.3, 0.5, 0.7, 1.0])
 def test_kraus_operators(gamma):
     """Test if the function returns correct Kraus operators for given gamma."""
-    kraus_ops = phase_damping(gamma=gamma)
+    kraus_ops = phase_damping(gamma=gamma, return_kraus_ops=True)
 
     k0_expected = np.diag([1, np.sqrt(1 - gamma)])
     k1_expected = np.diag([0, np.sqrt(gamma)])
@@ -44,7 +44,7 @@ def test_kraus_operators(gamma):
 )
 def test_apply_to_states(rho, gamma):
     """Apply the channel to various input states rho."""
-    kraus_ops = phase_damping(gamma=gamma)
+    kraus_ops = phase_damping(gamma=gamma, return_kraus_ops=True)
 
     expected_output = np.zeros((2, 2), dtype=complex)
     for k in kraus_ops:
@@ -91,7 +91,9 @@ def test_invalid_dimension(rho):
 
 def test_input_and_return_type():
     """Test for input handling and return types."""
-    kraus_ops = phase_damping(gamma=0.4)
+    choi = phase_damping(gamma=0.4)
+    assert choi.shape == (4, 4)
+    kraus_ops = phase_damping(gamma=0.4, return_kraus_ops=True)
     assert len(kraus_ops) == 2
     for op in kraus_ops:
         assert op.shape == (2, 2)


### PR DESCRIPTION
Closes #1667.

Constructing a channel previously yielded three different representations: amplitude_damping/bitflip/phase_damping returned Kraus lists, depolarizing/dephasing returned Choi matrices, and pauli_channel returned a Choi with a one-off return_kraus_ops flag that produced a tuple.

All six constructors now:
- return a Choi matrix by default, and
- accept a uniform return_kraus_ops flag that returns a flat list of Kraus operators.

amplitude_damping/bitflip/phase_damping build the Choi via kraus_to_choi. depolarizing/dephasing build their Kraus operators analytically when requested (importing choi_to_kraus there would create an import cycle through matrix_props.sk_norm); the analytic Kraus sets were checked to reconstruct the Choi exactly. pauli_channel's return_kraus_ops now returns the flat Kraus list rather than the previous deprecated tuple.

The common apply_channel(rho, constructor(...)) pattern is unaffected because apply_channel accepts both Choi matrices and Kraus lists.