### PR TITLE
Standardize is_rank_one/is_totally_positive/is_k_incoherent on rtol/atol

### DIFF
--- a/toqito/matrix_props/is_k_incoherent.py
+++ b/toqito/matrix_props/is_k_incoherent.py
@@ -1,5 +1,6 @@
 """Checks if the matrix is $k$-incoherent."""
 
+import warnings
 from itertools import combinations
 
 import cvxpy as cp
@@ -9,7 +10,9 @@ from toqito.matrices import comparison
 from toqito.matrix_props import is_positive_semidefinite, is_square
 
 
-def is_k_incoherent(mat: np.ndarray, k: int, tol: float = 1e-15) -> bool:
+def is_k_incoherent(
+    mat: np.ndarray, k: int, rtol: float = 1e-05, atol: float = 1e-15, *, tol: float | None = None
+) -> bool:
     r"""Determine whether a quantum state is k-incoherent [@johnston2022absolutely].
 
     For a positive integers, \(k\) and \(n\), the matrix \(X \in \text{Pos}(\mathbb{C}^n)\) is called
@@ -32,7 +35,9 @@ def is_k_incoherent(mat: np.ndarray, k: int, tol: float = 1e-15) -> bool:
     Args:
         mat: Density matrix to test.
         k: The positive integer coherence level.
-        tol: Tolerance for numerical comparisons (default is 1e-15).
+        rtol: Relative tolerance for the diagonal comparison (default 1e-05).
+        atol: Absolute tolerance for the diagonal comparison (default 1e-15).
+        tol: Deprecated alias retained for backward compatibility; if given it sets ``atol``.
 
     Returns:
         True if `mat` is k-incoherent, False otherwise.
@@ -57,6 +62,14 @@ def is_k_incoherent(mat: np.ndarray, k: int, tol: float = 1e-15) -> bool:
             [is_absolutely_k_incoherent()][toqito.matrix_props.is_absolutely_k_incoherent.is_absolutely_k_incoherent]
 
     """
+    if tol is not None:
+        warnings.warn(
+            "`tol` is deprecated; use `rtol` and `atol` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        atol = tol
+
     if k <= 0:
         raise ValueError("k must be a positive integer.")
     if not is_square(mat):
@@ -68,7 +81,7 @@ def is_k_incoherent(mat: np.ndarray, k: int, tol: float = 1e-15) -> bool:
         return True
 
     # If `mat` is diagonal, it is declared k-incoherent.
-    if np.allclose(mat, np.diag(np.diag(mat)), atol=tol):
+    if np.allclose(mat, np.diag(np.diag(mat)), rtol=rtol, atol=atol):
         return True
 
     # For k == 1, only diagonal states are 1-incoherent.
@@ -89,7 +102,7 @@ def is_k_incoherent(mat: np.ndarray, k: int, tol: float = 1e-15) -> bool:
         return True
 
     # Hierarchical recursion: for k >= 2 check incoherence for k-1.
-    rec = is_k_incoherent(mat, k - 1)
+    rec = is_k_incoherent(mat, k - 1, rtol=rtol, atol=atol)
     if rec is not None and rec is not False:
         return rec
 

--- a/toqito/matrix_props/is_rank_one.py
+++ b/toqito/matrix_props/is_rank_one.py
@@ -1,17 +1,24 @@
 """Checks if a matrix has rank one."""
 
+import warnings
+
 import numpy as np
 
 
-def is_rank_one(mat: np.ndarray, tol: float = 1e-08) -> bool:
+def is_rank_one(mat: np.ndarray, rtol: float = 1e-08, atol: float = 1e-08, *, tol: float | None = None) -> bool:
     r"""Determine whether the given matrix has rank one [@wikipediarank].
 
     The function evaluates the singular values (equivalently, eigenvalues for Hermitian matrices)
-    and counts how many are greater than the provided tolerance.
+    and counts how many exceed the threshold ``rtol * max_singular_value`` (or ``atol`` when the
+    matrix has no singular values).
 
     Args:
         mat: Matrix to test.
-        tol: Numerical tolerance used when distinguishing non-zero singular values.
+        rtol: Relative tolerance, applied to the largest singular value (default 1e-08).
+        atol: Absolute tolerance, used as the threshold when there are no singular values
+            (default 1e-08).
+        tol: Deprecated alias retained for backward compatibility; if given it sets both ``rtol``
+            and ``atol``.
 
     Returns:
         `True` if the matrix has rank at most one, `False` otherwise.
@@ -39,7 +46,15 @@ def is_rank_one(mat: np.ndarray, tol: float = 1e-08) -> bool:
         ```
 
     """
+    if tol is not None:
+        warnings.warn(
+            "`tol` is deprecated; use `rtol` and `atol` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        rtol = atol = tol
+
     singular_values = np.linalg.svd(mat, compute_uv=False)
     # Threshold relative to the largest singular value so the result is independent of the matrix scale.
-    threshold = tol * singular_values.max() if singular_values.size else tol
+    threshold = rtol * singular_values.max() if singular_values.size else atol
     return bool(np.count_nonzero(singular_values > threshold) <= 1)

--- a/toqito/matrix_props/is_totally_positive.py
+++ b/toqito/matrix_props/is_totally_positive.py
@@ -1,11 +1,19 @@
 """Checks if the matrix is totally positive."""
 
+import warnings
 from itertools import combinations
 
 import numpy as np
 
 
-def is_totally_positive(mat: np.ndarray, tol: float = 1e-6, sub_sizes: list | None = None) -> bool:
+def is_totally_positive(
+    mat: np.ndarray,
+    rtol: float = 0.0,
+    atol: float = 1e-6,
+    sub_sizes: list | None = None,
+    *,
+    tol: float | None = None,
+) -> bool:
     r"""Determine whether a matrix is totally positive [@wikipediatotallypositive].
 
     A totally positive matrix is a square matrix where all the minors are positive. Equivalently, the determinant of
@@ -13,8 +21,11 @@ def is_totally_positive(mat: np.ndarray, tol: float = 1e-6, sub_sizes: list | No
 
     Args:
         mat: Matrix to check.
-        tol: The absolute tolerance parameter (default 1e-06).
+        rtol: Relative tolerance applied (against the largest matrix entry) when testing entries
+            for negativity. Defaults to ``0.0``, so by default only ``atol`` is used.
+        atol: Absolute tolerance parameter (default 1e-06).
         sub_sizes: List of sizes of submatrices to consider. Default is all sizes up to `min(mat.shape)`.
+        tol: Deprecated alias retained for backward compatibility; if given it sets ``atol``.
 
     Returns:
         Return `True` if matrix is totally positive, and `False` otherwise.
@@ -88,10 +99,21 @@ def is_totally_positive(mat: np.ndarray, tol: float = 1e-6, sub_sizes: list | No
         ```
 
     """
+    if tol is not None:
+        warnings.warn(
+            "`tol` is deprecated; use `atol` (and optionally `rtol`) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        atol = tol
+
     if mat.size == 0:
         raise ValueError("Empty matrix to be neither totally positive nor not totally positive.")
 
     dims = mat.shape
+
+    # Entries are flagged as negative when they fall below the combined relative/absolute threshold.
+    neg_thresh = atol + rtol * np.abs(mat).max()
 
     if sub_sizes is None:
         sub_sizes = range(1, min(dims) + 1)
@@ -99,7 +121,7 @@ def is_totally_positive(mat: np.ndarray, tol: float = 1e-6, sub_sizes: list | No
     for j in sub_sizes:
         # Handle 1x1 determinants separately.
         if j == 1:
-            r, _ = np.where(np.minimum(np.real(mat), -np.abs(np.imag(mat))) < -tol)
+            r, _ = np.where(np.minimum(np.real(mat), -np.abs(np.imag(mat))) < -neg_thresh)
             if r.size > 0:
                 return False
 
@@ -111,6 +133,6 @@ def is_totally_positive(mat: np.ndarray, tol: float = 1e-6, sub_sizes: list | No
             for kr in sub_ind_r:
                 for kc in sub_ind_c:
                     d = np.linalg.det(mat[np.ix_(kr, kc)])
-                    if d < tol or abs(np.imag(d)) > tol:
+                    if d < atol or abs(np.imag(d)) > atol:
                         return False
     return True

--- a/toqito/matrix_props/tests/test_is_k_incoherent.py
+++ b/toqito/matrix_props/tests/test_is_k_incoherent.py
@@ -175,6 +175,13 @@ def test_sdp_branch(mat, k, expected):
     assert is_k_incoherent(mat, k) is True
 
 
+def test_is_k_incoherent_deprecated_tol_alias_warns():
+    """The deprecated `tol` keyword still works but emits a DeprecationWarning."""
+    diag = np.diag([0.5, 0.5])
+    with pytest.warns(DeprecationWarning, match="tol"):
+        assert is_k_incoherent(diag, 1, tol=1e-15) is True
+
+
 def test_non_square():
     """Ensure non-square input is flagged."""
     # Construct a non-square matrix.
@@ -197,11 +204,11 @@ def test_hierarchical_recursion(monkeypatch):
     orig_is_k_incoherent = is_k_incoherent
 
     # Monkey-patch is_k_incoherent so that when called with k == 2 it returns True.
-    def fake_is_k_incoherent(mat, k, tol=1e-15):
+    def fake_is_k_incoherent(mat, k, rtol=1e-05, atol=1e-15, *, tol=None):
         if k == 2:
             return True
         else:
-            return orig_is_k_incoherent(mat, k, tol)
+            return orig_is_k_incoherent(mat, k, rtol=rtol, atol=atol)
 
     monkeypatch.setattr("toqito.matrix_props.is_k_incoherent", fake_is_k_incoherent)
 
@@ -224,11 +231,11 @@ def test_hierarchical_recursion_branch():
     orig_is_k_incoherent = is_k_incoherent.__globals__["is_k_incoherent"]
 
     # Override is_k_incoherent so that when called with k==2 it returns True.
-    def fake_is_k_incoherent(mat, k, tol=1e-15):
+    def fake_is_k_incoherent(mat, k, rtol=1e-05, atol=1e-15, *, tol=None):
         if k == 2:
             return True
         else:
-            return orig_is_k_incoherent(mat, k, tol)
+            return orig_is_k_incoherent(mat, k, rtol=rtol, atol=atol)
 
     # Patch the global lookup so that recursive calls use fake_is_k_incoherent.
     is_k_incoherent.__globals__["is_k_incoherent"] = fake_is_k_incoherent

--- a/toqito/matrix_props/tests/test_is_rank_one.py
+++ b/toqito/matrix_props/tests/test_is_rank_one.py
@@ -28,9 +28,16 @@ def test_full_rank_matrix_returns_false(matrix):
 
 
 def test_small_singular_values_respected_by_tolerance():
-    """Ensure the tolerance parameter is honoured."""
+    """Ensure the relative tolerance parameter is honoured."""
     singular_values = np.diag([1.0, 1e-9])
-    np.testing.assert_equal(is_rank_one(singular_values, tol=1e-8), True)
+    np.testing.assert_equal(is_rank_one(singular_values, rtol=1e-8), True)
+
+
+def test_deprecated_tol_alias_warns():
+    """The deprecated `tol` keyword still works but emits a DeprecationWarning."""
+    singular_values = np.diag([1.0, 1e-9])
+    with pytest.warns(DeprecationWarning, match="tol"):
+        np.testing.assert_equal(is_rank_one(singular_values, tol=1e-8), True)
 
 
 def test_is_rank_one_scale_invariant():

--- a/toqito/matrix_props/tests/test_is_totally_positive.py
+++ b/toqito/matrix_props/tests/test_is_totally_positive.py
@@ -35,7 +35,7 @@ from toqito.matrix_props import is_totally_positive
 )
 def test_is_totally_positive(mat, tol, sub_sizes, expected_result):
     """Test function works as expected for a valid input."""
-    np.testing.assert_equal(is_totally_positive(mat, tol, sub_sizes), expected_result)
+    np.testing.assert_equal(is_totally_positive(mat, atol=tol, sub_sizes=sub_sizes), expected_result)
 
 
 @pytest.mark.parametrize(
@@ -48,4 +48,10 @@ def test_is_totally_positive(mat, tol, sub_sizes, expected_result):
 def test_is_totally_positive_invalid(mat, tol, sub_sizes):
     """Test function works as expected for an invalid input."""
     with np.testing.assert_raises(ValueError):
-        is_totally_positive(mat, tol, sub_sizes)
+        is_totally_positive(mat, atol=tol, sub_sizes=sub_sizes)
+
+
+def test_is_totally_positive_deprecated_tol_alias_warns():
+    """The deprecated `tol` keyword still works but emits a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="tol"):
+        np.testing.assert_equal(is_totally_positive(np.array([[1, 2], [2, 5]]), tol=1e-6), True)

--- a/toqito/state_props/learnability.py
+++ b/toqito/state_props/learnability.py
@@ -237,7 +237,7 @@ def _convert_states(
         density_matrices.append(rho)
 
         if all_pure:
-            if is_rank_one(rho, tol=tol):
+            if is_rank_one(rho, rtol=tol):
                 pure_vectors.append(_extract_state_vector(state_array, rho))
             else:
                 all_pure = False


### PR DESCRIPTION
Closes #1668.

These predicates exposed a single `tol` while `is_hermitian`, `is_unitary`, `is_positive_semidefinite`, and `is_circulant` use `rtol`/`atol`, so callers could not pass tolerances uniformly across related checks.

All three now expose an `rtol`/`atol` interface, with `tol` retained as a deprecated keyword-only alias that maps to the appropriate parameter and emits a `DeprecationWarning`.

Defaults preserve existing behavior:
- `is_rank_one`: threshold `rtol * max_singular_value` (rtol=1e-08), with atol=1e-08 as the fallback when there are no singular values.
- `is_totally_positive`: atol=1e-06 (the old absolute tolerance); rtol defaults to 0.0 so default behavior is unchanged, with rtol available for a relative entry threshold.
- `is_k_incoherent`: `np.allclose(rtol=1e-05, atol=1e-15)`, matching the old `np.allclose(atol=1e-15)` plus numpy's default rtol; the recursive call forwards both.

The internal `is_rank_one` caller in `learnability` now passes `rtol`.