### PR TITLE
Align channel_distinguishability and channel_exclusion with state_* conventions

### DIFF
--- a/toqito/channel_metrics/channel_distinguishability.py
+++ b/toqito/channel_metrics/channel_distinguishability.py
@@ -13,13 +13,13 @@ from toqito.channel_props.channel_dim import channel_dim
 def channel_distinguishability(
     phi: np.ndarray | list[np.ndarray] | list[list[np.ndarray]],
     psi: np.ndarray | list[np.ndarray] | list[list[np.ndarray]],
-    p: list[float] | None,
+    probs: list[float] | None = None,
     dim: int | list[int] | np.ndarray | None = None,
     strategy: str = "bayesian",
     solver: str = "cvxopt",
     primal_dual: str = "dual",
     **kwargs: Any,
-) -> float | np.floating:
+) -> tuple[float, list[np.ndarray]]:
     r"""Compute the optimal probability of distinguishing two quantum channels.
 
     Bayesian and minimax discrimination of two quantum channels are implemented.
@@ -44,7 +44,9 @@ def channel_distinguishability(
              or as a (1d or 2d) list of numpy arrays whose entries are its Kraus operators.
         psi: A superoperator. It should be provided either as a Choi matrix,
              or as a (1d or 2d) list of numpy arrays whose entries are its Kraus operators.
-        p: Prior probabilities of the two channels.
+        probs: Prior weights of the two channels (Bayesian strategy only). If omitted, a uniform
+            distribution is used. Weights need not be normalized (matching ``state_exclusion``);
+            they are normalized internally.
         dim: Input and output dimensions of the channels.
         strategy: Whether to perform Bayesian or minimax discrimination task. Possible
                   values are "Bayesian" and "minimax". Default option is `strategy="Bayesian"`.
@@ -53,13 +55,15 @@ def channel_distinguishability(
         kwargs: Additional arguments to pass to picos' solve method.
 
     Returns:
-        The optimal probability of discriminating two quantum channels.
+        A tuple ``(value, operators)``. ``value`` is the optimal probability of discriminating the
+        two channels. ``operators`` holds the optimal strategy operators for the minimax SDP
+        branches (the measurement operators for ``primal_dual="primal"`` and the dual operator for
+        ``primal_dual="dual"``) and is an empty list for the closed-form Bayesian branch.
 
     Raises:
-        ValueError: If prior probabilities not provided at all for Bayesian strategy.
         ValueError: If strategy is neither Bayesian nor minimax.
         ValueError: If channels have different input or output dimensions.
-        ValueError: If prior probabilities do not add up to 1.
+        ValueError: If the prior weights are negative or sum to zero.
         ValueError: If number of prior probabilities not equal to 2.
 
     Examples:
@@ -73,9 +77,10 @@ def channel_distinguishability(
         choi_ch_1 = kraus_to_choi(amplitude_damping(gamma=0.25, return_kraus_ops=True))
         choi_ch_2 = kraus_to_choi(amplitude_damping(gamma=0.5, return_kraus_ops=True))
 
-        p = [0.5, 0.5]
+        probs = [0.5, 0.5]
 
-        print(channel_distinguishability(choi_ch_1, choi_ch_2, p))
+        value, _ = channel_distinguishability(choi_ch_1, choi_ch_2, probs)
+        print(value)
         ```
 
         Optimal probability of distinguishing two amplitude damping channels in the minimax setting:
@@ -88,7 +93,10 @@ def channel_distinguishability(
         choi_ch_1 = kraus_to_choi(amplitude_damping(gamma=0.25, return_kraus_ops=True))
         choi_ch_2 = kraus_to_choi(amplitude_damping(gamma=0.5, return_kraus_ops=True))
 
-        print(channel_distinguishability(choi_ch_1, choi_ch_2, None, [2, 2], strategy="minimax",primal_dual="primal"))
+        value, _ = channel_distinguishability(
+            choi_ch_1, choi_ch_2, None, [2, 2], strategy="minimax", primal_dual="primal"
+        )
+        print(value)
         ```
 
     """
@@ -118,20 +126,26 @@ def channel_distinguishability(
         raise ValueError("The channels must have the same dimension input and output spaces as each other.")
 
     if strategy.lower() == "bayesian":
-        if p is None:
-            raise ValueError("Must provide valid prior probabilities for Bayesian strategy.")
+        # Default to a uniform prior, and accept unnormalized weights (matching state_exclusion).
+        probs = [1 / 2, 1 / 2] if probs is None else probs
 
-        if len(p) != 2:
-            raise ValueError("p must be a probability distribution with 2 entries.")
+        if len(probs) != 2:
+            raise ValueError("probs must be a probability distribution with 2 entries.")
 
-        if max(p) >= 1:
-            return 1
+        probs_arr = np.array(probs, dtype=float)
+        if np.any(probs_arr < 0):
+            raise ValueError("Prior probabilities must be non-negative.")
+        probs_sum = float(np.sum(probs_arr))
+        if probs_sum <= 0:
+            raise ValueError("Prior probabilities must have a positive sum.")
+        probs_arr = probs_arr / probs_sum
 
-        if abs(sum(p) - 1) != 0:
-            raise ValueError("Sum of prior probabilities must add up to 1.")
+        if max(probs_arr) >= 1:
+            return 1.0, []
 
         # optimal success probability is minimizing error probability (Bayes risk).
-        return 1 / 2 * (1 + completely_bounded_trace_norm(p[0] * phi - p[1] * psi))
+        value = 1 / 2 * (1 + completely_bounded_trace_norm(probs_arr[0] * phi - probs_arr[1] * psi))
+        return float(value), []
 
     if primal_dual == "primal":
         return _minimax_primal(phi, psi, d_in_phi[0], d_out_phi[0], solver=solver, **kwargs)
@@ -146,7 +160,7 @@ def _minimax_dual(
     dimB: int,
     solver: str = "cvxopt",
     **kwargs,
-) -> float:
+) -> tuple[float, list[np.ndarray]]:
     """Find the dual problem for minimax quantum channel distinguishability SDP."""
     J_var = list([phi, psi])
 
@@ -168,7 +182,7 @@ def _minimax_dual(
 
     problem.solve(solver=solver, **kwargs)
 
-    return problem.value
+    return problem.value, [np.array(Y_var.value)]
 
 
 def _minimax_primal(
@@ -178,7 +192,7 @@ def _minimax_primal(
     dimB: int,
     solver: str = "cvxopt",
     **kwargs,
-) -> float:
+) -> tuple[float, list[np.ndarray]]:
     """Find the primal problem for minimax quantum channel distinguishability SDP."""
     J_var = list([phi, psi])
 
@@ -198,4 +212,4 @@ def _minimax_primal(
 
     problem.solve(solver=solver, **kwargs)
 
-    return problem.value
+    return problem.value, [np.array(var.value) for var in P_var]

--- a/toqito/channel_metrics/channel_exclusion.py
+++ b/toqito/channel_metrics/channel_exclusion.py
@@ -82,7 +82,8 @@ def channel_exclusion(
 
     Args:
         channels: List of channels, each provided as a Choi matrix or as Kraus operators.
-        probs: Prior probabilities for the channels. If omitted, a uniform distribution is used.
+        probs: Prior weights for the channels. If omitted, a uniform distribution is used. Weights
+            need not be normalized (matching ``state_exclusion``); they are normalized internally.
         strategy: Exclusion strategy. In Phase 1, only `"min_error"` is implemented.
         solver: Optimization option for `picos` solver. Default is `"cvxopt"`.
         primal_dual: Option for the optimization problem (`"primal"` or `"dual"`).
@@ -123,8 +124,10 @@ def channel_exclusion(
         raise ValueError("Prior probabilities must be non-negative.")
 
     probs_sum = float(np.sum(probs_arr))
-    if abs(probs_sum - 1) > PROBABILITY_TOLERANCE:
-        raise ValueError("Prior probabilities must sum to 1 within tolerance.")
+    if probs_sum <= PROBABILITY_TOLERANCE:
+        raise ValueError("Prior probabilities must have a positive sum.")
+    # Accept unnormalized weights (matching state_exclusion, e.g. antidistinguishability passes
+    # [1, ..., 1]) by normalizing internally.
     probs_arr = probs_arr / probs_sum
 
     choi_channels: list[np.ndarray] = []

--- a/toqito/channel_metrics/tests/test_channel_distinguishability.py
+++ b/toqito/channel_metrics/tests/test_channel_distinguishability.py
@@ -11,8 +11,8 @@ amp_damp_1 = kraus_to_choi(amplitude_damping(gamma=0.22, return_kraus_ops=True))
 amp_damp_2 = kraus_to_choi(amplitude_damping(gamma=0.35, return_kraus_ops=True))
 
 # In Kraus representation.
-amp_damp_1_kraus = amplitude_damping(gamma=0.22)
-amp_damp_2_kraus = amplitude_damping(gamma=0.35)
+amp_damp_1_kraus = amplitude_damping(gamma=0.22, return_kraus_ops=True)
+amp_damp_2_kraus = amplitude_damping(gamma=0.35, return_kraus_ops=True)
 
 # Creating two phase damping channels.
 ph_damp_1 = kraus_to_choi(phase_damping(gamma=0.22, return_kraus_ops=True))
@@ -30,14 +30,17 @@ ph_damp_2 = kraus_to_choi(phase_damping(gamma=0.35, return_kraus_ops=True))
         (amp_damp_1_kraus, amp_damp_2, [0.2, 0.8], [2, 2], 0.8),
         # Both channels in Kraus representation.
         (amp_damp_1_kraus, amp_damp_2_kraus, [0.2, 0.8], [2, 2], 0.8),
-        # Same as previous channels but max(p) > 1.
-        (amp_damp_1_kraus, amp_damp_2, [0.2, 1.8], [2, 2], 1),
+        # Degenerate prior (certain which channel): trivially distinguishable.
+        (amp_damp_1_kraus, amp_damp_2, [1.0, 0.0], [2, 2], 1),
+        # Unnormalized weights are accepted and normalized internally ([2, 8] -> [0.2, 0.8]).
+        (amp_damp_1, amp_damp_2, [2, 8], [2, 2], 0.8),
     ],
 )
 def test_channel_distinguishability_bayesian(test_input_1, test_input_2, prior_prob, dim, expected):
     """Test function for Bayesian channel discrimination."""
-    calculated_value = channel_distinguishability(test_input_1, test_input_2, prior_prob, dim)
+    calculated_value, operators = channel_distinguishability(test_input_1, test_input_2, prior_prob, dim)
     assert pytest.approx(expected, 1e-3) == calculated_value
+    assert operators == []
 
 
 @pytest.mark.parametrize(
@@ -51,7 +54,7 @@ def test_channel_distinguishability_bayesian(test_input_1, test_input_2, prior_p
 )
 def test_channel_distinguishability_minimax(test_input_1, test_input_2, prior_prob, dim, primal_dual, expected):
     """Test function for minimax channel discrimination."""
-    calculated_value = channel_distinguishability(
+    calculated_value, operators = channel_distinguishability(
         test_input_1,
         test_input_2,
         prior_prob,
@@ -60,6 +63,8 @@ def test_channel_distinguishability_minimax(test_input_1, test_input_2, prior_pr
         primal_dual=primal_dual,
     )
     assert pytest.approx(expected, 1e-3) == calculated_value
+    # The minimax SDP branches return optimal strategy operators.
+    assert len(operators) >= 1
 
 
 @pytest.mark.parametrize(
@@ -131,29 +136,29 @@ def test_channel_distinguishability_invalid_primal_dual():
 @pytest.mark.parametrize(
     "test_input1, test_input_2, prior_prob, dim, expected_msg",
     [
-        # Sum of prior probabilities greater than 1.
-        (
-            dephasing(2),
-            dephasing(2),
-            [0.5, 0.9],
-            [2, 2],
-            "Sum of prior probabilities must add up to 1.",
-        ),
         # Length of prior probability list not equal to two.
         (
             dephasing(2),
             dephasing(2),
             [0.5],
             [2, 2],
-            "p must be a probability distribution with 2 entries.",
+            "probs must be a probability distribution with 2 entries.",
         ),
-        # Prior probability must be provided for Bayesian strategy.
+        # Negative weights are rejected.
         (
             dephasing(2),
             dephasing(2),
-            None,
+            [-0.5, 1.5],
             [2, 2],
-            "Must provide valid prior probabilities for Bayesian strategy.",
+            "Prior probabilities must be non-negative.",
+        ),
+        # Weights summing to zero are rejected.
+        (
+            dephasing(2),
+            dephasing(2),
+            [0.0, 0.0],
+            [2, 2],
+            "Prior probabilities must have a positive sum.",
         ),
     ],
 )
@@ -161,3 +166,10 @@ def test_bayesian_channel_distinguishability_invalid_inputs(test_input1, test_in
     """Test function raises error as expected for invalid inputs for bayesian setting."""
     with pytest.raises(ValueError, match=expected_msg):
         channel_distinguishability(test_input1, test_input_2, prior_prob, dim)
+
+
+def test_bayesian_channel_distinguishability_uniform_default():
+    """When probs is omitted, the Bayesian strategy uses a uniform prior."""
+    value_default, _ = channel_distinguishability(dephasing(2), dephasing(2), None, [2, 2])
+    value_uniform, _ = channel_distinguishability(dephasing(2), dephasing(2), [0.5, 0.5], [2, 2])
+    assert pytest.approx(value_uniform, 1e-6) == value_default

--- a/toqito/channel_metrics/tests/test_channel_exclusion.py
+++ b/toqito/channel_metrics/tests/test_channel_exclusion.py
@@ -47,12 +47,21 @@ def test_channel_exclusion_primal_dual_agree_mixed_representations():
     assert abs(primal_value - dual_value) <= 1e-5
 
 
-def test_channel_exclusion_invalid_probability_sum():
-    """Probabilities must sum to 1 up to a small tolerance."""
+def test_channel_exclusion_accepts_unnormalized_weights():
+    """Unnormalized weights are accepted and normalized internally (matching state_exclusion)."""
     channels = [depolarizing(2, 0.2), depolarizing(2, 0.9)]
 
-    with pytest.raises(ValueError, match="Prior probabilities must sum to 1 within tolerance."):
-        channel_exclusion(channels=channels, probs=[0.7, 0.4])
+    val_unnormalized, _ = channel_exclusion(channels=channels, probs=[2.0, 2.0])
+    val_normalized, _ = channel_exclusion(channels=channels, probs=[0.5, 0.5])
+    assert val_unnormalized == pytest.approx(val_normalized, abs=1e-6)
+
+
+def test_channel_exclusion_invalid_probability_sum():
+    """Weights summing to zero are rejected."""
+    channels = [depolarizing(2, 0.2), depolarizing(2, 0.9)]
+
+    with pytest.raises(ValueError, match="Prior probabilities must have a positive sum."):
+        channel_exclusion(channels=channels, probs=[0.0, 0.0])
 
 
 def test_channel_exclusion_invalid_number_of_channels():


### PR DESCRIPTION
Closes #1665.

The analogous discrimination entry points diverged on naming, defaults, normalization, and return shapes. `channel_distinguishability(p, ...) -> float` named the prior `p`, required it positionally, and returned a scalar; `channel_exclusion(probs=None, ...) -> tuple` named it `probs`, defaulted to None, and returned operators too. `channel_exclusion` also required `probs` to sum to 1 while `state_exclusion` accepts unnormalized weights (antidistinguishability passes `[1]*n`), so the same weights were rejected by one API and accepted by the other.

This aligns both on the `state_*` convention:

- `channel_distinguishability`: rename `p` to `probs`, default it to `None` (uniform), and accept unnormalized weights (normalized internally) instead of requiring an exact sum of 1. It now returns a `(value, operators)` tuple like `channel_exclusion` and the `state_*` functions: the optimal strategy operators for the minimax SDP branches (measurement operators for primal, the dual operator for dual), and an empty list for the closed-form Bayesian branch.
- `channel_exclusion`: stop rejecting unnormalized weights. It previously raised when weights did not sum to 1 even though it normalized them immediately afterward; it now normalizes any non-negative weights with a positive sum.

Tests and docstrings are updated for the new return shape and normalization semantics. This changes `channel_distinguishability`'s return type (float -> tuple), which is a breaking change.