### PR TITLE
Order the example gallery subsections pedagogically

### DIFF
--- a/docs/content/gallery_conf.py
+++ b/docs/content/gallery_conf.py
@@ -1,0 +1,49 @@
+"""mkdocs-gallery configuration for the example gallery.
+
+This sets the order in which the gallery subsections are listed on the gallery index:
+
+    Basic Tutorials -> Quantum States -> Nonlocal Games -> Extended Nonlocal Games
+
+mkdocs-gallery 0.10.4 (the latest release) has a bug in ``Gallery.populate_subsections``:
+the subsection sort key is wrapped in a nested function that calls itself instead of the
+underlying key, so any non-``None`` ``subsection_order`` raises ``RecursionError`` (and the
+key is handed a ``str`` rather than the ``Path`` that ``ExplicitOrder`` expects). Until that
+is fixed upstream, replace the method with a corrected copy that applies the sort key
+directly. Once mkdocs-gallery ships a fix, this monkeypatch can be dropped and only the
+``conf`` dict below is needed.
+"""
+
+from mkdocs_gallery.gen_data_model import Gallery, GallerySubSection, _has_readme
+from mkdocs_gallery.sorting import ExplicitOrder
+
+# Pedagogical order rather than the alphabetical default. Every subsection directory must be
+# listed here (ExplicitOrder raises for any folder it does not find).
+SUBSECTION_ORDER = ExplicitOrder(
+    [
+        "basics",
+        "quantum_states",
+        "nonlocal_games",
+        "extended_nonlocal_games",
+    ]
+)
+
+
+def _populate_subsections(self) -> None:
+    """Corrected copy of ``Gallery.populate_subsections`` (mkdocs-gallery 0.10.4 bugfix)."""
+    assert self.subsections is None, "This method can only be called once !"  # noqa: S101
+
+    subfolders = [
+        subfolder for subfolder in self.scripts_dir.iterdir() if subfolder.is_dir() and _has_readme(subfolder)
+    ]
+
+    sortkey = self.conf["subsection_order"]
+    sorted_subfolders = sorted(subfolders, key=sortkey) if sortkey is not None else sorted(subfolders)
+
+    self.subsections = tuple(
+        GallerySubSection(self, subpath=f.relative_to(self.scripts_dir)) for f in sorted_subfolders
+    )
+
+
+Gallery.populate_subsections = _populate_subsections
+
+conf = {"subsection_order": SUBSECTION_ORDER}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -79,6 +79,7 @@ plugins:
         - "re:.*\\.tests($|\\.)"
   
   - gallery:
+      conf_script: content/gallery_conf.py
       examples_dirs: content/examples
       gallery_dirs: content/generated/gallery
       filename_pattern: \.py$


### PR DESCRIPTION
The gallery index listed subsections alphabetically (Basic Tutorials, Extended Nonlocal Games, Nonlocal Games, Quantum States). This orders them as Basic Tutorials, Quantum States, Nonlocal Games, Extended Nonlocal Games.

mkdocs-gallery's `subsection_order` is the intended mechanism, but its 0.10.4 release (the latest) has a bug in `Gallery.populate_subsections`: the sort key is wrapped in a nested function that calls itself instead of the underlying key, so any `subsection_order` raises `RecursionError` (and the key is handed a `str` rather than the `Path` that `ExplicitOrder` expects).

This adds a gallery `conf_script` (`docs/content/gallery_conf.py`) that sets an `ExplicitOrder` and, until the upstream bug is fixed, patches `populate_subsections` with a corrected copy that applies the sort key directly. The example directories are unchanged, so tutorial URLs are unaffected.

Verified with a local `mkdocs build`: the gallery generates and the index lists the sections in the new order with no RecursionError.