### PR TITLE
feat(channel_props): add is_channel_antidistinguishable

### DIFF
--- a/toqito/channel_props/__init__.py
+++ b/toqito/channel_props/__init__.py
@@ -6,6 +6,7 @@ import sys
 __all__ = [
     "channel_dim",
     "choi_rank",
+    "is_channel_antidistinguishable",
     "is_completely_positive",
     "is_extremal",
     "is_herm_preserving",

--- a/toqito/channel_props/is_channel_antidistinguishable.py
+++ b/toqito/channel_props/is_channel_antidistinguishable.py
@@ -1,5 +1,7 @@
 """Check if a set of quantum channels is antidistinguishable."""
 
+from typing import Any
+
 import numpy as np
 
 from toqito.channel_metrics import channel_exclusion
@@ -9,7 +11,7 @@ def is_channel_antidistinguishable(
     channels: list[np.ndarray | list[np.ndarray] | list[list[np.ndarray]]],
     solver: str = "cvxopt",
     atol: float = 1e-6,
-    **kwargs,
+    **kwargs: Any,
 ) -> bool:
     r"""Check whether a collection of quantum channels is antidistinguishable.
 

--- a/toqito/channel_props/is_channel_antidistinguishable.py
+++ b/toqito/channel_props/is_channel_antidistinguishable.py
@@ -1,0 +1,73 @@
+"""Check if a set of quantum channels is antidistinguishable."""
+
+import numpy as np
+
+from toqito.channel_metrics import channel_exclusion
+
+
+def is_channel_antidistinguishable(
+    channels: list[np.ndarray | list[np.ndarray] | list[list[np.ndarray]]],
+    solver: str = "cvxopt",
+    atol: float = 1e-6,
+    **kwargs,
+) -> bool:
+    r"""Check whether a collection of quantum channels is antidistinguishable.
+
+    A set of channels \(\{\Xi_1, \ldots, \Xi_n\}\) is *antidistinguishable* if there is a single-shot
+    strategy (an input state, possibly entangled with an ancilla, together with a measurement on the
+    output) that, for whichever channel was actually applied, never reports that channel. Equivalently,
+    the set is antidistinguishable if and only if the minimum-error channel *exclusion* problem has
+    optimal value zero, i.e. the true channel can always be ruled out. This mirrors state
+    antidistinguishability [@heinosaari2018antidistinguishability] lifted to channels, and is decided
+    here via the channel exclusion SDP (Section 3.5 of [@watrous2018theory]).
+
+    The optimal value is obtained from
+    [`channel_exclusion`][toqito.channel_metrics.channel_exclusion.channel_exclusion] with uniform
+    prior weights; the set is antidistinguishable exactly when that value is (numerically) zero. The
+    less computationally intensive dual formulation is used, matching
+    [`is_antidistinguishable`][toqito.state_props.is_antidistinguishable.is_antidistinguishable].
+
+    Args:
+        channels: A list of channels, each given either as a Choi matrix or as a list of Kraus
+            operators. All channels must share the same input and output dimensions.
+        solver: Optimization solver passed to `picos`. Default is `"cvxopt"`.
+        atol: Absolute tolerance for deciding whether the optimal exclusion value is zero. The
+            channels are reported antidistinguishable when the value is within `atol` of zero.
+            Default is `1e-6`.
+        kwargs: Additional keyword arguments forwarded to the `picos` solve method.
+
+    Returns:
+        `True` if the channels are antidistinguishable; `False` otherwise.
+
+    Examples:
+        The Choi states of the four Pauli channels are precisely the four Bell states, which are
+        antidistinguishable. Hence the Pauli channels are antidistinguishable:
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.channel_props import is_channel_antidistinguishable
+        pauli_x = np.array([[0, 1], [1, 0]])
+        pauli_y = np.array([[0, -1j], [1j, 0]])
+        pauli_z = np.array([[1, 0], [0, -1]])
+        pauli_channels = [[np.eye(2)], [pauli_x], [pauli_y], [pauli_z]]
+        print(is_channel_antidistinguishable(pauli_channels))
+        ```
+
+        Two identical channels can never be antidistinguishable, since the true channel can never be
+        ruled out:
+
+        ```python exec="1" source="above" result="text"
+        from toqito.channels import depolarizing
+        from toqito.channel_props import is_channel_antidistinguishable
+        print(is_channel_antidistinguishable([depolarizing(2, 0.3), depolarizing(2, 0.3)]))
+        ```
+
+    """
+    opt_val, _ = channel_exclusion(
+        channels,
+        probs=[1] * len(channels),
+        primal_dual="dual",
+        solver=solver,
+        **kwargs,
+    )
+    return bool(np.isclose(opt_val, 0, atol=atol))

--- a/toqito/channel_props/tests/test_is_channel_antidistinguishable.py
+++ b/toqito/channel_props/tests/test_is_channel_antidistinguishable.py
@@ -1,0 +1,59 @@
+"""Test is_channel_antidistinguishable."""
+
+import numpy as np
+import pytest
+
+from toqito.channel_props import is_channel_antidistinguishable
+from toqito.channels import depolarizing
+from toqito.state_props import is_antidistinguishable
+
+PAULI_X = np.array([[0, 1], [1, 0]])
+PAULI_Y = np.array([[0, -1j], [1j, 0]])
+PAULI_Z = np.array([[1, 0], [0, -1]])
+
+
+@pytest.mark.parametrize(
+    "channels",
+    [
+        # The Choi states of the four Pauli channels are the four (antidistinguishable) Bell states.
+        ([[np.eye(2)], [PAULI_X], [PAULI_Y], [PAULI_Z]]),
+        # Three orthogonal Pauli channels remain antidistinguishable.
+        ([[np.eye(2)], [PAULI_X], [PAULI_Z]]),
+    ],
+)
+def test_is_channel_antidistinguishable_true(channels):
+    """Antidistinguishable sets of channels are detected."""
+    assert is_channel_antidistinguishable(channels)
+
+
+@pytest.mark.parametrize(
+    "channels",
+    [
+        # Two identical channels can never be antidistinguishable.
+        ([depolarizing(2, 0.3), depolarizing(2, 0.3)]),
+        # A pair of distinct but non-orthogonal channels is not antidistinguishable.
+        ([depolarizing(2, 0.2), depolarizing(2, 0.4)]),
+    ],
+)
+def test_is_channel_antidistinguishable_false(channels):
+    """Non-antidistinguishable sets of channels are rejected."""
+    assert not is_channel_antidistinguishable(channels)
+
+
+def test_is_channel_antidistinguishable_atol_is_threaded():
+    """The atol argument controls the zero test on the exclusion value."""
+    # Two identical channels have exclusion value 0.5 (not antidistinguishable at any sane atol),
+    # but a deliberately huge atol forces the value to be treated as zero.
+    channels = [depolarizing(2, 0.3), depolarizing(2, 0.3)]
+    assert not is_channel_antidistinguishable(channels)
+    assert is_channel_antidistinguishable(channels, atol=0.6)
+
+
+def test_is_channel_antidistinguishable_matches_choi_state_antidistinguishability():
+    """For unitary channels, channel antidistinguishability matches Choi-state antidistinguishability."""
+    unitaries = [np.eye(2), PAULI_X, PAULI_Y, PAULI_Z]
+    choi_state_vecs = [U.reshape(-1) / np.sqrt(2) for U in unitaries]
+
+    channel_result = is_channel_antidistinguishable([[U] for U in unitaries])
+    state_result = bool(is_antidistinguishable(choi_state_vecs))
+    assert channel_result == state_result


### PR DESCRIPTION
Adds `channel_props.is_channel_antidistinguishable`, a boolean predicate that
mirrors `state_props.is_antidistinguishable` for quantum channels.

A set of channels is antidistinguishable when there is a single-shot strategy
that can always rule out the channel that was applied. This is decided by the
`channel_exclusion` dual SDP: the set is antidistinguishable exactly when the
minimum-error exclusion value is zero, under uniform prior weights.

Details:
- Accepts channels as Choi matrices or as Kraus operators, matching
  `channel_exclusion`.
- Uses the dual formulation, matching `is_antidistinguishable` on the state side.
- Flagship example: the four Pauli channels are antidistinguishable, since their
  Choi states are the four Bell states.

Independent of the `probability_tolerance` refactor PR; they touch disjoint files.
