### PR TITLE
feat(channel_ops): add channel_gram_matrix

### DIFF
--- a/docs/content/refs.bib
+++ b/docs/content/refs.bib
@@ -1909,6 +1909,12 @@
   url = {https://en.wikipedia.org/wiki/Unitary_matrix},
 }
 
+@misc{wikipediaisometry,
+  author = "Wikipedia",
+  title = "Isometry",
+  url = {https://en.wikipedia.org/wiki/Isometry},
+}
+
 @misc{wikipediavonneumann,
   author = "Wikipedia",
   title = "Von Neumann entropy",

--- a/toqito/channel_ops/__init__.py
+++ b/toqito/channel_ops/__init__.py
@@ -7,3 +7,4 @@ from toqito.channel_ops.kraus_to_choi import kraus_to_choi
 from toqito.channel_ops.dual_channel import dual_channel
 from toqito.channel_ops.complementary_channel import complementary_channel
 from toqito.channel_ops.natural_representation import natural_representation
+from toqito.channel_ops.channel_gram_matrix import channel_gram_matrix

--- a/toqito/channel_ops/channel_gram_matrix.py
+++ b/toqito/channel_ops/channel_gram_matrix.py
@@ -1,0 +1,87 @@
+"""Weighted Gram matrix of a set of isometry channels."""
+
+import numpy as np
+
+from toqito.matrix_props import is_isometry
+
+
+def channel_gram_matrix(
+    isometries: list[np.ndarray],
+    sigma: np.ndarray | None = None,
+    tol: float = 1e-8,
+) -> np.ndarray:
+    r"""Compute the \(\sigma\)-weighted Gram matrix of a set of isometry channels.
+
+    For isometry channels \(\Xi_i(X) = V_i X V_i^*\) with \(V_i \in \text{U}(\mathcal{X}, \mathcal{Y})\)
+    (that is, \(V_i^* V_i = \mathbb{I}_{\mathcal{X}}\)) and a density operator \(\sigma \in
+    \text{D}(\mathcal{X})\), the \(\sigma\)-weighted Gram matrix is
+
+    \[
+        G(\sigma)_{i,j} = \text{Tr}(V_j^* V_i \sigma).
+    \]
+
+    This equals \(\langle \varphi_i | \varphi_j \rangle\) for the output states \(|\varphi_i\rangle =
+    (V_i \otimes \mathbb{I})|\psi\rangle\) obtained from any purification \(|\psi\rangle\) with
+    \(\text{Tr}_{\mathcal{Z}}(|\psi\rangle\langle\psi|) = \sigma\). The choice \(\sigma =
+    \mathbb{I}_{\mathcal{X}} / \dim(\mathcal{X})\) (the default) corresponds to the maximally
+    entangled input, for which \(G(\sigma)\) is the Gram matrix of the pure Choi states. Unlike the
+    Hilbert-Schmidt inner product \(\langle J(\Xi_i), J(\Xi_j) \rangle = |\text{Tr}(V_i^* V_j)|^2\) of
+    the Choi matrices, this weighted Gram matrix is linear in \(V_j^* V_i\) and carries no dimension
+    factors or squaring of overlaps.
+
+    Args:
+        isometries: A list of isometries \(V_i\), each a `(dim_out, dim_in)` array satisfying
+            \(V_i^* V_i = \mathbb{I}\). A unitary channel is provided by its unitary. All isometries
+            must share the same input and output dimensions.
+        sigma: A `(dim_in, dim_in)` density operator. If omitted, the maximally mixed state
+            \(\mathbb{I} / \dim_{\text{in}}\) is used.
+        tol: Tolerance for the isometry check \(V_i^* V_i = \mathbb{I}\). Default is `1e-8`.
+
+    Returns:
+        The `(n, n)` complex weighted Gram matrix \(G(\sigma)\).
+
+    Raises:
+        ValueError: If fewer than one isometry is provided.
+        ValueError: If the isometries have mismatched dimensions.
+        ValueError: If any provided operator is not an isometry.
+        ValueError: If `sigma` does not match the input dimension.
+
+    Examples:
+        With the default maximally entangled input, the weighted Gram matrix of the Pauli unitaries
+        is the identity, since the Pauli operators are orthogonal with respect to
+        \(\langle A, B \rangle = \text{Tr}(A^* B) / \dim\):
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.channel_ops import channel_gram_matrix
+        paulis = [
+            np.eye(2),
+            np.array([[0, 1], [1, 0]]),
+            np.array([[0, -1j], [1j, 0]]),
+            np.array([[1, 0], [0, -1]]),
+        ]
+        print(np.round(channel_gram_matrix(paulis).real, 6))
+        ```
+
+    """
+    if len(isometries) < 1:
+        raise ValueError("At least one isometry is required.")
+
+    dim_out, dim_in = isometries[0].shape
+    for mat in isometries:
+        if mat.shape != (dim_out, dim_in):
+            raise ValueError("All isometries must share the same input and output dimensions.")
+        if not is_isometry(mat, atol=tol):
+            raise ValueError("Each operator must be an isometry (V^* V = I).")
+
+    if sigma is None:
+        sigma = np.eye(dim_in) / dim_in
+    elif sigma.shape != (dim_in, dim_in):
+        raise ValueError("sigma must be a (dim_in, dim_in) density operator.")
+
+    n = len(isometries)
+    gram = np.zeros((n, n), dtype=complex)
+    for i in range(n):
+        for j in range(n):
+            gram[i, j] = np.trace(isometries[j].conj().T @ isometries[i] @ sigma)
+    return gram

--- a/toqito/channel_ops/tests/test_channel_gram_matrix.py
+++ b/toqito/channel_ops/tests/test_channel_gram_matrix.py
@@ -1,0 +1,64 @@
+"""Test channel_gram_matrix."""
+
+import numpy as np
+import pytest
+
+from toqito.channel_ops import channel_gram_matrix
+
+PAULI_X = np.array([[0, 1], [1, 0]])
+PAULI_Y = np.array([[0, -1j], [1j, 0]])
+PAULI_Z = np.array([[1, 0], [0, -1]])
+PAULIS = [np.eye(2), PAULI_X, PAULI_Y, PAULI_Z]
+
+
+def test_pauli_default_sigma_is_identity():
+    """The Pauli unitaries are orthonormal under Tr(A^* B)/dim, so G(I/d) = I."""
+    gram = channel_gram_matrix(PAULIS)
+    assert np.allclose(gram, np.eye(4))
+
+
+def test_matches_choi_state_gram_for_unitaries():
+    """At sigma = I/d, G(sigma)_ij equals the Choi-state overlap Tr(U_j^* U_i)/d."""
+    unitaries = [np.eye(2), PAULI_X, (PAULI_X + PAULI_Z) / np.sqrt(2)]
+    gram = channel_gram_matrix(unitaries)
+    expected = np.array([[np.trace(unitaries[j].conj().T @ unitaries[i]) / 2 for j in range(3)] for i in range(3)])
+    assert np.allclose(gram, expected)
+
+
+def test_hermitian_gram():
+    """The weighted Gram matrix is Hermitian for a Hermitian sigma."""
+    gram = channel_gram_matrix(PAULIS)
+    assert np.allclose(gram, gram.conj().T)
+
+
+def test_custom_sigma():
+    """A custom density operator is respected."""
+    sigma = np.array([[0.75, 0.0], [0.0, 0.25]])
+    gram = channel_gram_matrix([np.eye(2), PAULI_Z], sigma=sigma)
+    # G_00 = Tr(sigma) = 1; G_01 = Tr(Z sigma) = 0.75 - 0.25 = 0.5.
+    assert np.isclose(gram[0, 0], 1.0)
+    assert np.isclose(gram[0, 1], 0.5)
+
+
+def test_non_isometry_raises():
+    """A non-isometry operator is rejected."""
+    with pytest.raises(ValueError, match="must be an isometry"):
+        channel_gram_matrix([np.eye(2), 2 * np.eye(2)])
+
+
+def test_mismatched_dimensions_raise():
+    """Isometries of differing shape are rejected."""
+    with pytest.raises(ValueError, match="same input and output dimensions"):
+        channel_gram_matrix([np.eye(2), np.eye(3)])
+
+
+def test_wrong_sigma_shape_raises():
+    """A sigma of the wrong shape is rejected."""
+    with pytest.raises(ValueError, match="dim_in, dim_in"):
+        channel_gram_matrix([np.eye(2), PAULI_X], sigma=np.eye(3))
+
+
+def test_empty_raises():
+    """At least one isometry is required."""
+    with pytest.raises(ValueError, match="At least one isometry"):
+        channel_gram_matrix([])

--- a/toqito/matrix_props/__init__.py
+++ b/toqito/matrix_props/__init__.py
@@ -21,6 +21,7 @@ from toqito.matrix_props.is_positive_definite import is_positive_definite
 from toqito.matrix_props.is_commuting import is_commuting
 from toqito.matrix_props.is_projection import is_projection
 from toqito.matrix_props.is_unitary import is_unitary
+from toqito.matrix_props.is_isometry import is_isometry
 from toqito.matrix_props.majorizes import majorizes
 from toqito.matrix_props.sk_norm import sk_operator_norm
 from toqito.matrix_props.is_block_positive import is_block_positive

--- a/toqito/matrix_props/is_isometry.py
+++ b/toqito/matrix_props/is_isometry.py
@@ -1,0 +1,66 @@
+"""Checks if the matrix is an isometry."""
+
+import numpy as np
+
+
+def is_isometry(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
+    r"""Check if a matrix is an isometry [@wikipediaisometry].
+
+    A matrix \(V \in \text{L}(\mathcal{X}, \mathcal{Y})\) is an isometry if it preserves inner
+    products, equivalently if its columns are orthonormal, that is if
+
+    \[
+        V^* V = \mathbb{I}_{\mathcal{X}},
+    \]
+
+    where \(\mathbb{I}_{\mathcal{X}}\) is the identity on the input space. The matrix need not be
+    square; this requires \(\dim(\mathcal{Y}) \geq \dim(\mathcal{X})\). A square isometry is a unitary
+    matrix.
+
+    Args:
+        mat: Matrix to check.
+        rtol: The relative tolerance parameter (default 1e-05).
+        atol: The absolute tolerance parameter (default 1e-08).
+
+    Returns:
+        Return `True` if the matrix is an isometry, and `False` otherwise.
+
+    Examples:
+        The columns of the following \(3 \times 2\) matrix are orthonormal, so it is an isometry that
+        embeds \(\mathbb{C}^2\) into \(\mathbb{C}^3\):
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.matrix_props import is_isometry
+
+        V = np.array([[1, 0], [0, 1], [0, 0]])
+
+        print(is_isometry(V))
+        ```
+
+        Every unitary matrix is a (square) isometry:
+
+        ```python exec="1" source="above" result="text"
+        from toqito.matrix_props import is_isometry
+        from toqito.rand import random_unitary
+
+        print(is_isometry(random_unitary(3)))
+        ```
+
+        A matrix whose columns are not orthonormal is not an isometry:
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.matrix_props import is_isometry
+
+        B = np.array([[1, 0], [1, 1]])
+
+        print(is_isometry(B))
+        ```
+
+    """
+    dim_in = mat.shape[1]
+    vc_v_mat = mat.conj().T @ mat
+
+    # If V^* V = I on the input space, the columns of V are orthonormal, so V is an isometry.
+    return bool(np.allclose(vc_v_mat, np.eye(dim_in), rtol=rtol, atol=atol))

--- a/toqito/matrix_props/tests/test_is_isometry.py
+++ b/toqito/matrix_props/tests/test_is_isometry.py
@@ -1,0 +1,49 @@
+"""Test is_isometry."""
+
+import numpy as np
+import pytest
+
+from toqito.matrix_props import is_isometry
+from toqito.rand import random_unitary
+
+
+@pytest.mark.parametrize(
+    "mat",
+    [
+        # A rectangular embedding C^2 -> C^3 with orthonormal columns.
+        (np.array([[1, 0], [0, 1], [0, 0]])),
+        # The 2x2 identity.
+        (np.eye(2)),
+        # A Pauli matrix (square isometry = unitary).
+        (np.array([[0, 1], [1, 0]])),
+    ],
+)
+def test_is_isometry_true(mat):
+    """Matrices with orthonormal columns are isometries."""
+    assert is_isometry(mat)
+
+
+@pytest.mark.parametrize(
+    "mat",
+    [
+        # Columns not orthonormal.
+        (np.array([[1, 0], [1, 1]])),
+        # Rows orthonormal but columns are not (a co-isometry with dim_out < dim_in).
+        (np.array([[1, 0, 0], [0, 1, 0]])),
+    ],
+)
+def test_is_isometry_false(mat):
+    """Matrices without orthonormal columns are not isometries."""
+    assert not is_isometry(mat)
+
+
+def test_random_unitary_is_isometry():
+    """A random unitary is a square isometry."""
+    assert is_isometry(random_unitary(4))
+
+
+def test_tolerance():
+    """A near-isometry is rejected at a tight tolerance and accepted at a loose one."""
+    mat = np.array([[1.0, 0.0], [0.0, 1.0 + 1e-4], [0.0, 0.0]])
+    assert not is_isometry(mat)
+    assert is_isometry(mat, atol=1e-3)


### PR DESCRIPTION
Adds `channel_ops.channel_gram_matrix`, the sigma-weighted Gram matrix of a set
of isometry channels:

    G(sigma)_ij = Tr(V_j^* V_i sigma)

for isometries V_i (V_i^* V_i = I) and a density operator sigma. This is the
object that characterizes antidistinguishability of unitary and isometry
channels. It equals the overlap of the output states obtained by feeding a
purification with input marginal sigma into each channel.

Details:
- Default sigma = I/dim_in (maximally entangled input), for which G(sigma) is the
  Gram matrix of the pure Choi states.
- The linear form Tr(V_j^* V_i sigma) avoids the dimension factors and squared
  overlaps of the Hilbert-Schmidt inner product |Tr(V_i^* V_j)|^2 of the Choi
  matrices, so it is the quantity to which the pure-state antidistinguishability
  bounds apply directly.
- Input operators are validated to be isometries of matching dimensions.
