### PR TITLE
feat(matrix_props): add is_isometry

### DIFF
--- a/docs/content/refs.bib
+++ b/docs/content/refs.bib
@@ -1909,6 +1909,12 @@
   url = {https://en.wikipedia.org/wiki/Unitary_matrix},
 }
 
+@misc{wikipediaisometry,
+  author = "Wikipedia",
+  title = "Isometry",
+  url = {https://en.wikipedia.org/wiki/Isometry},
+}
+
 @misc{wikipediavonneumann,
   author = "Wikipedia",
   title = "Von Neumann entropy",

--- a/toqito/matrix_props/__init__.py
+++ b/toqito/matrix_props/__init__.py
@@ -21,6 +21,7 @@ from toqito.matrix_props.is_positive_definite import is_positive_definite
 from toqito.matrix_props.is_commuting import is_commuting
 from toqito.matrix_props.is_projection import is_projection
 from toqito.matrix_props.is_unitary import is_unitary
+from toqito.matrix_props.is_isometry import is_isometry
 from toqito.matrix_props.majorizes import majorizes
 from toqito.matrix_props.sk_norm import sk_operator_norm
 from toqito.matrix_props.is_block_positive import is_block_positive

--- a/toqito/matrix_props/is_isometry.py
+++ b/toqito/matrix_props/is_isometry.py
@@ -1,0 +1,66 @@
+"""Checks if the matrix is an isometry."""
+
+import numpy as np
+
+
+def is_isometry(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
+    r"""Check if a matrix is an isometry [@wikipediaisometry].
+
+    A matrix \(V \in \text{L}(\mathcal{X}, \mathcal{Y})\) is an isometry if it preserves inner
+    products, equivalently if its columns are orthonormal, that is if
+
+    \[
+        V^* V = \mathbb{I}_{\mathcal{X}},
+    \]
+
+    where \(\mathbb{I}_{\mathcal{X}}\) is the identity on the input space. The matrix need not be
+    square; this requires \(\dim(\mathcal{Y}) \geq \dim(\mathcal{X})\). A square isometry is a unitary
+    matrix.
+
+    Args:
+        mat: Matrix to check.
+        rtol: The relative tolerance parameter (default 1e-05).
+        atol: The absolute tolerance parameter (default 1e-08).
+
+    Returns:
+        Return `True` if the matrix is an isometry, and `False` otherwise.
+
+    Examples:
+        The columns of the following \(3 \times 2\) matrix are orthonormal, so it is an isometry that
+        embeds \(\mathbb{C}^2\) into \(\mathbb{C}^3\):
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.matrix_props import is_isometry
+
+        V = np.array([[1, 0], [0, 1], [0, 0]])
+
+        print(is_isometry(V))
+        ```
+
+        Every unitary matrix is a (square) isometry:
+
+        ```python exec="1" source="above" result="text"
+        from toqito.matrix_props import is_isometry
+        from toqito.rand import random_unitary
+
+        print(is_isometry(random_unitary(3)))
+        ```
+
+        A matrix whose columns are not orthonormal is not an isometry:
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.matrix_props import is_isometry
+
+        B = np.array([[1, 0], [1, 1]])
+
+        print(is_isometry(B))
+        ```
+
+    """
+    dim_in = mat.shape[1]
+    vc_v_mat = mat.conj().T @ mat
+
+    # If V^* V = I on the input space, the columns of V are orthonormal, so V is an isometry.
+    return bool(np.allclose(vc_v_mat, np.eye(dim_in), rtol=rtol, atol=atol))

--- a/toqito/matrix_props/tests/test_is_isometry.py
+++ b/toqito/matrix_props/tests/test_is_isometry.py
@@ -1,0 +1,49 @@
+"""Test is_isometry."""
+
+import numpy as np
+import pytest
+
+from toqito.matrix_props import is_isometry
+from toqito.rand import random_unitary
+
+
+@pytest.mark.parametrize(
+    "mat",
+    [
+        # A rectangular embedding C^2 -> C^3 with orthonormal columns.
+        (np.array([[1, 0], [0, 1], [0, 0]])),
+        # The 2x2 identity.
+        (np.eye(2)),
+        # A Pauli matrix (square isometry = unitary).
+        (np.array([[0, 1], [1, 0]])),
+    ],
+)
+def test_is_isometry_true(mat):
+    """Matrices with orthonormal columns are isometries."""
+    assert is_isometry(mat)
+
+
+@pytest.mark.parametrize(
+    "mat",
+    [
+        # Columns not orthonormal.
+        (np.array([[1, 0], [1, 1]])),
+        # Rows orthonormal but columns are not (a co-isometry with dim_out < dim_in).
+        (np.array([[1, 0, 0], [0, 1, 0]])),
+    ],
+)
+def test_is_isometry_false(mat):
+    """Matrices without orthonormal columns are not isometries."""
+    assert not is_isometry(mat)
+
+
+def test_random_unitary_is_isometry():
+    """A random unitary is a square isometry."""
+    assert is_isometry(random_unitary(4))
+
+
+def test_tolerance():
+    """A near-isometry is rejected at a tight tolerance and accepted at a loose one."""
+    mat = np.array([[1.0, 0.0], [0.0, 1.0 + 1e-4], [0.0, 0.0]])
+    assert not is_isometry(mat)
+    assert is_isometry(mat, atol=1e-3)


### PR DESCRIPTION
Adds `matrix_props.is_isometry`, checking whether a matrix has orthonormal
columns, that is V^* V = I on the input space. Unlike `is_unitary` it allows
non-square maps X -> Y with dim(Y) >= dim(X); a square isometry is a unitary.

Isometries come up in many places (Stinespring/Kraus isometries, embeddings,
column-orthonormal frames), so this is a general-purpose complement to
`is_unitary`. `channel_ops.channel_gram_matrix` can be simplified to use it in a
follow-up.
