### PR TITLE
Order the Examples subsections in the sidebar navigation

### DIFF
--- a/docs/_hooks/order_gallery_nav.py
+++ b/docs/_hooks/order_gallery_nav.py
@@ -1,0 +1,32 @@
+"""MkDocs hook to order the Examples gallery subsections in the navigation.
+
+The ``- Examples: generated/gallery`` nav entry is auto-populated by mkdocs from the generated
+gallery directory, which lists the subsections alphabetically (Basic Tutorials, Extended
+Nonlocal Games, Nonlocal Games, Quantum States). This reorders the "Examples" section's
+children into a pedagogical order.
+
+mkdocs-gallery's ``subsection_order`` (see ``content/gallery_conf.py``) only affects the gallery
+index page, not this sidebar navigation, so the ordering has to be applied here as well.
+"""
+
+from mkdocs.structure.nav import Navigation, Section
+
+# Desired order of the Examples subsections, by their rendered titles.
+_EXAMPLES_ORDER = (
+    "Basic Tutorials",
+    "Quantum States",
+    "Nonlocal Games",
+    "Extended Nonlocal Games",
+)
+
+
+def on_nav(nav: Navigation, /, **kwargs) -> Navigation:
+    """Reorder the children of the top-level 'Examples' section."""
+    rank = {title: index for index, title in enumerate(_EXAMPLES_ORDER)}
+    for item in nav.items:
+        if isinstance(item, Section) and item.title == "Examples":
+            # Unknown children (should be none) sort after the known subsections, preserving
+            # their relative order via Python's stable sort.
+            item.children.sort(key=lambda child: rank.get(getattr(child, "title", None), len(rank)))
+            break
+    return nav

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -119,6 +119,7 @@ extra_javascript:
 hooks:
   - _hooks/flatten_api_nav.py
   - _hooks/full_bibliography.py
+  - _hooks/order_gallery_nav.py
 
 extra:
   version:


### PR DESCRIPTION
The gallery reorder (#1703) only affects the gallery index page. The left sidebar nav is built by mkdocs from the auto-included `generated/gallery` directory, which lists the Examples subsections alphabetically (Basic Tutorials, Extended Nonlocal Games, Nonlocal Games, Quantum States).

This adds an `on_nav` hook (`docs/_hooks/order_gallery_nav.py`, same pattern as the existing `flatten_api_nav.py`) that reorders the Examples section's children to Basic Tutorials, Quantum States, Nonlocal Games, Extended Nonlocal Games, matching the gallery index page.

Verified the reordering logic against real mkdocs `Section` objects. The strict docs build in CI (`preview`) exercises the full build.