### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "toqito"
-version = "1.1.8"
+version = "1.2.0"
 description = "Python tools for the study of quantum information."
 readme = "README.md"
 requires-python = ">=3.12,<4"


### PR DESCRIPTION
Version bump for the 1.2.0 release. 87 non-dependency commits since v1.1.8, including breaking API changes (Choi-default channel constructors, channel_distinguishability tuple return, is_positive block-positivity, rtol/atol standardization, removed helper package, dropped Python 3.11), new features, bug fixes, and performance work.

Merge this, then publish the v1.2.0 GitHub release to trigger the PyPI publish and versioned docs deploy.