### PR TITLE
feat(channel_metrics): add unitary_exclusion and is_unitary_antidistinguishable

### DIFF
--- a/docs/content/refs.bib
+++ b/docs/content/refs.bib
@@ -1961,3 +1961,10 @@
   doi = {10.1103/PhysRevA.77.060301},
   url = {https://link.aps.org/doi/10.1103/PhysRevA.77.060301},
 }
+
+@article{manna2025single,
+  title = {Single-shot antidistinguishability of unitary operations},
+  author = {Manna, Soumyabrata and Bhowmik, Anandamay Das},
+  journal = {arXiv preprint arXiv:2510.14609},
+  year = {2025},
+}

--- a/toqito/channel_metrics/__init__.py
+++ b/toqito/channel_metrics/__init__.py
@@ -9,3 +9,4 @@ from toqito.channel_metrics.completely_bounded_trace_norm import completely_boun
 from toqito.channel_metrics.completely_bounded_spectral_norm import completely_bounded_spectral_norm
 from toqito.channel_metrics.channel_distinguishability import channel_distinguishability
 from toqito.channel_metrics.channel_exclusion import channel_exclusion
+from toqito.channel_metrics.unitary_exclusion import unitary_exclusion

--- a/toqito/channel_metrics/tests/test_unitary_exclusion.py
+++ b/toqito/channel_metrics/tests/test_unitary_exclusion.py
@@ -21,9 +21,7 @@ def pauli_roots(theta: float) -> list[np.ndarray]:
 @pytest.mark.parametrize("primal_dual", ["primal", "dual"])
 def test_paulis_antidistinguishable_with_bell_probe(primal_dual):
     """The three Pauli unitaries are perfectly excludable with a maximally entangled probe."""
-    value, measurements = unitary_exclusion(
-        PAULIS, probe=bell(0), primal_dual=primal_dual, cvxopt_kktsolver="ldl"
-    )
+    value, measurements = unitary_exclusion(PAULIS, probe=bell(0), primal_dual=primal_dual, cvxopt_kktsolver="ldl")
     assert abs(value) <= 1e-6
     assert len(measurements) == 3
 

--- a/toqito/channel_metrics/tests/test_unitary_exclusion.py
+++ b/toqito/channel_metrics/tests/test_unitary_exclusion.py
@@ -1,0 +1,74 @@
+"""Test unitary_exclusion."""
+
+import numpy as np
+import pytest
+
+from toqito.channel_metrics import unitary_exclusion
+from toqito.states import bell
+
+PAULIS = [
+    np.array([[0, 1], [1, 0]], dtype=complex),
+    np.array([[0, -1j], [1j, 0]], dtype=complex),
+    np.array([[1, 0], [0, -1]], dtype=complex),
+]
+
+
+def pauli_roots(theta: float) -> list[np.ndarray]:
+    """Rotations by angle theta about the three Pauli axes."""
+    return [np.cos(theta / 2) * np.eye(2) + 1j * np.sin(theta / 2) * pauli for pauli in PAULIS]
+
+
+@pytest.mark.parametrize("primal_dual", ["primal", "dual"])
+def test_paulis_antidistinguishable_with_bell_probe(primal_dual):
+    """The three Pauli unitaries are perfectly excludable with a maximally entangled probe."""
+    value, measurements = unitary_exclusion(
+        PAULIS, probe=bell(0), primal_dual=primal_dual, cvxopt_kktsolver="ldl"
+    )
+    assert abs(value) <= 1e-6
+    assert len(measurements) == 3
+
+
+def test_cube_roots_fixed_probe_value():
+    """The cube roots of the Paulis with the maximally entangled probe attain a known value."""
+    value, _ = unitary_exclusion(pauli_roots(np.pi / 3), probe=bell(0), cvxopt_kktsolver="ldl")
+    assert abs(value - 0.0375247) <= 1e-5
+
+
+def test_optimal_probe_matches_maximally_entangled_probe_for_su2_family():
+    """For rotations about orthogonal axes, no probe improves on the maximally entangled one."""
+    unitaries = pauli_roots(np.pi / 3)
+    fixed_value, _ = unitary_exclusion(unitaries, probe=bell(0), cvxopt_kktsolver="ldl")
+    optimal_value, _ = unitary_exclusion(unitaries, cvxopt_kktsolver="ldl")
+    assert abs(fixed_value - optimal_value) <= 1e-5
+
+
+def test_probe_without_ancilla():
+    """A probe of length d is interpreted as a trivial (one-dimensional) ancilla."""
+    # sigma_x|0> and sigma_y|0> are both |1> up to phase, so exclusion is perfect.
+    value, _ = unitary_exclusion(PAULIS, probe=np.array([1, 0]), cvxopt_kktsolver="ldl")
+    assert abs(value) <= 1e-6
+
+
+def test_larger_ancilla_matches_embedded_probe():
+    """Embedding the maximally entangled probe into a larger ancilla leaves the value unchanged."""
+    unitaries = pauli_roots(np.pi / 3)
+    probe = np.zeros(6)
+    probe[0] = probe[3] = 1 / np.sqrt(2)  # |0>|0> + |1>|1> inside C^3 (x) C^2
+    value_embedded, _ = unitary_exclusion(unitaries, probe=probe, cvxopt_kktsolver="ldl")
+    value_qubit, _ = unitary_exclusion(unitaries, probe=bell(0), cvxopt_kktsolver="ldl")
+    assert abs(value_embedded - value_qubit) <= 1e-5
+
+
+def test_invalid_inputs():
+    """Invalid inputs raise ValueError."""
+    with pytest.raises(ValueError, match="At least 2 unitaries"):
+        unitary_exclusion([PAULIS[0]])
+
+    with pytest.raises(ValueError, match="must be unitary"):
+        unitary_exclusion([PAULIS[0], np.array([[1, 1], [0, 1]], dtype=complex)])
+
+    with pytest.raises(ValueError, match="same dimension"):
+        unitary_exclusion([np.eye(2), np.eye(3)])
+
+    with pytest.raises(ValueError, match="probe length"):
+        unitary_exclusion(PAULIS, probe=np.array([1, 0, 0]))

--- a/toqito/channel_metrics/unitary_exclusion.py
+++ b/toqito/channel_metrics/unitary_exclusion.py
@@ -1,0 +1,148 @@
+"""Compute the probability of error of excluding a unitary from a collection of unitaries."""
+
+from typing import Any
+
+import numpy as np
+
+from toqito.channel_metrics.channel_exclusion import channel_exclusion
+from toqito.matrix_props import is_unitary
+from toqito.state_opt.state_exclusion import state_exclusion
+
+
+def unitary_exclusion(
+    unitaries: list[np.ndarray],
+    probe: np.ndarray | None = None,
+    probs: list[float] | None = None,
+    strategy: str = "min_error",
+    primal_dual: str = "dual",
+    solver: str = "cvxopt",
+    **kwargs: Any,
+) -> tuple[float, list]:
+    r"""Compute the optimal probability of error for unitary exclusion (antidistinguishability).
+
+    In the *unitary exclusion* problem, one of the unitaries \(\{U_1, \ldots, U_n\} \subset
+    \text{U}(\mathbb{C}^d)\) is applied (with prior weights \(p_1, \ldots, p_n\)) to one share of a
+    bipartite probe state \(|\phi\rangle \in \mathbb{C}^{d_A} \otimes \mathbb{C}^d\), producing the
+    output states
+
+    \[
+        |\psi_k\rangle = (\mathbb{I}_{d_A} \otimes U_k)|\phi\rangle,
+    \]
+
+    and the goal is to conclusively rule out one unitary that was *not* applied by measuring the
+    output. The set of unitaries is called *antidistinguishable with respect to the probe* when the
+    optimal error probability is zero. This is the unitary analogue of quantum state exclusion
+    [@bandyopadhyay2014conclusive] and was studied for qubit unitaries in [@manna2025single].
+
+    Two scenarios are supported:
+
+    - **Fixed probe** (`probe` is provided): the output states \(|\psi_k\rangle\) are formed and the
+      problem reduces to the state exclusion SDP
+      [`state_exclusion`][toqito.state_opt.state_exclusion.state_exclusion]. The probe may include an
+      ancilla of any dimension \(d_A \geq 1\): a vector of length \(d_A \cdot d\) is interpreted as an
+      element of \(\mathbb{C}^{d_A} \otimes \mathbb{C}^d\) with the unitary acting on the *second*
+      subsystem.
+    - **Optimal probe** (`probe=None`): the error probability is minimized over *all* input
+      strategies simultaneously (probe states of unbounded ancilla dimension together with output
+      measurements) by solving the lifted tester SDP
+      [`channel_exclusion`][toqito.channel_metrics.channel_exclusion.channel_exclusion] with each
+      unitary treated as the channel \(\rho \mapsto U_k \rho U_k^*\). This yields the exclusion value
+      of the unitaries themselves, certifying a global optimum that no choice of probe can improve
+      upon.
+
+    Args:
+        unitaries: A list of \(n \geq 2\) unitary matrices, all of the same dimension \(d\).
+        probe: Optional pure probe state, given as a vector of length \(d_A \cdot d\) for some
+            ancilla dimension \(d_A \geq 1\). If `None`, the exclusion value is optimized over all
+            input strategies via the channel exclusion SDP.
+        probs: Prior weights for the unitaries. If omitted, a uniform distribution is assumed.
+        strategy: Either `"min_error"` (default) or `"unambiguous"`. For `probe=None`, the
+            unambiguous strategy is supported in its primal formulation only (matching
+            `channel_exclusion`).
+        primal_dual: Option for the optimization problem (`"primal"` or `"dual"`).
+        solver: Optimization option for `picos` solver. Default is `"cvxopt"`.
+        kwargs: Additional arguments to pass to picos' solve method.
+
+    Returns:
+        The optimal probability of error together with the optimal strategy operators (measurement
+        operators for a fixed probe; lifted tester operators for `probe=None`).
+
+    Raises:
+        ValueError: If fewer than 2 unitaries are provided.
+        ValueError: If any provided matrix is not unitary.
+        ValueError: If the unitaries do not all have the same dimension.
+        ValueError: If the probe length is not a positive multiple of the unitary dimension.
+
+    Examples:
+        The three Pauli matrices are antidistinguishable when probed with the maximally entangled
+        state, as shown in [@manna2025single]:
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.channel_metrics import unitary_exclusion
+        from toqito.states import bell
+
+        paulis = [
+            np.array([[0, 1], [1, 0]]),
+            np.array([[0, -1j], [1j, 0]]),
+            np.array([[1, 0], [0, -1]]),
+        ]
+        value, _ = unitary_exclusion(paulis, probe=bell(0))
+        print(np.around(value, decimals=6))
+        ```
+
+        For the cube roots of the Pauli matrices, perfect exclusion is impossible for *any* input
+        strategy. Omitting the probe optimizes over all of them:
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.channel_metrics import unitary_exclusion
+
+        theta = np.pi / 3
+        paulis = [
+            np.array([[0, 1], [1, 0]]),
+            np.array([[0, -1j], [1j, 0]]),
+            np.array([[1, 0], [0, -1]]),
+        ]
+        roots = [np.cos(theta / 2) * np.eye(2) + 1j * np.sin(theta / 2) * p for p in paulis]
+        value, _ = unitary_exclusion(roots, cvxopt_kktsolver="ldl")
+        print(np.around(value, decimals=6))
+        ```
+
+    """
+    if len(unitaries) < 2:
+        raise ValueError("At least 2 unitaries are required for unitary exclusion.")
+
+    dim = unitaries[0].shape[0]
+    for unitary in unitaries:
+        if not is_unitary(unitary):
+            raise ValueError("All matrices provided must be unitary.")
+        if unitary.shape[0] != dim:
+            raise ValueError("All unitaries must have the same dimension.")
+
+    if probe is None:
+        return channel_exclusion(
+            [[unitary] for unitary in unitaries],
+            probs=probs,
+            strategy=strategy,
+            primal_dual=primal_dual,
+            solver=solver,
+            **kwargs,
+        )
+
+    probe_vec = np.asarray(probe, dtype=complex).flatten()
+    dim_ancilla, remainder = divmod(probe_vec.shape[0], dim)
+    if dim_ancilla < 1 or remainder != 0:
+        raise ValueError(
+            f"The probe length ({probe_vec.shape[0]}) must be a positive multiple of the unitary dimension ({dim})."
+        )
+
+    output_states = [(np.kron(np.eye(dim_ancilla), unitary) @ probe_vec).reshape(-1, 1) for unitary in unitaries]
+    return state_exclusion(
+        output_states,
+        probs=probs,
+        strategy=strategy,
+        primal_dual=primal_dual,
+        solver=solver,
+        **kwargs,
+    )

--- a/toqito/channel_props/__init__.py
+++ b/toqito/channel_props/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "is_trace_preserving",
     "is_unital",
     "is_unitary",
+    "is_unitary_antidistinguishable",
 ]
 
 

--- a/toqito/channel_props/is_unitary_antidistinguishable.py
+++ b/toqito/channel_props/is_unitary_antidistinguishable.py
@@ -1,0 +1,93 @@
+"""Check if a set of unitaries is antidistinguishable."""
+
+from typing import Any
+
+import numpy as np
+
+from toqito.channel_metrics.unitary_exclusion import unitary_exclusion
+
+
+def is_unitary_antidistinguishable(
+    unitaries: list[np.ndarray],
+    probe: np.ndarray | None = None,
+    solver: str = "cvxopt",
+    atol: float = 1e-6,
+    **kwargs: Any,
+) -> bool:
+    r"""Check whether a collection of unitaries is antidistinguishable.
+
+    A set of unitaries \(\{U_1, \ldots, U_n\} \subset \text{U}(\mathbb{C}^d)\) is
+    *antidistinguishable* if there is a single-shot strategy---an input probe state, possibly
+    entangled with an ancilla, together with a measurement on the output---that, for whichever
+    unitary was actually applied, never reports that unitary. Equivalently, the set is
+    antidistinguishable if and only if the minimum-error unitary *exclusion* problem has optimal
+    value zero. Antidistinguishability of qubit unitaries was studied in [@manna2025single]; see
+    also state antidistinguishability [@heinosaari2018antidistinguishability].
+
+    When `probe` is provided, antidistinguishability is decided *with respect to that probe*: the
+    output states \((\mathbb{I} \otimes U_k)|\phi\rangle\) are formed and checked for
+    antidistinguishability. When `probe=None`, the exclusion value is optimized over all input
+    strategies, so the result depends only on the unitaries themselves.
+
+    The optimal value is obtained from
+    [`unitary_exclusion`][toqito.channel_metrics.unitary_exclusion.unitary_exclusion] with uniform
+    prior weights; the set is antidistinguishable exactly when that value is (numerically) zero. The
+    less computationally intensive dual formulation is used, matching
+    [`is_antidistinguishable`][toqito.state_props.is_antidistinguishable.is_antidistinguishable].
+
+    Args:
+        unitaries: A list of \(n \geq 2\) unitary matrices, all of the same dimension \(d\).
+        probe: Optional pure probe state, given as a vector of length \(d_A \cdot d\) for some
+            ancilla dimension \(d_A \geq 1\), with the unitary acting on the second subsystem. If
+            `None`, the exclusion value is optimized over all input strategies.
+        solver: Optimization solver passed to `picos`. Default is `"cvxopt"`.
+        atol: Absolute tolerance for deciding whether the optimal exclusion value is zero. The
+            unitaries are reported antidistinguishable when the value is within `atol` of zero.
+            Default is `1e-6`.
+        kwargs: Additional keyword arguments forwarded to the `picos` solve method.
+
+    Returns:
+        `True` if the unitaries are antidistinguishable; `False` otherwise.
+
+    Examples:
+        The three Pauli matrices are antidistinguishable (a maximally entangled probe achieves
+        perfect exclusion [@manna2025single]):
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.channel_props import is_unitary_antidistinguishable
+
+        paulis = [
+            np.array([[0, 1], [1, 0]]),
+            np.array([[0, -1j], [1j, 0]]),
+            np.array([[1, 0], [0, -1]]),
+        ]
+        print(is_unitary_antidistinguishable(paulis, cvxopt_kktsolver="ldl"))
+        ```
+
+        The cube roots of the Pauli matrices are not antidistinguishable for any input strategy:
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.channel_props import is_unitary_antidistinguishable
+
+        theta = np.pi / 3
+        paulis = [
+            np.array([[0, 1], [1, 0]]),
+            np.array([[0, -1j], [1j, 0]]),
+            np.array([[1, 0], [0, -1]]),
+        ]
+        roots = [np.cos(theta / 2) * np.eye(2) + 1j * np.sin(theta / 2) * p for p in paulis]
+        print(is_unitary_antidistinguishable(roots, cvxopt_kktsolver="ldl"))
+        ```
+
+    """
+    opt_val, _ = unitary_exclusion(
+        unitaries,
+        probe=probe,
+        probs=[1] * len(unitaries),
+        primal_dual="dual",
+        solver=solver,
+        **kwargs,
+    )
+    return bool(np.isclose(opt_val, 0, atol=atol))

--- a/toqito/channel_props/tests/test_is_unitary_antidistinguishable.py
+++ b/toqito/channel_props/tests/test_is_unitary_antidistinguishable.py
@@ -1,0 +1,40 @@
+"""Test is_unitary_antidistinguishable."""
+
+import numpy as np
+import pytest
+
+from toqito.channel_props import is_unitary_antidistinguishable
+from toqito.states import bell
+
+PAULIS = [
+    np.array([[0, 1], [1, 0]], dtype=complex),
+    np.array([[0, -1j], [1j, 0]], dtype=complex),
+    np.array([[1, 0], [0, -1]], dtype=complex),
+]
+
+
+def pauli_roots(theta: float) -> list[np.ndarray]:
+    """Rotations by angle theta about the three Pauli axes."""
+    return [np.cos(theta / 2) * np.eye(2) + 1j * np.sin(theta / 2) * pauli for pauli in PAULIS]
+
+
+@pytest.mark.parametrize(
+    "unitaries, probe, expected",
+    [
+        # The Paulis are antidistinguishable for the optimal input strategy.
+        (PAULIS, None, True),
+        # ... and with the maximally entangled probe explicitly.
+        (PAULIS, bell(0), True),
+        # ... and even with a product probe (two output states coincide up to phase).
+        (PAULIS, np.kron([1, 0], [1, 0]), True),
+        # Square roots of the Paulis sit exactly at the antidistinguishability threshold.
+        (pauli_roots(np.pi / 2), bell(0), True),
+        # Cube roots of the Paulis are not antidistinguishable for any input strategy.
+        (pauli_roots(np.pi / 3), None, False),
+        # Identical unitaries can never be excluded.
+        ([np.eye(2), np.eye(2)], None, False),
+    ],
+)
+def test_is_unitary_antidistinguishable(unitaries, probe, expected):
+    """Antidistinguishability of unitary collections with and without a fixed probe."""
+    assert is_unitary_antidistinguishable(unitaries, probe=probe, cvxopt_kktsolver="ldl") == expected


### PR DESCRIPTION
## Description

Adds SDP routines for the exclusion (antidistinguishability) of unitary operations, complementing the existing state- and channel-level exclusion machinery. A set of unitaries $\{U_1, \ldots, U_n\}$ is applied to one share of a bipartite probe state, and the goal is to conclusively rule out one unitary that was not applied (cf. Manna & Bhowmik, arXiv:2510.14609).

Two scenarios are supported:

- **Fixed probe**: the output states $(\mathbb{I}_{d_A} \otimes U_k)|\phi\rangle$ are formed and the problem reduces to the `state_exclusion` SDP. The probe may carry an ancilla of any dimension $d_A \geq 1$.
- **Optimal probe** (`probe=None`): the error is minimized over *all* input strategies (probe + measurement, unbounded ancilla) via the lifted tester SDP already implemented in `channel_exclusion`, treating each unitary as the channel $\rho \mapsto U_k \rho U_k^*$. This certifies a global optimum that no probe choice can improve upon.

## Changes

  -  [x] Add `channel_metrics.unitary_exclusion` (fixed-probe reduction to `state_exclusion`; `probe=None` dispatches to the `channel_exclusion` tester SDP).
  -  [x] Add `channel_props.is_unitary_antidistinguishable`, mirroring `is_channel_antidistinguishable` / `is_antidistinguishable`.
  -  [x] Export both functions and add the Manna-Bhowmik reference to `docs/content/refs.bib`.
  -  [x] Tests: Pauli triple is perfectly excludable with a maximally entangled probe (and even a product probe); cube roots of the Paulis are not excludable under any input strategy; fixed maximally entangled probe matches the certified optimum for the SU(2) family; larger-ancilla embedding leaves the value unchanged; input validation.

## Checklist

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest` (`channel_metrics` + `channel_props`: 158 passed, 7 skipped).
  -  [ ] Check the documentation build does not lead to any failures.