### PR TITLE
fix(docs): correct first author name in manna2025single bib entry

### DIFF
--- a/docs/content/refs.bib
+++ b/docs/content/refs.bib
@@ -1964,7 +1964,7 @@
 
 @article{manna2025single,
   title = {Single-shot antidistinguishability of unitary operations},
-  author = {Manna, Soumyabrata and Bhowmik, Anandamay Das},
+  author = {Manna, Satyaki and Bhowmik, Anandamay Das},
   journal = {arXiv preprint arXiv:2510.14609},
   year = {2025},
 }


### PR DESCRIPTION
The refs.bib entry for arXiv:2510.14609 listed the first author as Soumyabrata Manna; the correct name is Satyaki Manna.