### PR TITLE
fix(docs): correct wrong citations and content errors in example gallery

### DIFF
--- a/docs/content/examples/basics/intro_tutorial.py
+++ b/docs/content/examples/basics/intro_tutorial.py
@@ -7,7 +7,7 @@ entanglement and PPT.
 """
 # %%
 # This is an introduction to the functionality in `|toqito⟩` and is not meant to serve as an
-# introduction to quantum information. For more information, please consult the book [@nielsen2011quantum] or the freely available lecture notes [@watrous2018theory].
+# introduction to quantum information. For more information, please consult the book [@nielsen2011quantum] or the freely available book [@watrous2018theory].
 #
 # This tutorial assumes you have `|toqito⟩` installed on your machine. If you
 # do not, please consult the installation instructions in [Getting Started](../../../getting-started.md).
@@ -757,7 +757,7 @@ measure(proj_1, rho)
 # G_i = P^{-1/2} \left(p_i \rho_i\right) P^{-1/2} \quad \text{where} \quad P = \sum_{i=1}^n p_i \rho_i.
 # $$
 #
-# This measurement was initially defined in [@hughston1993complete] and has found applications in quantum state discrimination tasks.
+# This measurement was initially defined in [@belavkin1975optimal] and later studied in [@hughston1993complete], and has found applications in quantum state discrimination tasks.
 # While not always optimal, the PGM provides a reasonable measurement strategy that can be computed efficiently.
 #
 # For example, consider the following trine states:
@@ -781,10 +781,11 @@ pgm
 #
 # Similarly, we can consider so-called "pretty bad measurement" (PBM) on the set of trine states [@mcirvin2024pretty].
 #
-# The pretty bad measurement (PBM) is a set of POVMs $(B_1, \ldots, B_n)$ defined as
+# The pretty bad measurement (PBM) is a set of POVMs $(B_1, \ldots, B_n)$ defined in
+# terms of the pretty good measurement operators $(G_1, \ldots, G_n)$ as
 #
 # $$
-# B_i = \left(P + (n-1)p_i \rho_i\right)^{-1} p_i \rho_i \left(P + (n-1)p_i \rho_i\right)^{-1} \quad \text{where} \quad P = \sum_{i=1}^n p_i \rho_i.
+# B_i = \frac{1}{n-1}\left(\mathbb{I} - G_i\right).
 # $$
 #
 # Like the PGM, the PBM provides a measurement strategy for quantum state discrimination, but with different properties that can be useful in certain contexts.

--- a/docs/content/examples/extended_nonlocal_games/enlg_introduction.py
+++ b/docs/content/examples/extended_nonlocal_games/enlg_introduction.py
@@ -240,5 +240,8 @@ non-signaling strategies as well as the relationships between their values.
 # games and use `|toqito⟩` to calculate their various values.
 #
 # %%
-# mkdocs_gallery_thumbnail_path = 'figures/extended_nonlocal_game.svg'
 # We will start by examining the BB84 extended nonlocal game in [The BB84 extended nonlocal game](enlg_bb84.md)
+
+# %%
+
+# mkdocs_gallery_thumbnail_path = 'figures/extended_nonlocal_game.svg'

--- a/docs/content/examples/extended_nonlocal_games/parallel_repetition.py
+++ b/docs/content/examples/extended_nonlocal_games/parallel_repetition.py
@@ -99,8 +99,9 @@ print(f"Exact (cos²(π/8)):    {exact:.5f}")
 # ### Strong parallel repetition for unentangled strategies
 #
 # For unentangled (classical) strategies, strong parallel repetition
-# *does* hold. The unentangled value of the 2-fold repetition should
-# equal the square of the single-game value:
+# *does* hold, as shown in [@johnston2016extended]. The unentangled
+# value of the 2-fold repetition should equal the square of the
+# single-game value:
 #
 # $$
 # \omega(G_{BB84}^2) = \omega(G_{BB84})^2 = \cos^4(\pi/8) \approx 0.729.
@@ -120,7 +121,7 @@ print(f"Strong parallel rep holds: {np.isclose(omega_ue_2, expected_ue_2, atol=1
 # ### Failure of strong parallel repetition for non-signaling strategies
 #
 # In contrast, the non-signaling value does *not* satisfy strong
-# parallel repetition. As shown in [@cosentino2015quantum], the
+# parallel repetition. As shown in [@russo2017extended], the
 # non-signaling value of $G_{BB84}^2$ is strictly greater than
 # $\omega_{ns}(G_{BB84})^2$:
 #
@@ -159,7 +160,9 @@ print(f"ω_ns(G²) > ω_ns(G)²: {omega_ns_2 > expected_ns_2 + 1e-3}")
 #    repetition remains an open question for many extended nonlocal
 #    games, including BB84.
 #
-# For further details, see [@cosentino2015quantum].
+# For further details, see [@johnston2016extended] and
+# [@russo2017extended].
 
 # %%
+
 # mkdocs_gallery_thumbnail_path = 'figures/extended_nonlocal_game.svg'

--- a/docs/content/examples/nonlocal_games/nonlocal_game.py
+++ b/docs/content/examples/nonlocal_games/nonlocal_game.py
@@ -414,7 +414,7 @@ print(f"Maximum quantum value after multiple runs is: {max(results)}")
 # $$
 #
 # It is well-known that both the classical and quantum value of this nonlocal
-# game is $2/3$ [@cleve2010consequences]. We can verify this fact using `|toqito⟩`.
+# game is $2/3$ [@watrous2020advanced]. We can verify this fact using `|toqito⟩`.
 # The following example encodes the FFL game. We then calculate the classical
 # value and calculate lower bounds on the quantum value of the FFL game.
 #

--- a/docs/content/examples/nonlocal_games/npa_hierarchy.py
+++ b/docs/content/examples/nonlocal_games/npa_hierarchy.py
@@ -37,9 +37,9 @@ hierarchy levels.
 #
 #     For more details, see the original paper
 #     [@navascues2008convergent] as well as the lecture notes by
-#     Watrous in [@watrous2018theory]. The hierarchy can also be
+#     Watrous in [@watrous2020advanced]. The hierarchy can also be
 #     generalized to extended nonlocal games, as described in
-#     [@cosentino2015quantum].
+#     [@johnston2016extended] and [@russo2017extended].
 #
 # ## Using the NPA hierarchy in `|toqito⟩`
 #
@@ -172,4 +172,5 @@ print(f"Known quantum value:        {exact_val:.6f}")
 # measurement operators.
 
 # %%
+
 # mkdocs_gallery_thumbnail_path = 'figures/nonlocal_game.svg'

--- a/docs/content/examples/quantum_states/classification.py
+++ b/docs/content/examples/quantum_states/classification.py
@@ -99,8 +99,8 @@ print(f"Average classification error (k=1): {learnability_result['value']}")
 
 # %%
 # ## k-Incoherence
-# The notion of $k$-incoherence comes from
-# [@johnston2022absolutely]. For a positive integers, $k$ and
+# The notion of $k$-incoherence, as studied in
+# [@johnston2022absolutely], is defined as follows. For positive integers $k$ and
 # $n$, the matrix $X \in \text{Pos}(\mathbb{C}^n)$ is called
 # $k$-incoherent if there exists a positive integer $m$, a set
 # $S = \{|\psi_0\rangle, |\psi_1\rangle,\ldots, |\psi_{m-1}\rangle\}
@@ -135,7 +135,7 @@ print(is_k_incoherent(mat, 2))
 # ## Factor width
 #
 # Another closely related definition to $k$-incoherence is that of
-# factor width [@barioli2003maximal][@johnston2025factor][@boman2005factor] below.
+# factor width [@boman2005factor][@johnston2025factor] below.
 #
 # Let $k$ be a positive integer. The factor width of a positive
 # semidefinite matrix $X$ is the smallest $k$ such that it is
@@ -160,7 +160,7 @@ result = factor_width(hadamard, k=1)
 print(result["feasible"])
 
 # %%
-# This example comes directly from [@johnston2025factor]. Suppose we want to determine the factor width of
+# This example comes directly from [@johnston2025complexity]. Suppose we want to determine the factor width of
 # the rank-$3$ matrix
 #
 # $$
@@ -178,7 +178,7 @@ print(result["feasible"])
 #
 # $$
 # \begin{aligned}
-# R_1 = \{S_1, S_2, S_3, S_3\}, \quad \text{where} \quad S_1 & = \operatorname{span}\{(0,1,-1,1), (0,1,-3,1)\}, \\
+# R_1 = \{S_1, S_2, S_3, S_4\}, \quad \text{where} \quad S_1 & = \operatorname{span}\{(0,1,-1,1), (0,1,-3,1)\}, \\
 # S_2 & = \operatorname{span}\{(1,0,2,-1), (3,0,2,-3)\}, \\
 # S_3 & = \operatorname{span}\{(1,2,0,1), (3,2,0,-1)\}, \ \ \text{and} \\
 # S_4 & = \operatorname{span}\{(1,1,1,0), (3,3,1,0)\}.

--- a/docs/content/examples/quantum_states/equiangular_threshold.py
+++ b/docs/content/examples/quantum_states/equiangular_threshold.py
@@ -2,7 +2,7 @@
 
 In this tutorial, we explore a sharp threshold for the antidistinguishability
 of a special class of quantum states known as equiangular states. We will
-numerically verify a tight bound presented in the paper by Johnson et.al
+numerically verify a tight bound presented in the paper by Johnston et al.
 [@johnston2025tight] and visualize the "sharp cliff" where this
 property changes.
 
@@ -17,12 +17,13 @@ This tutorial builds upon the concepts introduced in the [Quantum state exclusio
 # any two distinct states is a constant, i.e.,
 # $|\langle \psi_i | \psi_j \rangle| = \gamma$ for all $i \neq j$.
 #
-# Johnston et.al [@johnston2025tight]
-# introduced a simple and powerful necessary condition for a set of states to be
-# antidistinguishable.
+# A simple and powerful necessary condition for a set of states to be
+# antidistinguishable was established in [@russo2023inner]; a simpler proof,
+# along with a demonstration that the bound is tight, was later given in
+# [@johnston2025tight].
 #
 # According to **Corollary 4.2 from** [@johnston2025tight], when $n \geq 2$, $S = \{|
-# \psi_0\rangle, \ldots, |\psi_{n-1}\rangle\}$ is not anstidistinguishable if the following condition is satisfied.
+# \psi_0\rangle, \ldots, |\psi_{n-1}\rangle\}$ is not antidistinguishable if the following condition is satisfied.
 #
 # $$
 # |\langle \psi_i | \psi_j \rangle| > \frac{n-2}{n-1}

--- a/docs/content/examples/quantum_states/pbr_theorem.py
+++ b/docs/content/examples/quantum_states/pbr_theorem.py
@@ -191,5 +191,3 @@ is_ad_general = is_antidistinguishable(general_pbr_states)
 
 print(f"\nAre the four general PBR states (n=2, theta=pi/3) antidistinguishable? {is_ad_general}")
 # mkdocs_gallery_thumbnail_path = 'figures/pbr_theorem.png'
-
-# %%

--- a/docs/content/examples/quantum_states/pgm_pbm.py
+++ b/docs/content/examples/quantum_states/pgm_pbm.py
@@ -5,7 +5,7 @@ In this tutorial, we will explore the "pretty good measurement" (PGM) and its
 novel counterpart, the "pretty bad measurement" (PBM). The PGM, also known as the
 square-root measurement, is a widely used measurement for quantum
 state discrimination [@belavkin1975optimal][@hughston1993complete]. The PBM, in contrast,
-was recently introduced by McIrvin et. al. [@mcirvin2024pretty]. Both these measurements
+was recently introduced by McIrvin et al. [@mcirvin2024pretty]. Both these measurements
 provide elegant, easy-to-construct tools for two opposing goals in quantum
 information: state discrimination and state exclusion.
 PGM is useful for the former while PBM is of use for the latter.
@@ -65,7 +65,7 @@ results and figures from the paper using `|toqito⟩`.
 # P_{\text{PBM}} = \sum_{i=1}^k p_i \text{Tr}(\rho_i B_i)
 # $$
 #
-# A key result from McIrvin et.al [@mcirvin2024pretty] is the tight relationship
+# A key result from McIrvin et al. [@mcirvin2024pretty] is the tight relationship
 # between the success probabilities of these two measurements:
 #
 # $$
@@ -83,7 +83,7 @@ results and figures from the paper using `|toqito⟩`.
 #
 # ### Numerical Example: The Trine States
 #
-# Figure 3 from McIrvin et.al [@mcirvin2024pretty] analyzes the performance
+# Figure 3 from McIrvin et al. [@mcirvin2024pretty] analyzes the performance
 # of these measurements for the three **trine states** with a uniform prior
 # probability. The trine states are a classic example of a set that is
 # antidistinguishable but not distinguishable, a property demonstrated in the [Quantum state exclusion](state_exclusion.md) tutorial.
@@ -196,7 +196,7 @@ print(f"  P_PBM >= P_Worst:   {p_pbm:.4f} >= {p_worst:.4f} ->  {p_pbm >= p_worst
 # %%
 # ## Visualizing Performance on Random States
 #
-# Figures 4 and 5 from McIrvin et. al [@mcirvin2024pretty] show that for many randomly generated
+# Figures 4 and 5 from McIrvin et al. [@mcirvin2024pretty] show that for many randomly generated
 # states, the PGM and PBM probabilities cluster around the blind guessing
 # baseline of $1/k$. We can reproduce a similar plot.
 #

--- a/docs/content/examples/quantum_states/separability.py
+++ b/docs/content/examples/quantum_states/separability.py
@@ -23,14 +23,14 @@ entangled states, Werner states, and random density matrices.
 # !!! note
 #
 #     Determining separability is **NP-hard** in general
-#     [@gurvits2002largest]. The `is_separable` function in `|toqito⟩`
+#     [@gurvits2003classical]. The `is_separable` function in `|toqito⟩`
 #     applies a hierarchy of increasingly powerful tests, returning
 #     `True` (separable) or `False` (entangled) based on which test
 #     provides a definitive answer.
 #
 # ## The hierarchy of checks
 #
-# The `is_separable` function runs through 13 tests in order:
+# The `is_separable` function runs through the following tests in order:
 #
 # 1. **Trivial cases** — one subsystem has dimension 1
 # 2. **Pure states** — Schmidt rank check
@@ -123,8 +123,8 @@ print(f"Random state is separable: {sep} (reason: {reason})")
 # %%
 # ## Example: States near the maximally mixed state
 #
-# The Gurvits-Barnum separable ball criterion guarantees that states
-# sufficiently close to $I/d$ are separable. The maximally mixed state
+# The Gurvits-Barnum separable ball criterion [@gurvits2002largest]
+# guarantees that states sufficiently close to $I/d$ are separable. The maximally mixed state
 # itself is trivially separable.
 
 # %%
@@ -157,4 +157,5 @@ print(f"Near-mixed state is separable: {sep} (reason: {reason})")
 # $$
 
 # %%
+
 # mkdocs_gallery_thumbnail_path = 'figures/quantum_state_distinguish.svg'

--- a/docs/content/examples/quantum_states/state_exclusion.py
+++ b/docs/content/examples/quantum_states/state_exclusion.py
@@ -11,8 +11,8 @@ Bell states and trine states.
 # It may be useful to consult the [quantum state distinguishability](state_distinguishability.md)
 # tutorial on this topic.
 #
-# Further information beyond the scope of this tutorial can be found in the text
-# [@pusey2012reality] as well as the course [@bandyopadhyay2014conclusive].
+# Further information beyond the scope of this tutorial can be found in the papers
+# [@pusey2012reality] and [@bandyopadhyay2014conclusive].
 #
 # ## The state exclusion problem
 #

--- a/docs/content/gallery_conf.py
+++ b/docs/content/gallery_conf.py
@@ -46,4 +46,6 @@ def _populate_subsections(self) -> None:
 
 Gallery.populate_subsections = _populate_subsections
 
-conf = {"subsection_order": SUBSECTION_ORDER}
+# remove_config_comments strips gallery directives (e.g. mkdocs_gallery_thumbnail_path)
+# from the rendered pages instead of showing them as literal text.
+conf = {"subsection_order": SUBSECTION_ORDER, "remove_config_comments": True}

--- a/docs/content/refs.bib
+++ b/docs/content/refs.bib
@@ -616,6 +616,19 @@
   year = {2002},
   month = {Dec},
 }
+
+@inproceedings{gurvits2003classical,
+  title = {Classical deterministic complexity of Edmonds' problem and quantum
+           entanglement},
+  author = {Gurvits, Leonid},
+  booktitle = {Proceedings of the Thirty-Fifth Annual ACM Symposium on Theory
+               of Computing},
+  pages = {10--19},
+  year = {2003},
+  DOI = {10.1145/780542.780545},
+  eprint = {quant-ph/0303055},
+  archivePrefix = {arXiv},
+}
 % Keys beginning with H
 @misc{ha2011entanglement,
   title = {Entanglement Witnesses Arising from Exposed Positive Linear Maps},
@@ -897,6 +910,7 @@
   title = {Extended non-local games and monogamy-of-entanglement games},
   volume = {472},
   ISSN = {1471-2946},
+  DOI = {10.1098/rspa.2016.0003},
   url = {https://arxiv.org/abs/1510.02083},
   number = {2189},
   journal = {Proceedings of the Royal Society A: Mathematical, Physical and
@@ -951,6 +965,8 @@
   volume = {9},
   pages = {1622},
   year = {2025},
+  DOI = {10.22331/q-2025-02-04-1622},
+  url = {https://doi.org/10.22331/q-2025-02-04-1622},
 }
 
 % Keys beginning with K
@@ -1320,7 +1336,22 @@
   title = {Extended Nonlocal Games},
   author = {Russo, Vincent},
   year = {2017},
+  note = {PhD thesis, University of Waterloo},
   eprint = {1704.07375},
+  archivePrefix = {arXiv},
+  primaryClass = {quant-ph},
+}
+
+@article{russo2023inner,
+  title = {A note on the inner products of pure states and their
+           antidistinguishability},
+  author = {Russo, Vincent and Sikora, Jamie},
+  journal = {Physical Review A},
+  volume = {107},
+  pages = {L030202},
+  year = {2023},
+  DOI = {10.1103/PhysRevA.107.L030202},
+  eprint = {2206.08313},
   archivePrefix = {arXiv},
   primaryClass = {quant-ph},
 }
@@ -1481,6 +1512,14 @@
   author = {Watrous, John},
   year = {2018},
   url = {https://cs.uwaterloo.ca/~watrous/TQI/TQI.pdf},
+}
+
+@misc{watrous2020advanced,
+  title = {Advanced Topics in Quantum Information Theory},
+  author = {Watrous, John},
+  year = {2020},
+  note = {Lecture notes, University of Waterloo},
+  url = {https://cs.uwaterloo.ca/~watrous/QIT-notes/},
 }
 
 @article{werner1989quantum,


### PR DESCRIPTION
## Summary

An audit of every citation across the docs example gallery (59 usages, 16 files) found six wrong citations and a few related content errors. This PR fixes all of them, adds the missing bib entries, and fixes the `mkdocs_gallery_thumbnail_path` directive rendering as literal text on gallery pages.

## Wrong citations fixed

| Location | Was | Now | Why |
|---|---|---|---|
| `parallel_repetition.py` | `cosentino2015quantum` | `johnston2016extended`, `russo2017extended` | Cosentino's thesis is on state distinguishability; unentangled strong parallel repetition is from JMRW 2016, and the non-signaling failure is from Russo's thesis (Sec. 6.2) |
| `npa_hierarchy.py` (extended NPA) | `cosentino2015quantum` | `johnston2016extended`, `russo2017extended` | The extended NPA hierarchy is proven in JMRW 2016 and developed in Russo's thesis |
| `npa_hierarchy.py` (further reading) | `watrous2018theory` | `watrous2020advanced` (new) | The TQI book does not cover nonlocal games or the NPA hierarchy; the Advanced Topics in QIT notes do (Lecture 8) |
| `nonlocal_game.py` (FFL value 2/3) | `cleve2010consequences` | `watrous2020advanced` | The FFL game appears nowhere in CHTW (verified against full text); the notes state the result in Example 6.10. Miscitation dates back to the old Sphinx docs |
| `separability.py` (NP-hardness) | `gurvits2002largest` | `gurvits2003classical` (new) | Gurvits-Barnum 2002 is the separable ball paper and has no hardness result; NP-hardness is Gurvits STOC 2003. The ball section now cites `gurvits2002largest` where it belongs |
| `classification.py` (factor width example) | `johnston2025factor` | `johnston2025complexity` | The worked example (matrix M, recursive spans) comes verbatim from arXiv:2510.20789, not the factor width rank paper. Also dropped `barioli2003maximal` from the factor width definition (that paper is about cp-rank) |

## Content errors fixed

- `intro_tutorial.py`: the displayed PBM formula was wrong (not a POVM, matched neither the cited paper nor toqito's implementation); corrected to `B_i = (I - G_i)/(n-1)`. PGM origin now credited to Belavkin 1975 alongside HJW 1993.
- `classification.py`: `R_1 = {S_1, S_2, S_3, S_3}` corrected to `S_4`.
- `equiangular_threshold.py`: the necessary condition is first established in Russo and Sikora, PRA 107, L030202 (2023) (added as `russo2023inner`, now co-cited); fixed "Johnson et.al" and "anstidistinguishable" typos.
- `separability.py`: "13 tests" while listing 12; `state_exclusion.py`: two papers were called "the text" and "the course"; assorted "et.al" fixes in `pgm_pbm.py`.

## Gallery rendering fix

`mkdocs_gallery_thumbnail_path = '...'` rendered as literal page text (e.g. on the parallel repetition tutorial) because mkdocs-gallery only strips config comments from code blocks, and four files carried the directive in a trailing markdown cell. Enabled `remove_config_comments` in `gallery_conf.py` and fixed the placement in the four affected files. Verified with the mkdocs-gallery 0.10.4 parser that all 16 example pages render with no directive text, no empty code fences, and thumbnails still parsed.

## Bib changes

- New entries: `gurvits2003classical`, `watrous2020advanced`, `russo2023inner`.
- Added DOIs to `johnston2025tight` and `johnston2016extended`; noted `russo2017extended` is a PhD thesis.
- Validated: all bib keys unique, every `[@key]` in the gallery resolves.