### PR TITLE
feat(channel_metrics): generalize channel_distinguishability to n channels

### DIFF
--- a/toqito/channel_metrics/channel_distinguishability.py
+++ b/toqito/channel_metrics/channel_distinguishability.py
@@ -1,4 +1,4 @@
-"""Computes the maximum probability of distinguishing two quantum channels."""
+"""Computes the maximum probability of distinguishing a collection of quantum channels."""
 
 from typing import Any
 
@@ -12,7 +12,7 @@ from toqito.channel_props.channel_dim import channel_dim
 
 def channel_distinguishability(
     phi: np.ndarray | list[np.ndarray] | list[list[np.ndarray]],
-    psi: np.ndarray | list[np.ndarray] | list[list[np.ndarray]],
+    psi: np.ndarray | list[np.ndarray] | list[list[np.ndarray]] | None = None,
     probs: list[float] | None = None,
     dim: int | list[int] | np.ndarray | None = None,
     strategy: str = "bayesian",
@@ -20,51 +20,93 @@ def channel_distinguishability(
     primal_dual: str = "dual",
     **kwargs: Any,
 ) -> tuple[float, list[np.ndarray]]:
-    r"""Compute the optimal probability of distinguishing two quantum channels.
+    r"""Compute the optimal probability of distinguishing a collection of quantum channels.
 
-    Bayesian and minimax discrimination of two quantum channels are implemented.
+    Bayesian discrimination of \(n \geq 2\) quantum channels and minimax discrimination of two
+    quantum channels are implemented.
 
-    For Bayesian discrimination, channels to be distinguished should have a given a priori probability distribution.
-    The task of discriminating channels can be connected to the completely bounded trace norm
-    (Section 3.3.3 of [@watrous2018theory]).
-    The problem is finding POVMs for which error probability of discrimination of
-    output states is minimized after input state is acted on by the two quantum channels.
-    In the language of statistical decision theory, the problem is equivalent to minimizing quantum Bayes' risk.
+    For Bayesian discrimination, the channels to be distinguished are given with an a priori
+    probability distribution. The task is to find an input state and a POVM on the (reference and)
+    output system for which the error probability of identifying which channel acted is minimized.
+    In the language of statistical decision theory, the problem is equivalent to minimizing quantum
+    Bayes' risk. For two channels, the optimal value admits a closed form in terms of the completely
+    bounded trace norm (Section 3.3.3 of [@watrous2018theory]), which is used whenever the channels
+    are supplied through the two-argument signature ``channel_distinguishability(phi, psi, ...)``.
+
+    For \(n \geq 2\) channels supplied as a single list (with ``psi=None``), the full semidefinite
+    program of Section 3.5 of [@watrous2018theory] is solved. Given channels
+    \(\{\Phi_1, \ldots, \Phi_n\}\) with priors \(\{p_1, \ldots, p_n\}\) and Choi matrices
+    \(J(\Phi_i)\), the primal problem is
+
+    \[
+        \begin{aligned}
+            \text{maximize:} \quad & \sum_{i=1}^n p_i \text{Tr}\left[P_i J(\Phi_i)\right] \\
+            \text{subject to:} \quad & \sum_{i=1}^n P_i = \rho \otimes \mathbb{I}_{\mathcal{Y}}, \\
+            & P_i \succeq 0 \quad \forall i, \\
+            & \rho \succeq 0, \; \text{Tr}(\rho) = 1,
+        \end{aligned}
+    \]
+
+    and the corresponding dual problem is
+
+    \[
+        \begin{aligned}
+            \text{minimize:} \quad & \lambda \\
+            \text{subject to:} \quad & Y \succeq p_i J(\Phi_i) \quad \forall i, \\
+            & \text{Tr}_{\mathcal{Y}}(Y) \preceq \lambda \, \mathbb{I}_{\mathcal{X}}.
+        \end{aligned}
+    \]
+
+    Note on notation: in [@watrous2018theory], each channel maps operators on an input space
+    \(\mathcal{X}\) to operators on an output space \(\mathcal{Y}\), and the Choi operator
+    \(J(\Phi)\) lives on \(\mathcal{Y} \otimes \mathcal{X}\). In toqito's convention the Choi
+    matrix instead lives on \(\mathcal{X} \otimes \mathcal{Y}\) (input \(\otimes\) output); that
+    is, subsystem index 0 is the input space \(\mathcal{X}\) (of dimension ``dim_in``) and
+    subsystem index 1 is the output space \(\mathcal{Y}\) (of dimension ``dim_out``). Accordingly,
+    tracing out the output space \(\mathcal{Y}\) in the dual constraint corresponds to
+    ``picos.partial_trace(Y, 1)`` in the implementation.
 
     In the minimax problem, there are no a priori probabilities.
     Minimax discrimination of two channels consists of finding the
     optimal input state so that the two possible output states are discriminated
-    with minimum risk. ([@dariano2005minimax]).
+    with minimum risk. ([@dariano2005minimax]). Minimax discrimination is only implemented for two
+    channels; requesting it for more than two channels raises a ``ValueError``.
 
     QETLAB's functionality inspired the Bayesian option [@qetlablink]
     and the minimax option is adapted from QuTIpy [@qutipylink].
 
     Args:
-        phi: A superoperator. It should be provided either as a Choi matrix,
-             or as a (1d or 2d) list of numpy arrays whose entries are its Kraus operators.
+        phi: Either a single superoperator (provided as a Choi matrix, or as a (1d or 2d) list of
+             numpy arrays whose entries are its Kraus operators) to be distinguished from ``psi``,
+             or, when ``psi`` is ``None``, a list of \(n \geq 2\) superoperators (each a
+             Choi matrix or a list of Kraus operators) to be mutually distinguished.
         psi: A superoperator. It should be provided either as a Choi matrix,
              or as a (1d or 2d) list of numpy arrays whose entries are its Kraus operators.
-        probs: Prior weights of the two channels (Bayesian strategy only). If omitted, a uniform
+             If ``None``, ``phi`` is interpreted as a list of channels.
+        probs: Prior weights of the channels (Bayesian strategy only). If omitted, a uniform
             distribution is used. Weights need not be normalized (matching ``state_exclusion``);
             they are normalized internally.
         dim: Input and output dimensions of the channels.
         strategy: Whether to perform Bayesian or minimax discrimination task. Possible
                   values are "Bayesian" and "minimax". Default option is `strategy="Bayesian"`.
         solver: Optimization option for `picos` solver. Default option is `solver="cvxopt"`.
-        primal_dual: Option for the optimization problem. Default option is `solver="cvxopt"`.
+        primal_dual: Option for the optimization problem. Default option is `primal_dual="dual"`.
         kwargs: Additional arguments to pass to picos' solve method.
 
     Returns:
         A tuple ``(value, operators)``. ``value`` is the optimal probability of discriminating the
-        two channels. ``operators`` holds the optimal strategy operators for the minimax SDP
-        branches (the measurement operators for ``primal_dual="primal"`` and the dual operator for
-        ``primal_dual="dual"``) and is an empty list for the closed-form Bayesian branch.
+        channels. ``operators`` holds the optimal strategy operators for the SDP branches (the
+        measurement operators :math:`P_i` for ``primal_dual="primal"`` and the dual operator for
+        ``primal_dual="dual"``) and is an empty list for the closed-form two-channel Bayesian
+        branch and for degenerate priors.
 
     Raises:
         ValueError: If strategy is neither Bayesian nor minimax.
+        ValueError: If strategy is minimax and more than 2 channels are provided.
+        ValueError: If fewer than 2 channels are provided in list mode.
         ValueError: If channels have different input or output dimensions.
         ValueError: If the prior weights are negative or sum to zero.
-        ValueError: If number of prior probabilities not equal to 2.
+        ValueError: If number of prior probabilities is not equal to the number of channels.
 
     Examples:
         Optimal probability of distinguishing two amplitude damping channels in the Bayesian setting:
@@ -80,6 +122,19 @@ def channel_distinguishability(
         probs = [0.5, 0.5]
 
         value, _ = channel_distinguishability(choi_ch_1, choi_ch_2, probs)
+        print(value)
+        ```
+
+        Optimal probability of distinguishing three depolarizing channels with distinct noise
+        parameters, supplied as a single list of channels:
+
+        ```python exec="1" source="above" result="text"
+        from toqito.channels import depolarizing
+        from toqito.channel_metrics import channel_distinguishability
+        # Define three depolarizing channels with distinct noise parameters.
+        channels = [depolarizing(2, 0.1), depolarizing(2, 0.5), depolarizing(2, 0.9)]
+
+        value, _ = channel_distinguishability(channels, probs=[1 / 3, 1 / 3, 1 / 3])
         print(value)
         ```
 
@@ -100,6 +155,61 @@ def channel_distinguishability(
         ```
 
     """
+    # Checking for errors common to both modes.
+    if strategy.lower() not in ("bayesian", "minimax"):
+        raise ValueError("The strategy must either be Bayesian or Minimax.")
+
+    if primal_dual not in {"primal", "dual"}:
+        raise ValueError("The primal_dual option must be either 'primal' or 'dual'.")
+
+    if psi is not None:
+        return _two_channel_distinguishability(phi, psi, probs, dim, strategy, solver, primal_dual, **kwargs)
+
+    # n-channel (list) mode: `phi` is a list of channels, each given as a Choi matrix or Kraus list.
+    if not isinstance(phi, list) or len(phi) < 2:
+        raise ValueError("When psi is None, phi must be a list of at least 2 channels.")
+
+    channels = phi
+    num_channels = len(channels)
+
+    # Get the input and output dimensions of every channel and check they all agree. The environment
+    # dimension is not used here, so skip the extra matrix_rank computation it would require.
+    channel_dims = [channel_dim(channel, dim=dim, compute_env_dim=False) for channel in channels]
+    dims = [np.array([d_in, d_out]) for d_in, d_out, _ in channel_dims]
+    if any(not np.array_equal(dims[0], dims_i) for dims_i in dims[1:]):
+        raise ValueError("The channels must have the same dimension input and output spaces as each other.")
+    dim_in, dim_out = int(dims[0][0][0]), int(dims[0][1][0])
+
+    # Convert any Kraus representations to Choi matrices.
+    choi_matrices = [kraus_to_choi(channel) if isinstance(channel, list) else channel for channel in channels]
+
+    if strategy.lower() == "minimax":
+        if num_channels != 2:
+            raise ValueError("Minimax discrimination is only supported for exactly 2 channels.")
+        if primal_dual == "primal":
+            return _minimax_primal(choi_matrices[0], choi_matrices[1], dim_in, dim_out, solver=solver, **kwargs)
+        return _minimax_dual(choi_matrices[0], choi_matrices[1], dim_in, dim_out, solver=solver, **kwargs)
+
+    probs_arr = _validate_probs(probs, num_channels)
+    if max(probs_arr) >= 1:
+        return 1.0, []
+
+    if primal_dual == "primal":
+        return _bayesian_primal(choi_matrices, probs_arr, dim_in, dim_out, solver=solver, **kwargs)
+    return _bayesian_dual(choi_matrices, probs_arr, dim_in, dim_out, solver=solver, **kwargs)
+
+
+def _two_channel_distinguishability(
+    phi: np.ndarray | list[np.ndarray] | list[list[np.ndarray]],
+    psi: np.ndarray | list[np.ndarray] | list[list[np.ndarray]],
+    probs: list[float] | None,
+    dim: int | list[int] | np.ndarray | None,
+    strategy: str,
+    solver: str,
+    primal_dual: str,
+    **kwargs: Any,
+) -> tuple[float, list[np.ndarray]]:
+    """Distinguish two channels (legacy two-argument mode)."""
     # Get the input and output dimensions of phi and psi. The environment dimension is not used here, so skip the
     # extra matrix_rank computation it would require.
     d_in_phi, d_out_phi, _ = channel_dim(phi, dim=dim, compute_env_dim=False)
@@ -115,30 +225,11 @@ def channel_distinguishability(
 
     dim_phi, dim_psi = np.array([d_in_phi, d_out_phi]), np.array([d_in_psi, d_out_psi])
 
-    # checking for errors.
-    if strategy.lower() not in ("bayesian", "minimax"):
-        raise ValueError("The strategy must either be Bayesian or Minimax.")
-
-    if primal_dual not in {"primal", "dual"}:
-        raise ValueError("The primal_dual option must be either 'primal' or 'dual'.")
-
     if not np.array_equal(dim_phi, dim_psi):
         raise ValueError("The channels must have the same dimension input and output spaces as each other.")
 
     if strategy.lower() == "bayesian":
-        # Default to a uniform prior, and accept unnormalized weights (matching state_exclusion).
-        probs = [1 / 2, 1 / 2] if probs is None else probs
-
-        if len(probs) != 2:
-            raise ValueError("probs must be a probability distribution with 2 entries.")
-
-        probs_arr = np.array(probs, dtype=float)
-        if np.any(probs_arr < 0):
-            raise ValueError("Prior probabilities must be non-negative.")
-        probs_sum = float(np.sum(probs_arr))
-        if probs_sum <= 0:
-            raise ValueError("Prior probabilities must have a positive sum.")
-        probs_arr = probs_arr / probs_sum
+        probs_arr = _validate_probs(probs, 2)
 
         if max(probs_arr) >= 1:
             return 1.0, []
@@ -151,6 +242,91 @@ def channel_distinguishability(
         return _minimax_primal(phi, psi, d_in_phi[0], d_out_phi[0], solver=solver, **kwargs)
 
     return _minimax_dual(phi, psi, d_in_phi[0], d_out_phi[0], solver=solver, **kwargs)
+
+
+def _validate_probs(probs: list[float] | None, num_channels: int) -> np.ndarray:
+    """Validate and normalize the prior weights of the channels."""
+    # Default to a uniform prior, and accept unnormalized weights (matching state_exclusion).
+    probs = [1 / num_channels] * num_channels if probs is None else probs
+
+    if len(probs) != num_channels:
+        raise ValueError(f"probs must be a probability distribution with {num_channels} entries.")
+
+    probs_arr = np.array(probs, dtype=float)
+    if np.any(probs_arr < 0):
+        raise ValueError("Prior probabilities must be non-negative.")
+    probs_sum = float(np.sum(probs_arr))
+    if probs_sum <= 0:
+        raise ValueError("Prior probabilities must have a positive sum.")
+    return probs_arr / probs_sum
+
+
+def _bayesian_primal(
+    choi_matrices: list[np.ndarray],
+    probs: np.ndarray,
+    dimA: int,
+    dimB: int,
+    solver: str = "cvxopt",
+    **kwargs,
+) -> tuple[float, list[np.ndarray]]:
+    """Find the primal problem for Bayesian discrimination of n quantum channels.
+
+    See Section 3.5 of [@watrous2018theory]. The Choi matrices live on input (x) output
+    (subsystem 0 is the input space of dimension dimA, subsystem 1 the output space of
+    dimension dimB).
+    """
+    num_channels = len(choi_matrices)
+
+    problem = pc.Problem()
+
+    P_var = [pc.HermitianVariable(f"P[{i}]", (dimA * dimB, dimA * dimB)) for i in range(num_channels)]
+    rho = pc.HermitianVariable("rho", (dimA, dimA))
+
+    problem.add_list_of_constraints(P_var[i] >> 0 for i in range(num_channels))
+    problem.add_constraint(pc.sum(P_var) == rho @ np.eye(dimB))
+    problem.add_constraint(rho >> 0)
+    problem.add_constraint(pc.trace(rho) == 1)
+
+    problem.set_objective(
+        "max", pc.sum([probs[i] * pc.trace(P_var[i] * choi_matrices[i]).real for i in range(num_channels)])
+    )
+
+    problem.solve(solver=solver, **kwargs)
+
+    return problem.value, [np.array(var.value) for var in P_var]
+
+
+def _bayesian_dual(
+    choi_matrices: list[np.ndarray],
+    probs: np.ndarray,
+    dimA: int,
+    dimB: int,
+    solver: str = "cvxopt",
+    **kwargs,
+) -> tuple[float, list[np.ndarray]]:
+    """Find the dual problem for Bayesian discrimination of n quantum channels.
+
+    See Section 3.5 of [@watrous2018theory]. Minimize lambda subject to Y >= p_i J(Phi_i) for all i
+    and Tr_out(Y) <= lambda * I_in, i.e. minimize the largest eigenvalue of Tr_out(Y).
+    """
+    num_channels = len(choi_matrices)
+
+    problem = pc.Problem()
+
+    a_var = pc.RealVariable("a")
+    Y_var = pc.HermitianVariable("Y", (dimA * dimB, dimA * dimB))
+
+    # Trace out the output space (subsystem index 1 in toqito's input (x) output Choi convention).
+    Y0 = pc.partial_trace(Y_var, subsystems=1, dimensions=[dimA, dimB])
+
+    problem.add_list_of_constraints(Y_var >> probs[i] * choi_matrices[i] for i in range(num_channels))
+    problem.add_constraint(Y0 << a_var * np.eye(dimA))
+
+    problem.set_objective("min", a_var)
+
+    problem.solve(solver=solver, **kwargs)
+
+    return problem.value, [np.array(Y_var.value)]
 
 
 def _minimax_dual(

--- a/toqito/channel_metrics/tests/test_channel_distinguishability.py
+++ b/toqito/channel_metrics/tests/test_channel_distinguishability.py
@@ -1,10 +1,12 @@
 """Test channel_distinguishability."""
 
+import numpy as np
 import pytest
 
 from toqito.channel_metrics import channel_distinguishability
 from toqito.channel_ops import kraus_to_choi
 from toqito.channels import amplitude_damping, dephasing, depolarizing, phase_damping
+from toqito.matrices import pauli
 
 # Creating two amplitude damping channels.
 amp_damp_1 = kraus_to_choi(amplitude_damping(gamma=0.22, return_kraus_ops=True))
@@ -173,3 +175,131 @@ def test_bayesian_channel_distinguishability_uniform_default():
     value_default, _ = channel_distinguishability(dephasing(2), dephasing(2), None, [2, 2])
     value_uniform, _ = channel_distinguishability(dephasing(2), dephasing(2), [0.5, 0.5], [2, 2])
     assert pytest.approx(value_uniform, 1e-6) == value_default
+
+
+@pytest.mark.parametrize("primal_dual", ["primal", "dual"])
+def test_three_depolarizing_channels(primal_dual):
+    """Discrimination among 3 depolarizing channels with distinct noise parameters."""
+    channels = [depolarizing(2, 0.1), depolarizing(2, 0.5), depolarizing(2, 0.9)]
+    value, operators = channel_distinguishability(channels, probs=[1 / 3, 1 / 3, 1 / 3], primal_dual=primal_dual)
+    # A uniformly random guess succeeds with probability 1/3; the SDP must do at least as well.
+    assert 1 / 3 <= value <= 1
+    if primal_dual == "primal":
+        assert len(operators) == 3
+    else:
+        assert len(operators) == 1
+
+
+def test_three_depolarizing_channels_primal_equals_dual():
+    """The primal and dual SDP values agree for 3 depolarizing channels."""
+    channels = [depolarizing(2, 0.1), depolarizing(2, 0.5), depolarizing(2, 0.9)]
+    value_primal, _ = channel_distinguishability(channels, primal_dual="primal")
+    value_dual, _ = channel_distinguishability(channels, primal_dual="dual")
+    assert pytest.approx(value_dual, abs=1e-6) == value_primal
+
+
+@pytest.mark.parametrize("num_channels", [3, 4])
+@pytest.mark.parametrize("primal_dual", ["primal", "dual"])
+def test_orthogonal_unitary_channels_perfectly_distinguishable(num_channels, primal_dual):
+    """Pauli unitary channels are orthogonal in Hilbert-Schmidt inner product, hence perfectly distinguishable."""
+    channels = [[pauli(ind)] for ind in range(num_channels)]
+    value, _ = channel_distinguishability(channels, primal_dual=primal_dual)
+    assert pytest.approx(1, abs=1e-6) == value
+
+
+@pytest.mark.parametrize("prior_prob", [None, [0.5, 0.5], [0.2, 0.8], [2, 8]])
+@pytest.mark.parametrize("primal_dual", ["primal", "dual"])
+def test_two_channel_list_mode_matches_cb_trace_norm(prior_prob, primal_dual):
+    """The n = 2 list-mode SDP agrees with the legacy CB-trace-norm shortcut, including non-uniform priors."""
+    value_legacy, _ = channel_distinguishability(amp_damp_1, amp_damp_2, prior_prob)
+    value_sdp, operators = channel_distinguishability(
+        [amp_damp_1, amp_damp_2], probs=prior_prob, primal_dual=primal_dual
+    )
+    assert pytest.approx(value_legacy, abs=1e-6) == value_sdp
+    assert len(operators) >= 1
+
+
+def test_list_mode_accepts_mixed_kraus_and_choi():
+    """List mode accepts each channel either as a Choi matrix or as a Kraus operator list."""
+    value_choi, _ = channel_distinguishability([amp_damp_1, amp_damp_2, dephasing(2)])
+    value_mixed, _ = channel_distinguishability([amp_damp_1_kraus, amp_damp_2, dephasing(2)])
+    assert pytest.approx(value_choi, abs=1e-6) == value_mixed
+
+
+def test_list_mode_minimax_two_channels():
+    """List mode with 2 channels routes minimax to the existing helpers."""
+    value_legacy, _ = channel_distinguishability(amp_damp_1, amp_damp_2, None, [2, 2], strategy="minimax")
+    value_list, operators = channel_distinguishability([amp_damp_1, amp_damp_2], strategy="minimax")
+    assert pytest.approx(value_legacy, abs=1e-6) == value_list
+    assert len(operators) >= 1
+
+    value_legacy_primal, _ = channel_distinguishability(
+        amp_damp_1, amp_damp_2, None, [2, 2], strategy="minimax", primal_dual="primal"
+    )
+    value_list_primal, _ = channel_distinguishability(
+        [amp_damp_1, amp_damp_2], strategy="minimax", primal_dual="primal"
+    )
+    assert pytest.approx(value_legacy_primal, abs=1e-6) == value_list_primal
+
+
+def test_list_mode_minimax_three_channels_raises():
+    """Minimax discrimination is out of scope for more than 2 channels."""
+    channels = [depolarizing(2, 0.1), depolarizing(2, 0.5), depolarizing(2, 0.9)]
+    with pytest.raises(ValueError, match="Minimax discrimination is only supported for exactly 2 channels."):
+        channel_distinguishability(channels, strategy="minimax")
+
+
+def test_list_mode_degenerate_prior_short_circuit():
+    """A degenerate prior in list mode short-circuits to a certain outcome."""
+    channels = [depolarizing(2, 0.1), depolarizing(2, 0.5), depolarizing(2, 0.9)]
+    value, operators = channel_distinguishability(channels, probs=[0, 1, 0])
+    assert value == 1.0
+    assert operators == []
+
+
+@pytest.mark.parametrize(
+    "channels, probs, expected_msg",
+    [
+        # A single channel is not enough for a discrimination task.
+        ([depolarizing(2, 0.1)], None, "When psi is None, phi must be a list of at least 2 channels."),
+        # A bare Choi matrix (not a list) with psi=None is rejected.
+        (depolarizing(2, 0.1), None, "When psi is None, phi must be a list of at least 2 channels."),
+        # Mismatched channel dimensions.
+        (
+            [depolarizing(2, 0.1), depolarizing(3, 0.5)],
+            None,
+            "The channels must have the same dimension input and output spaces as each other.",
+        ),
+        # Number of priors must match the number of channels.
+        (
+            [depolarizing(2, 0.1), depolarizing(2, 0.5), depolarizing(2, 0.9)],
+            [0.5, 0.5],
+            "probs must be a probability distribution with 3 entries.",
+        ),
+        # Negative weights are rejected.
+        (
+            [depolarizing(2, 0.1), depolarizing(2, 0.5), depolarizing(2, 0.9)],
+            [-0.5, 1.0, 0.5],
+            "Prior probabilities must be non-negative.",
+        ),
+        # Weights summing to zero are rejected.
+        (
+            [depolarizing(2, 0.1), depolarizing(2, 0.5), depolarizing(2, 0.9)],
+            [0.0, 0.0, 0.0],
+            "Prior probabilities must have a positive sum.",
+        ),
+    ],
+)
+def test_list_mode_invalid_inputs(channels, probs, expected_msg):
+    """List mode raises clear errors for invalid channel collections and priors."""
+    with pytest.raises(ValueError, match=expected_msg):
+        channel_distinguishability(channels, probs=probs)
+
+
+def test_list_mode_dual_operator_shape():
+    """The dual SDP returns a single dual operator of the expected shape."""
+    channels = [depolarizing(2, 0.1), depolarizing(2, 0.5), depolarizing(2, 0.9)]
+    _, operators = channel_distinguishability(channels, primal_dual="dual")
+    assert len(operators) == 1
+    assert operators[0].shape == (4, 4)
+    assert isinstance(operators[0], np.ndarray)


### PR DESCRIPTION
## Description
Fixes #1524.

Generalizes `channel_distinguishability` to accept a list of $n \geq 2$ channels with prior probabilities and solve the full Bayesian discrimination SDP of Watrous, *The Theory of Quantum Information* (2018), Section 3.5, in both primal and dual form. The existing two-argument signature is unchanged and keeps the CB-trace-norm shortcut, so existing callers get bit-identical values.

## Changes

  -  [x] New n-channel mode: `channel_distinguishability(channels, probs=...)` (with `psi=None`) accepts a list of channels, each given as a Choi matrix or a Kraus operator list; dimensions are validated per channel via `channel_dim`.
  -  [x] `_bayesian_primal`: maximize $\sum_i p_i \mathrm{Tr}[P_i J(\Phi_i)]$ subject to $\sum_i P_i = \rho \otimes \mathbb{I}_{\text{out}}$, $P_i \succeq 0$, $\rho \succeq 0$, $\mathrm{Tr}(\rho) = 1$; returns the optimal measurement operators.
  -  [x] `_bayesian_dual`: minimize $\lambda$ subject to $Y \succeq p_i J(\Phi_i)$ for all $i$ and $\mathrm{Tr}_{\text{out}}(Y) \preceq \lambda \mathbb{I}_{\text{in}}$; returns the dual operator.
  -  [x] Docstring documents both SDPs and includes a note mapping Watrous's notation (spaces $\mathcal{X}, \mathcal{Y}$, Choi operator on $\mathcal{Y} \otimes \mathcal{X}$) to toqito's input $\otimes$ output Choi convention and the corresponding `partial_trace` subsystem index, plus a runnable 3-depolarizing-channel example.
  -  [x] Minimax remains restricted to exactly 2 channels (out of scope per the issue) and raises a clear `ValueError` for $n \geq 3$; list mode with $n = 2$ routes to the existing minimax helpers.
  -  [x] Tests: 3 depolarizing channels with distinct noise parameters (primal and dual agree to $5 \times 10^{-9}$); $n = 3$ and $n = 4$ Hilbert-Schmidt-orthogonal unitary (Pauli) channels are perfectly distinguishable (value $\approx 1$); $n = 2$ list mode matches the legacy CB-trace-norm shortcut to $\sim 10^{-9}$ for uniform, non-uniform, and unnormalized priors; error paths for the new mode. Existing tests are untouched and pass.

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://vprusso.github.io/toqito/contributing-guide/).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures.