### PR TITLE
fix(channel_metrics): route CB norm dimension handling through channel_dim

### DIFF
--- a/toqito/channel_metrics/completely_bounded_spectral_norm.py
+++ b/toqito/channel_metrics/completely_bounded_spectral_norm.py
@@ -4,15 +4,23 @@ import numpy as np
 
 from toqito.channel_metrics import completely_bounded_trace_norm
 from toqito.channel_ops import dual_channel
+from toqito.channel_props.channel_dim import channel_dim
 
 
-def completely_bounded_spectral_norm(phi: np.ndarray) -> float | np.floating:
+def completely_bounded_spectral_norm(
+    phi: np.ndarray, dim: int | list[int] | np.ndarray | None = None
+) -> float | np.floating:
     r"""Compute the completely bounded spectral norm of a quantum channel.
 
     As defined in [@watrous2009semidefinite] and [@qetlablink].
 
     Args:
         phi: superoperator
+        dim: A scalar or vector containing the input and output dimensions of `phi`. This only
+            needs to be provided if the input and output dimensions of the channel differ (e.g. a
+            channel mapping a qubit to a qutrit), since they cannot be inferred from the Choi
+            matrix alone in that case. If the channel maps \(M_m\) to \(M_n\), then `dim` is
+            the vector `[m, n]`.
 
     Returns:
         The completely bounded spectral norm of the channel
@@ -29,4 +37,8 @@ def completely_bounded_spectral_norm(phi: np.ndarray) -> float | np.floating:
         ```
 
     """
-    return completely_bounded_trace_norm(dual_channel(phi))
+    # The dual channel swaps the input and output spaces, so the dimensions passed along to the
+    # completely bounded trace norm are reversed.
+    dim_in, dim_out, _ = channel_dim(phi, dim=dim, allow_rect=False, compute_env_dim=False)
+    dim_in, dim_out = int(dim_in), int(dim_out)
+    return completely_bounded_trace_norm(dual_channel(phi, dims=[dim_in, dim_out]), dim=[dim_out, dim_in])

--- a/toqito/channel_metrics/completely_bounded_trace_norm.py
+++ b/toqito/channel_metrics/completely_bounded_trace_norm.py
@@ -6,11 +6,17 @@ import numpy as np
 import picos as pc
 
 from toqito.channel_ops import apply_channel, dual_channel
-from toqito.channel_props import is_completely_positive, is_quantum_channel
+from toqito.channel_props import is_completely_positive, is_trace_preserving
+from toqito.channel_props.channel_dim import channel_dim
 from toqito.matrix_props import trace_norm
 
 
-def completely_bounded_trace_norm(phi: np.ndarray, solver: str = "cvxopt", **kwargs: Any) -> float | np.floating:
+def completely_bounded_trace_norm(
+    phi: np.ndarray,
+    solver: str = "cvxopt",
+    dim: int | list[int] | np.ndarray | None = None,
+    **kwargs: Any,
+) -> float | np.floating:
     r"""Find the completely bounded trace norm of a quantum channel.
 
     Also known as the diamond norm of a quantum channel (Section 3.3.2 of [@watrous2018theory]).
@@ -19,6 +25,11 @@ def completely_bounded_trace_norm(phi: np.ndarray, solver: str = "cvxopt", **kwa
     Args:
         phi: superoperator as choi matrix
         solver: Optimization option for `picos` solver. Default option is `solver="cvxopt"`.
+        dim: A scalar or vector containing the input and output dimensions of `phi`. This only
+            needs to be provided if the input and output dimensions of the channel differ (e.g. a
+            channel mapping a qubit to a qutrit), since they cannot be inferred from the Choi
+            matrix alone in that case. If the channel maps \(M_m\) to \(M_n\), then `dim` is
+            the vector `[m, n]`.
         kwargs: Additional arguments to pass to picos' solve method.
 
     Returns:
@@ -26,6 +37,8 @@ def completely_bounded_trace_norm(phi: np.ndarray, solver: str = "cvxopt", **kwa
 
     Raises:
         ValueError: If matrix is not square.
+        ValueError: If the dimensions of `phi` are inconsistent with `dim` (or, when `dim` is not
+            provided, if the input and output dimensions cannot be inferred from the Choi matrix).
 
     Examples:
         To compute the completely bounded trace norm of a depolarizing channel:
@@ -44,14 +57,19 @@ def completely_bounded_trace_norm(phi: np.ndarray, solver: str = "cvxopt", **kwa
     if dim_lx != dim_ly:
         raise ValueError("The input and output spaces of the superoperator phi must both be square.")
 
-    if is_quantum_channel(phi):
-        return 1
+    # Determine the input and output dimensions of the channel. This correctly handles channels
+    # with unequal input/output dimensions (given `dim`) instead of assuming both are
+    # sqrt(dim_lx).
+    dim_in, dim_out, _ = channel_dim(phi, dim=dim, allow_rect=False, compute_env_dim=False)
+    dim_in, dim_out = int(dim_in), int(dim_out)
 
     if is_completely_positive(phi):
-        v = apply_channel(np.eye(dim_ly), dual_channel(phi))
+        # Quantum channels have a completely bounded trace norm of 1.
+        if is_trace_preserving(phi, dim=[dim_in, dim_out]):
+            return 1
+        v = apply_channel(np.eye(dim_ly), dual_channel(phi, dims=[dim_in, dim_out]))
         return trace_norm(v)
 
-    dim = round(np.sqrt(dim_lx))
     # SDP
     sdp = pc.Problem()
     y0 = pc.HermitianVariable("y0", (dim_lx, dim_lx))
@@ -62,7 +80,11 @@ def completely_bounded_trace_norm(phi: np.ndarray, solver: str = "cvxopt", **kwa
 
     a_var = pc.block([[y0, -phi], [-phi.conj().T, y1]])
     sdp.add_constraint(a_var >> 0)
-    obj = pc.SpectralNorm(y0.partial_trace(1, dimensions=dim)) + pc.SpectralNorm(y1.partial_trace(1, dimensions=dim))
+    # The Choi matrix subsystems are ordered as (input, output), so the output space is traced
+    # out of each block.
+    obj = pc.SpectralNorm(y0.partial_trace(1, dimensions=(dim_in, dim_out))) + pc.SpectralNorm(
+        y1.partial_trace(1, dimensions=(dim_in, dim_out))
+    )
     sdp.set_objective("min", obj)
     sdp.solve(solver=solver, **kwargs)
 

--- a/toqito/channel_metrics/diamond_distance.py
+++ b/toqito/channel_metrics/diamond_distance.py
@@ -3,7 +3,9 @@
 import numpy as np
 
 
-def diamond_distance(choi_1: np.ndarray, choi_2: np.ndarray) -> float | np.floating:
+def diamond_distance(
+    choi_1: np.ndarray, choi_2: np.ndarray, dim: int | list[int] | np.ndarray | None = None
+) -> float | np.floating:
     r"""Return the diamond norm distance between two quantum channels.
 
     This function is a wrapper around
@@ -16,8 +18,13 @@ def diamond_distance(choi_1: np.ndarray, choi_2: np.ndarray) -> float | np.float
 
 
     Args:
-        choi_1: A 4**N by 4**N matrix (where N is the number of qubits).
-        choi_2: A 4**N by 4**N matrix (where N is the number of qubits).
+        choi_1: A (d_in * d_out) by (d_in * d_out) Choi matrix of the first channel.
+        choi_2: A (d_in * d_out) by (d_in * d_out) Choi matrix of the second channel.
+        dim: A scalar or vector containing the input and output dimensions of the channels. This
+            only needs to be provided if the input and output dimensions of the channels differ
+            (e.g. channels mapping a qubit to a qutrit), since they cannot be inferred from the
+            Choi matrices alone in that case. If the channels map \(M_m\) to \(M_n\), then
+            `dim` is the vector `[m, n]`.
 
     Raises:
         ValueError: If matrices are not of equal dimension.
@@ -51,4 +58,4 @@ def diamond_distance(choi_1: np.ndarray, choi_2: np.ndarray) -> float | np.float
     """
     from toqito.channel_metrics import completely_bounded_trace_norm  # noqa
 
-    return completely_bounded_trace_norm(choi_1 - choi_2)
+    return completely_bounded_trace_norm(choi_1 - choi_2, dim=dim)

--- a/toqito/channel_metrics/tests/test_channel_fidelity.py
+++ b/toqito/channel_metrics/tests/test_channel_fidelity.py
@@ -44,6 +44,27 @@ def test_channel_fidelity_raises_error(input1, input2, expected_msg):
         channel_fidelity(input1, input2)
 
 
+@pytest.mark.parametrize(
+    "dim",
+    [
+        # Qutrit channels (a non-power-of-2 dimension).
+        3,
+        # Dimension-6 channels (a non-power-of-2, non-prime dimension).
+        6,
+    ],
+)
+def test_channel_fidelity_qudit(dim):
+    """Qudit dimensions such as 3 and 6 are handled correctly (issue #1596).
+
+    The channel fidelity of a channel with itself is 1 and the root channel fidelity between the
+    dephasing and (completely) depolarizing channels is 1/sqrt(dim).
+    """
+    dephasing_choi = dephasing(dim)
+    depolarizing_choi = depolarizing(dim)
+    assert channel_fidelity(dephasing_choi, dephasing_choi, 1e-4) == pytest.approx(1, abs=1e-3)
+    assert channel_fidelity(dephasing_choi, depolarizing_choi, 1e-4) == pytest.approx(1 / np.sqrt(dim), abs=1e-3)
+
+
 def test_channel_fidelity_non_perfect_square_dim_raises():
     """A Choi matrix whose dimension is not a perfect square is rejected before the SDP."""
     mat = np.eye(6, dtype=complex)

--- a/toqito/channel_metrics/tests/test_completely_bounded_spectral_norm.py
+++ b/toqito/channel_metrics/tests/test_completely_bounded_spectral_norm.py
@@ -20,3 +20,15 @@ def test_cb_spectral_norm_identity_channel():
     """A non-tautological check: the CB spectral norm of the identity channel is 1."""
     identity_choi = kraus_to_choi([np.eye(2)])
     assert abs(completely_bounded_spectral_norm(identity_choi) - 1.0) <= 1e-4
+
+
+def test_cb_spectral_norm_rectangular_map():
+    r"""Maps with unequal input/output dimensions are handled via `dim` (issue #1596).
+
+    The qutrit-to-qubit map \(\Psi(Y) = V^\dagger Y V\), with \(V\) an isometry, is
+    completely positive and unital, so its dual is a quantum channel and its completely bounded
+    spectral norm is 1.
+    """
+    isometry = np.array([[1, 0], [0, 1], [0, 0]])
+    choi = kraus_to_choi([[isometry.conj().T, isometry.conj().T]])
+    assert abs(completely_bounded_spectral_norm(choi, dim=[3, 2]) - 1.0) <= 1e-3

--- a/toqito/channel_metrics/tests/test_completely_bounded_trace_norm.py
+++ b/toqito/channel_metrics/tests/test_completely_bounded_trace_norm.py
@@ -14,6 +14,18 @@ lam, _ = np.linalg.eig(U)
 dist = np.abs(lam[:, None] - lam[None, :])  # all to all distance
 diameter = np.max(dist)
 
+# A qutrit analogue: the difference of the clock-unitary channel and the identity channel. The
+# convex hull of the eigenvalues {1, w, w^2} of the clock unitary contains the origin, so the
+# completely bounded trace norm of the difference is 2.
+omega = np.exp(2j * np.pi / 3)
+clock = np.diag([1, omega, omega**2])
+phi_qutrit = kraus_to_choi([[np.eye(3), np.eye(3)], [clock, -clock]])
+
+# Isometries from a qubit into a qutrit, used to build channels with unequal input and output
+# dimensions.
+isometry_1 = np.array([[1, 0], [0, 1], [0, 0]])
+isometry_2 = np.array([[1, 0], [0, 0], [0, 1]])
+
 solvers = ["cvxopt"]
 
 
@@ -26,6 +38,8 @@ solvers = ["cvxopt"]
         (np.eye(4), 4.0),
         # unitaries channel, phi, diameter in terms of the eigenvalues of U
         (phi, diameter),
+        # qutrit unitaries channel (non-power-of-2 dimension)
+        (phi_qutrit, 2),
     ],
 )
 @pytest.mark.parametrize("solver", solvers)
@@ -33,6 +47,30 @@ def test_cb_trace_norm(test_input, solver, expected):
     """Test function works as expected for valid inputs."""
     calculated_value = completely_bounded_trace_norm(test_input, solver)
     assert abs(calculated_value - expected) <= 1e-3
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [
+        # A channel with unequal input and output dimensions (a qubit-to-qutrit isometry
+        # channel) is a quantum channel, so its completely bounded trace norm is 1.
+        (kraus_to_choi([[isometry_1, isometry_1]]), 1),
+        # The difference of two isometry channels whose isometries map |1> to orthogonal states
+        # is perfectly distinguishable, so its completely bounded trace norm is 2.
+        (kraus_to_choi([[isometry_1, isometry_1]]) - kraus_to_choi([[isometry_2, isometry_2]]), 2),
+    ],
+)
+def test_cb_trace_norm_rectangular(test_input, expected):
+    """Channels with unequal input/output dimensions are handled via `dim` (issue #1596)."""
+    calculated_value = completely_bounded_trace_norm(test_input, dim=[2, 3])
+    assert abs(calculated_value - expected) <= 1e-3
+
+
+def test_cb_trace_norm_rectangular_requires_dim():
+    """A Choi matrix with unequal input/output dimensions requires the `dim` argument."""
+    choi = kraus_to_choi([[isometry_1, isometry_1]])
+    with pytest.raises(ValueError, match="the optional argument DIM must be specified"):
+        completely_bounded_trace_norm(choi)
 
 
 def test_cb_trace_norm_invalid_input():

--- a/toqito/channel_metrics/tests/test_diamond_distance.py
+++ b/toqito/channel_metrics/tests/test_diamond_distance.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from toqito.channel_metrics import diamond_distance
+from toqito.channel_ops import kraus_to_choi
 from toqito.channels import dephasing, depolarizing
 
 
@@ -20,6 +21,38 @@ def test_diamond_norm_valid_inputs(test_input1, test_input_2, expected):
     """Test function works as expected for valid inputs."""
     calculated_value = diamond_distance(test_input1, test_input_2)
     assert pytest.approx(expected, 1e-3) == calculated_value
+
+
+def test_diamond_norm_qutrit_unitaries():
+    """Qutrit unitary channels (a non-power-of-2 dimension) are handled correctly (issue #1596).
+
+    For unitary channels the diamond distance is determined by the eigenvalues of U^dagger V.
+    For U = diag(1, 1, exp(i * theta)) versus the identity, it equals 2 * sin(theta / 2).
+    """
+    theta = np.pi / 2
+    unitary = np.diag([1, 1, np.exp(1j * theta)])
+    choi_u = kraus_to_choi([[unitary, unitary]])
+    choi_id = kraus_to_choi([[np.eye(3), np.eye(3)]])
+    assert pytest.approx(2 * np.sin(theta / 2), abs=1e-3) == diamond_distance(choi_u, choi_id)
+
+
+@pytest.mark.parametrize(
+    "test_input_2, expected",
+    [
+        # The two isometries map |1> to orthogonal states, so the channels are perfectly
+        # distinguishable and the diamond distance is 2.
+        (np.array([[1, 0], [0, 0], [0, 1]]), 2),
+        # V2 = |0><0| + (cos(t)|1> + sin(t)|2>)<1| with t = pi / 6. For isometry channels the
+        # diamond distance is 2 * sin(t) = 1.
+        (np.array([[1, 0], [0, np.cos(np.pi / 6)], [0, np.sin(np.pi / 6)]]), 1),
+    ],
+)
+def test_diamond_norm_rectangular_channels(test_input_2, expected):
+    """Channels with unequal input/output dimensions are handled via `dim` (issue #1596)."""
+    isometry_1 = np.array([[1, 0], [0, 1], [0, 0]])
+    choi_1 = kraus_to_choi([[isometry_1, isometry_1]])
+    choi_2 = kraus_to_choi([[test_input_2, test_input_2]])
+    assert pytest.approx(expected, abs=1e-3) == diamond_distance(choi_1, choi_2, dim=[2, 3])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
Fixes #1596.

The completely bounded trace norm inferred subsystem dimensions with `round(sqrt(choi_dim))`, assuming equal square input/output spaces, so channels with unequal input/output dimensions (e.g. a qubit-to-qutrit isometry channel) were computed incorrectly or crashed; `diamond_distance` and `completely_bounded_spectral_norm` inherited the same assumption. This PR routes dimension handling through `channel_dim`, mirroring the fix pattern already applied elsewhere.

Note: the other items listed in #1596 (the `np.log2` dimension inference in `channel_fidelity`, flat CP Kraus acceptance in `is_trace_preserving`/`is_quantum_channel`, the broad `except Exception`, and the `is_extremal` non-CP crash) were already fixed on master by #1625 and follow-up PRs; each was re-verified against master before this PR was scoped to the remaining CB norm family.

## Changes

  -  [x] `completely_bounded_trace_norm`: infer `dim_in`/`dim_out` via `channel_dim` instead of `round(sqrt(...))`, add an optional `dim` argument for channels whose input and output dimensions differ (required, since they cannot be inferred from the Choi matrix alone), pass explicit dimensions to the SDP partial traces and to `dual_channel`, and replace the `is_quantum_channel` early return with an `is_trace_preserving` check nested in the existing CP branch so it works for unequal dimensions.
  -  [x] `completely_bounded_spectral_norm`: accept `dim` and forward the reversed dimensions to the CB trace norm of the dual channel.
  -  [x] `diamond_distance`: accept `dim` and forward it; docstring no longer claims a `4**N` qubit-only shape.
  -  [x] Tests: qutrit CB trace norm (clock-unitary channel difference, value 2); qubit-to-qutrit isometry channels (CB trace norm 1 for a single isometry channel, 2 for the difference of two perfectly distinguishable ones); a clear error when `dim` is omitted for unequal-dimension Choi matrices; qutrit diamond distance against the closed form $2\sin(\theta/2)$ for unitary channels; rectangular-map CB spectral norm; `channel_fidelity` regression tests for $d = 3$ and $d = 6$.

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://vprusso.github.io/toqito/contributing-guide/).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures.