### PR TITLE
Fix Bures angle fidelity convention

### DIFF
--- a/toqito/state_metrics/bures_angle.py
+++ b/toqito/state_metrics/bures_angle.py
@@ -14,12 +14,12 @@ def bures_angle(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> flo
     Calculate the Bures angle between two density matrices `rho_1` and `rho_2` defined by:
 
     \[
-        \arccos{\sqrt{F (\rho_1, \rho_2)}}
+        \arccos{F (\rho_1, \rho_2)}
     \]
 
-    where \(F(\cdot)\) denotes the fidelity between \(\rho_1\) and \(\rho_2\). The return is a value between
-    \(0\) and \(\pi / 2\), with \(0\) corresponding to matrices `rho_1 = rho_2` and \(\pi / 2\)
-    corresponding to the case `rho_1` and `rho_2` with orthogonal support.
+    where \(F(\cdot)\) denotes the root fidelity between \(\rho_1\) and \(\rho_2\). The return is a value
+    between \(0\) and \(\pi / 2\), with \(0\) corresponding to matrices `rho_1 = rho_2` and
+    \(\pi / 2\) corresponding to the case `rho_1` and `rho_2` with orthogonal support.
 
     Args:
         rho_1: Density operator.
@@ -76,4 +76,4 @@ def bures_angle(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> flo
     # sqrtm-based fidelity can push it just above 1 for near-identical states, which would make
     # arccos receive an argument greater than 1 and yield NaN.
     fid = np.clip(np.round(fidelity(rho_1, rho_2), decimals), 0.0, 1.0)
-    return np.real(np.arccos(np.sqrt(fid)))
+    return np.real(np.arccos(fid))

--- a/toqito/state_metrics/tests/test_bures_angle.py
+++ b/toqito/state_metrics/tests/test_bures_angle.py
@@ -22,7 +22,7 @@ def test_bures_angle_non_identical_states_1():
     sigma = 2 / 3 * e_0 @ e_0.conj().T + 1 / 3 * e_1 @ e_1.conj().T
 
     ang = bures_angle(rho, sigma)
-    np.testing.assert_equal(np.isclose(ang, 0.06499, rtol=1e-03), True)
+    np.testing.assert_equal(np.isclose(ang, 0.09188, rtol=1e-03), True)
 
 
 def test_bures_angle_non_identical_states_2():
@@ -32,7 +32,7 @@ def test_bures_angle_non_identical_states_2():
     sigma = 1 / 8 * e_0 @ e_0.conj().T + 7 / 8 * e_1 @ e_1.conj().T
 
     ang = bures_angle(rho, sigma)
-    np.testing.assert_equal(np.isclose(ang, 0.4955, rtol=1e-03), True)
+    np.testing.assert_equal(np.isclose(ang, 0.68583, rtol=1e-03), True)
 
 
 def test_bures_angle_pure_states():
@@ -43,7 +43,7 @@ def test_bures_angle_pure_states():
     sigma = e_0 @ e_0.conj().T
 
     ang = bures_angle(rho, sigma)
-    np.testing.assert_equal(np.isclose(ang, 0.5718, rtol=1e-03), True)
+    np.testing.assert_equal(np.isclose(ang, np.pi / 4, rtol=1e-03), True)
 
 
 def test_bures_angle_non_square():


### PR DESCRIPTION
## Summary
- correct the Bures angle formula for the root-fidelity convention used by `fidelity`
- update the Bures angle docstring to match the implemented convention
- update tests for non-identical states under the corrected convention

## Validation
- `uv run pytest toqito/state_metrics/tests/test_bures_angle.py -q`

Closes #1718