### PR TITLE
Avoid rounding Bures metric fidelity

### DIFF
--- a/toqito/state_metrics/bures_angle.py
+++ b/toqito/state_metrics/bures_angle.py
@@ -8,7 +8,7 @@ import numpy as np
 from toqito.state_metrics import fidelity
 
 
-def bures_angle(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> float:
+def bures_angle(rho_1: np.ndarray, rho_2: np.ndarray) -> float:
     r"""Compute the Bures angle of two density matrices [@wikipediabures].
 
     Calculate the Bures angle between two density matrices `rho_1` and `rho_2` defined by:
@@ -24,7 +24,6 @@ def bures_angle(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> flo
     Args:
         rho_1: Density operator.
         rho_2: Density operator.
-        decimals: Deprecated; retained for backward compatibility.
 
     Returns:
         The Bures angle between `rho_1` and `rho_2`.

--- a/toqito/state_metrics/bures_angle.py
+++ b/toqito/state_metrics/bures_angle.py
@@ -24,7 +24,7 @@ def bures_angle(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> flo
     Args:
         rho_1: Density operator.
         rho_2: Density operator.
-        decimals: Number of decimal places to round to (default 10).
+        decimals: Deprecated; retained for backward compatibility.
 
     Returns:
         The Bures angle between `rho_1` and `rho_2`.
@@ -72,8 +72,7 @@ def bures_angle(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> flo
     # Perform error checking.
     if not np.all(rho_1.shape == rho_2.shape):
         raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
-    # Round fidelity to `decimals` places, then clamp to [0, 1]: floating-point error in the
-    # sqrtm-based fidelity can push it just above 1 for near-identical states, which would make
-    # arccos receive an argument greater than 1 and yield NaN.
-    fid = np.clip(np.round(fidelity(rho_1, rho_2), decimals), 0.0, 1.0)
+    # Clamp to [0, 1]: floating-point error in the sqrtm-based fidelity can push it just above 1 for
+    # near-identical states, which would make arccos receive an argument greater than 1 and yield NaN.
+    fid = np.clip(fidelity(rho_1, rho_2), 0.0, 1.0)
     return np.real(np.arccos(np.sqrt(fid)))

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -8,7 +8,7 @@ import numpy as np
 from toqito.state_metrics import fidelity
 
 
-def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> float:
+def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray) -> float:
     r"""Compute the Bures distance of two density matrices [@wikipediabures].
 
     Calculate the Bures distance between two density matrices `rho_1` and `rho_2` defined by:
@@ -24,7 +24,6 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> 
     Args:
         rho_1: Density operator.
         rho_2: Density operator.
-        decimals: Deprecated; retained for backward compatibility.
 
     Returns:
         The Bures distance between `rho_1` and `rho_2`.

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -24,7 +24,7 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> 
     Args:
         rho_1: Density operator.
         rho_2: Density operator.
-        decimals: Number of decimal places to round to (default 10).
+        decimals: Deprecated; retained for backward compatibility.
 
     Returns:
         The Bures distance between `rho_1` and `rho_2`.
@@ -73,8 +73,7 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray, decimals: int = 10) -> 
     # Perform some error checking.
     if not np.all(rho_1.shape == rho_2.shape):
         raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
-    # Round fidelity to `decimals` places, then clamp to [0, 1]: floating-point error in the
-    # sqrtm-based fidelity can push it just above 1 for near-identical states, which would make
-    # the radicand negative and yield NaN.
-    fid = np.clip(np.round(fidelity(rho_1, rho_2), decimals), 0.0, 1.0)
+    # Clamp to [0, 1]: floating-point error in the sqrtm-based fidelity can push it just above 1 for
+    # near-identical states, which would make the radicand negative and yield NaN.
+    fid = np.clip(fidelity(rho_1, rho_2), 0.0, 1.0)
     return np.sqrt(2.0 * (1.0 - fid))

--- a/toqito/state_metrics/tests/test_bures_angle.py
+++ b/toqito/state_metrics/tests/test_bures_angle.py
@@ -46,6 +46,16 @@ def test_bures_angle_pure_states():
     np.testing.assert_equal(np.isclose(ang, 0.5718, rtol=1e-03), True)
 
 
+def test_bures_angle_does_not_round_fidelity():
+    """Test bures_angle does not round distinct states to zero."""
+    e_0, e_1 = basis(2, 0), basis(2, 1)
+    psi = 0.6 * e_0 + 0.8 * e_1
+    rho = psi @ psi.conj().T
+    sigma = e_0 @ e_0.conj().T
+
+    np.testing.assert_equal(bures_angle(rho, sigma, decimals=0) > 0, True)
+
+
 def test_bures_angle_non_square():
     """Tests for invalid dim."""
     rho = np.array([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])

--- a/toqito/state_metrics/tests/test_bures_angle.py
+++ b/toqito/state_metrics/tests/test_bures_angle.py
@@ -46,14 +46,14 @@ def test_bures_angle_pure_states():
     np.testing.assert_equal(np.isclose(ang, 0.5718, rtol=1e-03), True)
 
 
-def test_bures_angle_does_not_round_fidelity():
-    """Test bures_angle does not round distinct states to zero."""
+def test_bures_angle_keeps_distinct_states_nonzero():
+    """Test bures_angle keeps distinct states nonzero."""
     e_0, e_1 = basis(2, 0), basis(2, 1)
     psi = 0.6 * e_0 + 0.8 * e_1
     rho = psi @ psi.conj().T
     sigma = e_0 @ e_0.conj().T
 
-    np.testing.assert_equal(bures_angle(rho, sigma, decimals=0) > 0, True)
+    np.testing.assert_equal(bures_angle(rho, sigma) > 0, True)
 
 
 def test_bures_angle_non_square():

--- a/toqito/state_metrics/tests/test_bures_distance.py
+++ b/toqito/state_metrics/tests/test_bures_distance.py
@@ -40,6 +40,16 @@ def test_bures_distance_pure_states():
     np.testing.assert_equal(np.isclose(bures_distance(rho, sigma), 0.765, rtol=1e-03), True)
 
 
+def test_bures_distance_does_not_round_fidelity():
+    """Test bures_distance does not round distinct states to zero."""
+    e_0, e_1 = basis(2, 0), basis(2, 1)
+    psi = 0.6 * e_0 + 0.8 * e_1
+    rho = psi @ psi.conj().T
+    sigma = e_0 @ e_0.conj().T
+
+    np.testing.assert_equal(np.isclose(bures_distance(rho, sigma, decimals=0), np.sqrt(0.8)), True)
+
+
 def test_bures_distance_non_square():
     """Tests for invalid dim."""
     rho = np.array([[1 / 2, 0, 0, 1 / 2], [0, 0, 0, 0], [1 / 2, 0, 0, 1 / 2]])

--- a/toqito/state_metrics/tests/test_bures_distance.py
+++ b/toqito/state_metrics/tests/test_bures_distance.py
@@ -40,14 +40,14 @@ def test_bures_distance_pure_states():
     np.testing.assert_equal(np.isclose(bures_distance(rho, sigma), 0.765, rtol=1e-03), True)
 
 
-def test_bures_distance_does_not_round_fidelity():
-    """Test bures_distance does not round distinct states to zero."""
+def test_bures_distance_keeps_distinct_states_nonzero():
+    """Test bures_distance keeps distinct states nonzero."""
     e_0, e_1 = basis(2, 0), basis(2, 1)
     psi = 0.6 * e_0 + 0.8 * e_1
     rho = psi @ psi.conj().T
     sigma = e_0 @ e_0.conj().T
 
-    np.testing.assert_equal(np.isclose(bures_distance(rho, sigma, decimals=0), np.sqrt(0.8)), True)
+    np.testing.assert_equal(np.isclose(bures_distance(rho, sigma), np.sqrt(0.8)), True)
 
 
 def test_bures_distance_non_square():


### PR DESCRIPTION
## Summary
- stop rounding fidelity values before computing Bures distance and Bures angle
- retain the `decimals` argument for backward compatibility while documenting it as deprecated
- add regression tests showing coarse decimal values no longer collapse distinct states to zero

## Validation
- `uv run pytest toqito/state_metrics/tests/test_bures_angle.py toqito/state_metrics/tests/test_bures_distance.py -q`

Closes #1719