### PR TITLE
Validate Breuer state parameters

### DIFF
--- a/toqito/states/breuer.py
+++ b/toqito/states/breuer.py
@@ -12,9 +12,9 @@ from toqito.states import max_entangled
 def breuer(dim: int, lam: float) -> np.ndarray:
     r"""Produce a Breuer state [@breuer2006optimal].
 
-    Gives a Breuer bound entangled state for two qudits of local dimension `dim`, with the
-    `lam` parameter describing the weight of the singlet component as described in
-    [@breuer2006optimal].
+    Gives a Breuer state for two qudits of local dimension `dim`, with the `lam` parameter describing the
+    weight of the singlet component as described in [@breuer2006optimal]. For even local dimensions
+    \(d \geq 4\) and \(\lambda > 0\), this construction gives bound entangled states.
 
     This function was adapted from the QETLAB package [@qetlablink].
 
@@ -26,20 +26,25 @@ def breuer(dim: int, lam: float) -> np.ndarray:
         Breuer state of dimension `dim` with weight `lam`.
 
     Raises:
-        ValueError: Dimension must be greater than or equal to 1.
+        ValueError: Dimension must be a positive even integer.
+        ValueError: `lam` must be between 0 and 1.
 
     Examples:
-        We can generate a Breuer state of dimension \(4\) with weight \(0.1\). For any weight above \(0\), the
-        state will be bound entangled, that is, it will satisfy the PPT criterion, but it will be entangled.
+        We can generate a Breuer bound entangled state of local dimension \(4\) with weight \(0.1\). For even
+        local dimension at least \(4\) and any positive weight, the state satisfies the PPT criterion, but it
+        is entangled.
 
         ```python exec="1" source="above" result="text"
         from toqito.states import breuer
-        print(breuer(2, 0.1))
+        print(breuer(4, 0.1))
         ```
 
     """
     if dim % 2 == 1 or dim <= 0:
         raise ValueError(f"The value {dim} must be an even positive integer.")
+
+    if not 0 <= lam <= 1:
+        raise ValueError("The weight `lam` must be between 0 and 1.")
 
     v_mat = np.fliplr(np.diag((-1) ** np.mod(np.arange(1, dim + 1), 2)))
     max_entangled(dim)

--- a/toqito/states/tests/test_breuer.py
+++ b/toqito/states/tests/test_breuer.py
@@ -9,7 +9,7 @@ from toqito.states import breuer
 @pytest.mark.parametrize(
     "dim, lam, expected_result",
     [
-        # Generate Breuer state of dimension 4 with weight 0.1.
+        # Generate Breuer state of local dimension 2 with weight 0.1.
         (2, 0.1, np.array([[0.3, 0, 0, 0], [0, 0.2, 0.1, 0], [0, 0.1, 0.2, 0], [0, 0, 0, 0.3]])),
     ],
 )
@@ -21,8 +21,12 @@ def test_breuer(dim, lam, expected_result):
 @pytest.mark.parametrize(
     "dim, lam",
     [
-        # Ensures that an odd dimension if not accepted.
-        (3, 0.1)
+        # Ensures that an odd dimension is not accepted.
+        (3, 0.1),
+        # Ensures that negative weights are not accepted.
+        (2, -0.1),
+        # Ensures that weights greater than one are not accepted.
+        (2, 1.1),
     ],
 )
 def test_breuer_invalid(dim, lam):


### PR DESCRIPTION
## Summary
- validate that the Breuer state weight is between 0 and 1
- correct the Breuer documentation to use local dimension 4 for the bound-entangled example
- add invalid-weight regression tests

## Validation
- `uv run pytest toqito/states/tests/test_breuer.py -q`

Closes #1720