### PR TITLE
Validate GHZ coefficient norm

### DIFF
--- a/toqito/states/ghz.py
+++ b/toqito/states/ghz.py
@@ -18,20 +18,21 @@ def ghz(dim: int, num_qubits: int, coeff: list[int] | None = None) -> np.ndarray
     as
 
     \[
-        |GHZ \rangle = \frac{1}{\sqrt{n}} \left(|0\rangle^{\otimes n} +
-        |1 \rangle^{\otimes n} \right)).
+        |GHZ \rangle = \frac{1}{\sqrt{2}} \left(|0\rangle^{\otimes n} +
+        |1 \rangle^{\otimes n} \right).
     \]
 
     Args:
         dim: The local dimension.
         num_qubits: The number of parties (qubits/qudits)
-        coeff: (default `[1, 1, ..., 1])/sqrt(dim)`: a 1-by-`dim` vector of coefficients.
+        coeff: Default is `[1, 1, ..., 1] / sqrt(dim)`, a 1-by-`dim` vector of coefficients.
 
     Returns:
         Numpy vector array as GHZ state.
 
     Raises:
         ValueError: Number of qubits is not a positive integer.
+        ValueError: Coefficient vector has zero norm.
 
     Examples:
         When `dim = 2`, and `num_qubits = 3` this produces the standard GHZ state
@@ -71,6 +72,8 @@ def ghz(dim: int, num_qubits: int, coeff: list[int] | None = None) -> np.ndarray
 
     # Normalize coefficients if they are not.
     norm = np.linalg.norm(coeff)
+    if np.isclose(norm, 0.0):
+        raise ValueError("InvalidCoeff: The variable `coeff` must have nonzero norm.")
     if not np.isclose(norm, 1.0):
         coeff = coeff / norm
 

--- a/toqito/states/tests/test_ghz.py
+++ b/toqito/states/tests/test_ghz.py
@@ -57,6 +57,8 @@ def test_ghz_4_7():
         (2, 0, None),
         # Invalid coefficients.
         (2, 3, [1, 2, 3, 4, 5]),
+        # Zero-norm coefficients.
+        (2, 3, [0, 0]),
     ],
 )
 def test_ghz_invalid_input(dim, num_qubits, coeff):


### PR DESCRIPTION
## Summary
- reject zero-norm GHZ coefficient vectors before normalization
- add a regression test for all-zero coefficients
- correct the GHZ docstring formula and coefficient description

## Validation
- `uv run pytest toqito/states/tests/test_ghz.py -q`

Closes #1721