### PR TITLE
Validate empty operator collections

### DIFF
--- a/toqito/channel_ops/kraus_to_choi.py
+++ b/toqito/channel_ops/kraus_to_choi.py
@@ -58,6 +58,9 @@ def kraus_to_choi(kraus_ops: list[np.ndarray] | list[list[np.ndarray]], sys: int
     if sys < 0:
         raise ValueError("The `sys` parameter must be non-negative.")
 
+    if not kraus_ops:
+        raise ValueError("The list of Kraus operators cannot be empty.")
+
     if sys == 2:
         # Fast path for the default convention (apply the channel to the second subsystem of the unnormalized
         # maximally entangled state). The Choi matrix is then sum_i vec(A_i) vec(B_i)^dagger, where vec stacks the

--- a/toqito/channel_ops/natural_representation.py
+++ b/toqito/channel_ops/natural_representation.py
@@ -22,6 +22,9 @@ def natural_representation(kraus_ops: list[np.ndarray]) -> np.ndarray:
         ```
 
     """
+    if not kraus_ops:
+        raise ValueError("The list of Kraus operators cannot be empty.")
+
     dim = kraus_ops[0].shape
     if not all(k.shape == dim for k in kraus_ops):
         raise ValueError("All Kraus operators must have the same dimensions.")

--- a/toqito/channel_ops/tests/test_kraus_to_choi.py
+++ b/toqito/channel_ops/tests/test_kraus_to_choi.py
@@ -143,3 +143,9 @@ def test_kraus_to_choi_raises_on_negative_sys():
     """Ensure negative `sys` raises ValueError."""
     with pytest.raises(ValueError):
         kraus_to_choi(kraus_ops_transpose, sys=-1)
+
+
+def test_kraus_to_choi_raises_on_empty_kraus_list():
+    """Ensure empty Kraus lists raise ValueError."""
+    with pytest.raises(ValueError, match="The list of Kraus operators cannot be empty."):
+        kraus_to_choi([])

--- a/toqito/channel_ops/tests/test_natural_representataion.py
+++ b/toqito/channel_ops/tests/test_natural_representataion.py
@@ -57,6 +57,12 @@ def test_natural_representation_different_dimensions():
         natural_representation([k1, k2])
 
 
+def test_natural_representation_empty_kraus_list():
+    """Test natural_representation with an empty Kraus list."""
+    with pytest.raises(ValueError, match="The list of Kraus operators cannot be empty."):
+        natural_representation([])
+
+
 def test_natural_representation_trace_preserving():
     """Test that the natural representation produces a trace-preserving map."""
     nat_rep = natural_representation(depol_channel)

--- a/toqito/matrix_ops/tensor_comb.py
+++ b/toqito/matrix_ops/tensor_comb.py
@@ -64,6 +64,9 @@ def tensor_comb(
     if not states:
         raise ValueError("Input list of states cannot be empty.")
 
+    if k <= 0:
+        raise ValueError("k must be a positive integer.")
+
     if mode not in ("injective", "non-injective", "diagonal"):
         raise ValueError("mode must be injective, non-injective, or diagonal.")
 

--- a/toqito/matrix_ops/tests/test_tensor_comb.py
+++ b/toqito/matrix_ops/tests/test_tensor_comb.py
@@ -192,6 +192,10 @@ def test_tensor_comb_density_matrix(states, k, mode, expected_comb_keys, expecte
         ),
         # empty input
         ([], 2, False, "injective", "Input list of states cannot be empty."),
+        # invalid sequence length
+        ([np.array([1, 0]), np.array([0, 1])], 0, False, "injective", "k must be a positive integer."),
+        # invalid sequence length
+        ([np.array([1, 0]), np.array([0, 1])], -1, False, "injective", "k must be a positive integer."),
     ],
 )
 def test_raised_errors(test_input, test_k, test_density_matrix, test_mode, expected_msg):

--- a/toqito/measurements/pretty_good_measurement.py
+++ b/toqito/measurements/pretty_good_measurement.py
@@ -58,7 +58,10 @@ def pretty_good_measurement(
     """
     n = len(states)
 
-    # If not probabilities are explicitly given, assume a uniform distribution.
+    if n == 0:
+        raise ValueError("The list of states must contain at least one state.")
+
+    # If probabilities are not explicitly given, assume a uniform distribution.
     if probs is None:
         probs = n * [1 / n]
 

--- a/toqito/measurements/tests/test_pretty_good_measurement.py
+++ b/toqito/measurements/tests/test_pretty_good_measurement.py
@@ -72,3 +72,9 @@ def test_pgm_invalid_states(states, probs):
     """Ensures that number of states and number of probabilities are equal."""
     with np.testing.assert_raises(ValueError):
         pretty_good_measurement(states, probs)
+
+
+def test_pgm_empty_states():
+    """Ensures at least one state is provided."""
+    with np.testing.assert_raises(ValueError):
+        pretty_good_measurement([])


### PR DESCRIPTION
## Summary
- add explicit validation for nonpositive tensor sequence lengths
- reject empty state lists in pretty good measurement construction
- reject empty Kraus operator lists in channel conversion helpers
- add regression tests for these invalid inputs

## Validation
- `uv run pytest toqito/matrix_ops/tests/test_tensor_comb.py toqito/measurements/tests/test_pretty_good_measurement.py toqito/channel_ops/tests/test_kraus_to_choi.py toqito/channel_ops/tests/test_natural_representataion.py -q`

Closes #1722