### PR TITLE
Apply matrix property tolerances consistently

### DIFF
--- a/toqito/matrix_props/is_equiangular_tight_frame.py
+++ b/toqito/matrix_props/is_equiangular_tight_frame.py
@@ -65,11 +65,11 @@ def is_equiangular_tight_frame(mat: np.ndarray, tol: float = 1e-8) -> bool:
 
     if num_vecs < 2:
         # A single vector trivially satisfies ETF conditions if it has unit norm.
-        return np.isclose(np.linalg.norm(mat[:, 0]), 1.0, atol=tol) if num_vecs == 1 else False
+        return np.isclose(np.linalg.norm(mat[:, 0]), 1.0, rtol=0, atol=tol) if num_vecs == 1 else False
 
     # 1. Check unit norms.
     norms = np.linalg.norm(mat, axis=0)
-    if not np.allclose(norms, 1.0, atol=tol):
+    if not np.allclose(norms, 1.0, rtol=0, atol=tol):
         return False
 
     # 2. Check equiangularity.

--- a/toqito/matrix_props/is_positive_semidefinite.py
+++ b/toqito/matrix_props/is_positive_semidefinite.py
@@ -60,6 +60,8 @@ def is_positive_semidefinite(mat: np.ndarray, rtol: float = 1e-05, atol: float =
     """
     if not is_hermitian(mat, rtol, atol):
         return False
-    evals = np.linalg.eigvalsh(mat)
+    evals, _ = np.linalg.eigh(mat)
+    if evals.size == 0:
+        return True
     scale = max(1.0, np.max(np.abs(evals)))
     return bool(np.min(evals) >= -(atol + rtol * scale))

--- a/toqito/matrix_props/is_positive_semidefinite.py
+++ b/toqito/matrix_props/is_positive_semidefinite.py
@@ -60,5 +60,6 @@ def is_positive_semidefinite(mat: np.ndarray, rtol: float = 1e-05, atol: float =
     """
     if not is_hermitian(mat, rtol, atol):
         return False
-    evals, _ = np.linalg.eigh(mat)
-    return all(x >= -abs(atol) for x in evals)
+    evals = np.linalg.eigvalsh(mat)
+    scale = max(1.0, np.max(np.abs(evals)))
+    return bool(np.min(evals) >= -(atol + rtol * scale))

--- a/toqito/matrix_props/is_tight_frame.py
+++ b/toqito/matrix_props/is_tight_frame.py
@@ -69,4 +69,4 @@ def is_tight_frame(vectors: list[np.ndarray], tol: float = 1e-8) -> bool:
     if frame_bound < tol:
         return False
 
-    return np.allclose(frame_op, frame_bound * np.eye(dim), atol=tol)
+    return np.allclose(frame_op, frame_bound * np.eye(dim), rtol=0, atol=tol)

--- a/toqito/matrix_props/tests/test_is_equiangular_tight_frame.py
+++ b/toqito/matrix_props/tests/test_is_equiangular_tight_frame.py
@@ -80,3 +80,10 @@ def test_empty_matrix():
     """Matrix with no columns."""
     mat = np.zeros((3, 0))
     assert not is_equiangular_tight_frame(mat)
+
+
+def test_etf_does_not_use_default_relative_tolerance():
+    """Test ETF norm checks use only the requested absolute tolerance."""
+    mat = np.array([[1 + 5e-6], [0]])
+
+    assert not is_equiangular_tight_frame(mat, tol=1e-8)

--- a/toqito/matrix_props/tests/test_is_positive_semidefinite.py
+++ b/toqito/matrix_props/tests/test_is_positive_semidefinite.py
@@ -15,3 +15,10 @@ def test_is_not_positive_semidefinite():
     """Test that non-positive semidefinite matrix returns False."""
     mat = np.array([[-1, -1], [-1, -1]])
     np.testing.assert_equal(is_positive_semidefinite(mat), False)
+
+
+def test_is_positive_semidefinite_uses_relative_tolerance():
+    """Test that the eigenvalue cutoff honors relative tolerance."""
+    mat = np.diag([1e6, -2e-2])
+    np.testing.assert_equal(is_positive_semidefinite(mat, rtol=1e-8, atol=1e-8), False)
+    np.testing.assert_equal(is_positive_semidefinite(mat, rtol=3e-8, atol=1e-8), True)

--- a/toqito/matrix_props/tests/test_is_tight_frame.py
+++ b/toqito/matrix_props/tests/test_is_tight_frame.py
@@ -68,3 +68,11 @@ def test_inconsistent_dimensions_raises():
 def test_zero_vectors_have_zero_frame_bound_and_are_not_tight_frame():
     """A set of zero vectors has frame bound 0 and cannot form a tight frame."""
     assert not is_tight_frame([np.zeros(3), np.zeros(3)])
+
+
+def test_tight_frame_does_not_use_default_relative_tolerance():
+    """Test tight frame checks use only the requested absolute tolerance."""
+    e0 = np.array([1, 0])
+    e1 = np.array([0, 1 + 5e-6])
+
+    assert not is_tight_frame([e0, e1], tol=1e-8)


### PR DESCRIPTION
## Summary
- make positive semidefinite checks honor both absolute and relative tolerances in the eigenvalue cutoff
- use `eigvalsh` when only Hermitian eigenvalues are needed
- pass `rtol=0` in tight-frame and equiangular-tight-frame comparisons so `tol` is not weakened by NumPy defaults
- add regression tests for tolerance behavior

## Validation
- `uv run pytest toqito/matrix_props/tests/test_is_positive_semidefinite.py toqito/matrix_props/tests/test_is_tight_frame.py toqito/matrix_props/tests/test_is_equiangular_tight_frame.py -q`

Closes #1723