### PR TITLE
Fix citation reference keys

### DIFF
--- a/docs/content/refs.bib
+++ b/docs/content/refs.bib
@@ -1195,6 +1195,19 @@
   month = {Feb},
 }
 
+@article{navascues2009complete,
+  title = {Complete Criterion for Separability Detection},
+  author = {Navascués, Miguel and Owari, Masaki and Plenio, Martin B.},
+  journal = {Physical Review Letters},
+  volume = {103},
+  number = {16},
+  pages = {160404},
+  year = {2009},
+  publisher = {American Physical Society},
+  DOI = {10.1103/PhysRevLett.103.160404},
+  url = {https://link.aps.org/doi/10.1103/PhysRevLett.103.160404},
+}
+
 @article{navascues2014characterization,
   title = {Characterization of quantum correlations with local dimension
            constraints and its device-independent applications},
@@ -1388,6 +1401,14 @@
   primaryClass = {quant-ph},
 }
 
+@phdthesis{speelman2016position,
+  title = {Position-Based Quantum Cryptography and Catalytic Computation},
+  author = {Speelman, Florian},
+  school = {University of Amsterdam},
+  year = {2016},
+  url = {https://eprints.illc.uva.nl/id/eprint/2138/},
+}
+
 @misc{sikora2019semidefinite,
   title = {Semidefinite programming in quantum theory (lecture series)},
   author = {Sikora, Jamie},
@@ -1432,6 +1453,18 @@
   year = {2001},
   month = {jun},
   pages = {5807-5810},
+}
+
+@inproceedings{tropp2005complex,
+  title = {Complex Equiangular Tight Frames},
+  author = {Tropp, Joel A.},
+  booktitle = {Wavelets XI},
+  volume = {5914},
+  pages = {591401},
+  year = {2005},
+  publisher = {SPIE},
+  DOI = {10.1117/12.618821},
+  url = {https://doi.org/10.1117/12.618821},
 }
 
 @article{tomamichel2013monogamy,

--- a/toqito/matrices/standard_basis.py
+++ b/toqito/matrices/standard_basis.py
@@ -18,7 +18,7 @@ def standard_basis(dim: int, flatten: bool = False) -> list[np.ndarray]:
         |n> = (0, 0, 0, ..., 1)^T
     \]
 
-    This function was inspired by [@Seshadri_2021_Git, Seshadri_2021_Theory, Seshadri_2021_Versatile]
+    This function was inspired by [@seshadri2021git, @seshadri2021theory, @seshadri2021versatile]
 
     Args:
         dim: The dimension of the basis.

--- a/toqito/measurements/pretty_bad_measurement.py
+++ b/toqito/measurements/pretty_bad_measurement.py
@@ -12,7 +12,7 @@ def pretty_bad_measurement(
 
     This computes the "pretty bad measurement" (PBM) as defined in
     [@mcirvin2024pretty]. The PBM is an analogue to the "pretty
-    good measurement" defined in [@Belavkin_1975_Optimal,Hughston_1993_Complete]
+    good measurement" defined in [@belavkin1975optimal, @hughston1993complete]
     and is useful for approximating the optimal measurement
     for state exclusion.
 

--- a/toqito/measurements/pretty_good_measurement.py
+++ b/toqito/measurements/pretty_good_measurement.py
@@ -12,7 +12,7 @@ def pretty_good_measurement(
 
     This computes the "pretty good measurement" (PGM), also known as the
     square-root measurement, which is a widely used measurement for quantum
-    state discrimination [@Belavkin_1975_Optimal,Hughston_1993_Complete].
+    state discrimination [@belavkin1975optimal, @hughston1993complete].
 
     The PGM is the set of POVMs \((G_1, \ldots, G_n)\) such that
 

--- a/toqito/nonlocal_games/quantum_hedging.py
+++ b/toqito/nonlocal_games/quantum_hedging.py
@@ -11,7 +11,7 @@ class QuantumHedging:
     r"""Calculate optimal winning probabilities for hedging scenarios.
 
     Calculate the maximal and minimal winning probabilities for quantum
-    hedging to occur in certain two-party scenarios [@Arunachalam_2017_QuantumHedging, Molina_2012_Hedging].
+    hedging to occur in certain two-party scenarios [@arunachalam2017quantum, @molina2012hedging].
 
     Examples:
         This example illustrates the initial example of perfect hedging when Alice

--- a/toqito/state_opt/bell_inequality_max.py
+++ b/toqito/state_opt/bell_inequality_max.py
@@ -953,7 +953,7 @@ def _fc_to_fp(fc_mat: np.ndarray, behavior: bool = False) -> np.ndarray:
         The probability tensor \(V[a, b, x, y]\) in Full Probability notation (oa=2, ob=2).
 
     !!! Note
-        This function is adapted from the QETLAB MATLAB package function ``FC2FP`` [@QETLAB].
+        This function is adapted from the QETLAB MATLAB package function ``FC2FP`` [@qetlablink].
         For `behavior=True`, it applies the standard formula relating probabilities to correlators:
         \(P(a', b' | x, y) = (1 + a'\langle A_x \rangle + b'\langle B_y \rangle +\)
         \(a'b'\langle A_x B_y \rangle) / 4\),

--- a/toqito/state_opt/npa_hierarchy.py
+++ b/toqito/state_opt/npa_hierarchy.py
@@ -94,7 +94,7 @@ def npa_constraints(
 
             # Moment matrix (Gamma matrix in NPA paper [@navascues2008convergent] - arXiv:0803.4290)
             # This hierarchy can be generalized, e.g., to incorporate referee systems
-            # as seen in extended nonlocal games (see, e.g., F. Speelman's thesis, [@Speelman_2016_Position]).
+            # as seen in extended nonlocal games (see, e.g., F. Speelman's thesis, [@speelman2016position]).
             current_block = moment_matrix_R[
                 i * referee_dim : (i + 1) * referee_dim, j * referee_dim : (j + 1) * referee_dim
             ]


### PR DESCRIPTION
## Summary
- replace mismatched citation keys with keys present in `refs.bib`
- add missing bibliography entries for the symmetric-extension, position-based cryptography, and ETF references
- verify the previously missing citation keys now resolve

## Validation
- `uv run --with ruff==0.15.0 ruff check toqito/matrices/standard_basis.py toqito/measurements/pretty_bad_measurement.py toqito/measurements/pretty_good_measurement.py toqito/nonlocal_games/quantum_hedging.py toqito/state_opt/bell_inequality_max.py toqito/state_opt/npa_hierarchy.py`

Closes #1725