### PR TITLE
Correct documentation math and prose

### DIFF
--- a/toqito/measurements/pretty_bad_measurement.py
+++ b/toqito/measurements/pretty_bad_measurement.py
@@ -64,7 +64,7 @@ def pretty_bad_measurement(
     if n < 2:
         raise ValueError("The pretty bad measurement is undefined for fewer than two states (it divides by n - 1).")
 
-    # If not probabilities are explicitly given, assume a uniform distribution.
+    # If probabilities are not explicitly given, assume a uniform distribution.
     if probs is None:
         probs = n * [1 / n]
 

--- a/toqito/measurements/pretty_good_measurement.py
+++ b/toqito/measurements/pretty_good_measurement.py
@@ -58,7 +58,7 @@ def pretty_good_measurement(
     """
     n = len(states)
 
-    # If not probabilities are explicitly given, assume a uniform distribution.
+    # If probabilities are not explicitly given, assume a uniform distribution.
     if probs is None:
         probs = n * [1 / n]
 

--- a/toqito/state_metrics/helstrom_holevo.py
+++ b/toqito/state_metrics/helstrom_holevo.py
@@ -1,4 +1,4 @@
-"""Helstrom-Holevo metric gives the bst success probability to distinguish two mixed states."""
+"""Helstrom-Holevo metric gives the best success probability to distinguish two mixed states."""
 
 import numpy as np
 
@@ -35,7 +35,7 @@ def helstrom_holevo(rho: np.ndarray, sigma: np.ndarray) -> float | np.floating:
         The corresponding density matrix of \(u\) may be calculated by:
 
         \[
-            \rho = u u^* = \begin{pmatrix}
+            \rho = u u^* = \frac{1}{2}\begin{pmatrix}
                              1 & 0 & 0 & 1 \\
                              0 & 0 & 0 & 0 \\
                              0 & 0 & 0 & 0 \\

--- a/toqito/state_metrics/sub_fidelity.py
+++ b/toqito/state_metrics/sub_fidelity.py
@@ -18,7 +18,7 @@ def sub_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
         \sqrt{2 \left[ \text{Tr}(\rho \sigma)^2 - \text{Tr}(\rho \sigma \rho \sigma) \right]},
     \]
 
-    where \(\sigma\) and \(\rho\) are density matrices. The sub-fidelity serves as an lower bound for the
+    where \(\sigma\) and \(\rho\) are density matrices. The sub-fidelity serves as a lower bound for the
     fidelity.
 
     Args:
@@ -57,7 +57,7 @@ def sub_fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
         ```
 
         As the sub-fidelity is a lower bound on the fidelity, that is \(E(\rho, \sigma) \leq F(\rho, \sigma)\), we can
-        use `|toqito⟩` to observe that \(E(\rho, \sigma) \approx 0.599\leq F(\rho, \sigma \approx 0.774\).
+        use `|toqito⟩` to observe that \(E(\rho, \sigma) \approx 0.599 \leq F(\rho, \sigma) \approx 0.774\).
 
         ```python exec="1" source="above" result="text"
         from toqito.states import basis

--- a/toqito/state_metrics/trace_distance.py
+++ b/toqito/state_metrics/trace_distance.py
@@ -40,7 +40,7 @@ def trace_distance(rho: np.ndarray, sigma: np.ndarray) -> float | np.floating:
         The corresponding density matrix of \(u\) may be calculated by:
 
         \[
-            \rho = u u^* = \begin{pmatrix}
+            \rho = u u^* = \frac{1}{2}\begin{pmatrix}
                              1 & 0 & 0 & 1 \\
                              0 & 0 & 0 & 0 \\
                              0 & 0 & 0 & 0 \\
@@ -48,7 +48,7 @@ def trace_distance(rho: np.ndarray, sigma: np.ndarray) -> float | np.floating:
                            \end{pmatrix} \in \text{D}(\mathcal{X}).
         \]
 
-        The trace distance between \(\rho\) and another state \(\sigma\) is equal to \(0\) if any only if
+        The trace distance between \(\rho\) and another state \(\sigma\) is equal to \(0\) if and only if
         \(\rho = \sigma\). We can check this using the `|toqito⟩` package.
 
         ```python exec="1" source="above" result="text"

--- a/toqito/states/pusey_barrett_rudolph.py
+++ b/toqito/states/pusey_barrett_rudolph.py
@@ -30,11 +30,11 @@ def pusey_barrett_rudolph(n: int, theta: float) -> list[np.ndarray]:
     These PBR states are defined in Equation (A6) from [@pusey2012reality].
 
     Args:
-        n: The number of states in the set.
+        n: The number of tensor copies used to construct the state set.
         theta: Angle parameter that defines the states.
 
     Returns:
-        Vector of trine states.
+        List of Pusey-Barrett-Rudolph state vectors.
 
     Examples:
         Generating the PBR states can be done by simply invoking the function with a given choice of `n` and


### PR DESCRIPTION
## Summary
- add the missing Bell-state density-matrix factors in metric docstrings
- correct Pusey-Barrett-Rudolph parameter and return descriptions
- fix small prose and grammar issues in docstrings and comments

## Validation
- `uv run --with ruff==0.15.0 ruff check toqito/state_metrics/trace_distance.py toqito/state_metrics/helstrom_holevo.py toqito/states/pusey_barrett_rudolph.py toqito/state_metrics/sub_fidelity.py toqito/measurements/pretty_good_measurement.py toqito/measurements/pretty_bad_measurement.py`

Closes #1726