### PR TITLE
Cache Bell inequality measurement operators

### DIFF
--- a/toqito/state_opt/bell_inequality_max.py
+++ b/toqito/state_opt/bell_inequality_max.py
@@ -447,6 +447,17 @@ def bell_inequality_max_qubits(
 
     tot_dim = 2 ** (2 * m + 2)
     obj_mat = np.zeros((tot_dim, tot_dim), dtype=float)
+    dim_party = 2 ** (m + 1)
+    identity = np.eye(dim_party)
+    alice_ops = {}
+    bob_ops = {}
+
+    for outcome in range(2):
+        for setting in range(1, m + 1):
+            perm_setting = [setting if i == 0 else (0 if i == setting else i) for i in range(m + 1)]
+            op = outcome * identity + ((-1) ** outcome) * permutation_operator([2] * (m + 1), perm_setting, 0, 1)
+            alice_ops[(outcome, setting)] = op
+            bob_ops[(outcome, setting)] = op
 
     # Nested loops to compute the objective matrix.
     for a in range(2):  # a = 0 to 1
@@ -460,14 +471,8 @@ def bell_inequality_max_qubits(
                     if x == 1:
                         b_coeff += b_coe[y - 1, 0] * b_val[b, 0]
 
-                    # Construct Alice and Bob's extended measurement operators.
-                    perm_x = [x if i == 0 else (0 if i == x else i) for i in range(m + 1)]
-                    perm_y = [y if i == 0 else (0 if i == y else i) for i in range(m + 1)]
-                    M = a * np.eye(2 ** (m + 1)) + ((-1) ** a) * permutation_operator([2] * (m + 1), perm_x, 0, 1)
-                    N = b * np.eye(2 ** (m + 1)) + ((-1) ** b) * permutation_operator([2] * (m + 1), perm_y, 0, 1)
-
                     # Adding the result of the tensor product to the objective matrix.
-                    obj_mat += b_coeff * np.kron(M, N)
+                    obj_mat += b_coeff * np.kron(alice_ops[(a, x)], bob_ops[(b, y)])
 
     # Symmetrize the matrix to avoid numerical issues.
     obj_mat = (obj_mat + obj_mat.T) / 2


### PR DESCRIPTION
## Summary
- precompute Alice and Bob measurement operators in the qubit Bell-inequality SDP helper
- reuse the cached matrices while constructing the objective matrix
- avoid repeated permutation-operator and identity-matrix construction in nested loops

## Validation
- `uv run pytest toqito/state_opt/tests/test_bell_inequality_max.py -q`

Closes #1728