### PR TITLE
Simplify small numerical hot paths

### DIFF
--- a/toqito/channel_ops/natural_representation.py
+++ b/toqito/channel_ops/natural_representation.py
@@ -27,4 +27,7 @@ def natural_representation(kraus_ops: list[np.ndarray]) -> np.ndarray:
         raise ValueError("All Kraus operators must have the same dimensions.")
 
     # Compute the natural representation.
-    return np.sum([tensor(k, np.conjugate(k)) for k in kraus_ops], axis=0)
+    natural_rep = tensor(kraus_ops[0], np.conjugate(kraus_ops[0]))
+    for k_mat in kraus_ops[1:]:
+        natural_rep += tensor(k_mat, np.conjugate(k_mat))
+    return natural_rep

--- a/toqito/matrix_ops/tensor_comb.py
+++ b/toqito/matrix_ops/tensor_comb.py
@@ -72,17 +72,18 @@ def tensor_comb(
 
     # Generate sequences based on the selected mode.
     if mode == "injective":
-        sequences = list(itertools.permutations(range(len(states)), k))
+        sequences = itertools.permutations(range(len(states)), k)
     elif mode == "non-injective":
-        sequences = list(itertools.product(range(len(states)), repeat=k))
+        sequences = itertools.product(range(len(states)), repeat=k)
     else:  # mode == "diagonal"
-        sequences = [(i,) * k for i in range(len(states))]
+        sequences = ((i,) * k for i in range(len(states)))
 
     sequences_of_states = {}
     for seq in sequences:
-        state_sequence = [states[i] for i in seq]
-        sequence_tensor_product = np.array(state_sequence[0])
-        for state in state_sequence[1:]:
+        state_iter = iter(seq)
+        sequence_tensor_product = np.array(states[next(state_iter)])
+        for state_idx in state_iter:
+            state = states[state_idx]
             sequence_tensor_product = np.kron(sequence_tensor_product, state)
 
         if density_matrix:

--- a/toqito/matrix_props/is_positive_semidefinite.py
+++ b/toqito/matrix_props/is_positive_semidefinite.py
@@ -60,5 +60,5 @@ def is_positive_semidefinite(mat: np.ndarray, rtol: float = 1e-05, atol: float =
     """
     if not is_hermitian(mat, rtol, atol):
         return False
-    evals = np.linalg.eigvalsh(mat)
+    evals, _ = np.linalg.eigh(mat)
     return all(x >= -abs(atol) for x in evals)

--- a/toqito/matrix_props/is_positive_semidefinite.py
+++ b/toqito/matrix_props/is_positive_semidefinite.py
@@ -60,5 +60,5 @@ def is_positive_semidefinite(mat: np.ndarray, rtol: float = 1e-05, atol: float =
     """
     if not is_hermitian(mat, rtol, atol):
         return False
-    evals, _ = np.linalg.eigh(mat)
+    evals = np.linalg.eigvalsh(mat)
     return all(x >= -abs(atol) for x in evals)

--- a/toqito/state_metrics/trace_distance.py
+++ b/toqito/state_metrics/trace_distance.py
@@ -5,7 +5,7 @@ The trace distance is calculated via density matrices.
 
 import numpy as np
 
-from toqito.matrix_props import is_density, trace_norm
+from toqito.matrix_props import is_density
 
 
 def trace_distance(rho: np.ndarray, sigma: np.ndarray) -> float | np.floating:
@@ -64,4 +64,4 @@ def trace_distance(rho: np.ndarray, sigma: np.ndarray) -> float | np.floating:
     """
     if not is_density(rho) or not is_density(sigma):
         raise ValueError("Trace distance only defined for density matrices.")
-    return trace_norm(rho - sigma) / 2
+    return np.sum(np.abs(np.linalg.eigvalsh(rho - sigma))) / 2

--- a/toqito/states/breuer.py
+++ b/toqito/states/breuer.py
@@ -42,7 +42,6 @@ def breuer(dim: int, lam: float) -> np.ndarray:
         raise ValueError(f"The value {dim} must be an even positive integer.")
 
     v_mat = np.fliplr(np.diag((-1) ** np.mod(np.arange(1, dim + 1), 2)))
-    max_entangled(dim)
     psi = np.dot(np.kron(np.identity(dim), v_mat), max_entangled(dim))
 
     return lam * (psi * psi.conj().T) + (1 - lam) * 2 * symmetric_projection(dim) / (dim * (dim + 1))


### PR DESCRIPTION
## Summary
- avoid materializing tensor-combination sequence lists before iteration
- accumulate natural representation terms without an intermediate list
- remove a discarded maximally entangled state call in Breuer state construction
- use Hermitian eigenvalue routines for trace distance and PSD checks

## Validation
- `uv run pytest toqito/matrix_ops/tests/test_tensor_comb.py toqito/channel_ops/tests/test_natural_representataion.py toqito/states/tests/test_breuer.py toqito/state_metrics/tests/test_trace_distance.py toqito/matrix_props/tests/test_is_positive_semidefinite.py -q`

Closes #1730