### PR TITLE
chore(packaging): expand PyPI keywords for discoverability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,20 @@ maintainers = [
     { name = "Vincent Russo", email = "vincentrusso1@gmail.com" },
     { name = "Purva Thakre", email = "quantum.purvat@gmail.com" },
 ]
-keywords = ["quantum information", "quantum computing", "nonlocal games"]
+keywords = [
+    "quantum information",
+    "quantum information theory",
+    "quantum computing",
+    "quantum states",
+    "quantum channels",
+    "quantum measurements",
+    "entanglement",
+    "density matrices",
+    "nonlocal games",
+    "semidefinite programming",
+    "cvxpy",
+    "numpy",
+]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
## Description
Expands the `keywords` field in `pyproject.toml` from the original three (`quantum information`, `quantum computing`, `nonlocal games`) to twelve, improving discoverability on PyPI search.

## Changes
Added: `quantum information theory`, `quantum states`, `quantum channels`, `quantum measurements`, `entanglement`, `density matrices`, `semidefinite programming`, `cvxpy`, `numpy`. The three existing keywords are retained.

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures.