### PR TITLE
fix(docs): use semicolon separator for multi-key citations

### DIFF
--- a/toqito/matrices/standard_basis.py
+++ b/toqito/matrices/standard_basis.py
@@ -18,7 +18,7 @@ def standard_basis(dim: int, flatten: bool = False) -> list[np.ndarray]:
         |n> = (0, 0, 0, ..., 1)^T
     \]
 
-    This function was inspired by [@seshadri2021git, @seshadri2021theory, @seshadri2021versatile]
+    This function was inspired by [@seshadri2021git;@seshadri2021theory;@seshadri2021versatile]
 
     Args:
         dim: The dimension of the basis.

--- a/toqito/measurements/pretty_bad_measurement.py
+++ b/toqito/measurements/pretty_bad_measurement.py
@@ -12,7 +12,7 @@ def pretty_bad_measurement(
 
     This computes the "pretty bad measurement" (PBM) as defined in
     [@mcirvin2024pretty]. The PBM is an analogue to the "pretty
-    good measurement" defined in [@belavkin1975optimal, @hughston1993complete]
+    good measurement" defined in [@belavkin1975optimal;@hughston1993complete]
     and is useful for approximating the optimal measurement
     for state exclusion.
 

--- a/toqito/measurements/pretty_good_measurement.py
+++ b/toqito/measurements/pretty_good_measurement.py
@@ -12,7 +12,7 @@ def pretty_good_measurement(
 
     This computes the "pretty good measurement" (PGM), also known as the
     square-root measurement, which is a widely used measurement for quantum
-    state discrimination [@belavkin1975optimal, @hughston1993complete].
+    state discrimination [@belavkin1975optimal;@hughston1993complete].
 
     The PGM is the set of POVMs \((G_1, \ldots, G_n)\) such that
 

--- a/toqito/nonlocal_games/quantum_hedging.py
+++ b/toqito/nonlocal_games/quantum_hedging.py
@@ -11,7 +11,7 @@ class QuantumHedging:
     r"""Calculate optimal winning probabilities for hedging scenarios.
 
     Calculate the maximal and minimal winning probabilities for quantum
-    hedging to occur in certain two-party scenarios [@arunachalam2017quantum, @molina2012hedging].
+    hedging to occur in certain two-party scenarios [@arunachalam2017quantum;@molina2012hedging].
 
     Examples:
         This example illustrates the initial example of perfect hedging when Alice


### PR DESCRIPTION
## Description
Follow-up to #1739. That PR converted several single citations to multi-key citations but wrote them as `[@keyA, @keyB]`. The docs citation extension only recognizes the semicolon form.

## Problem
`docs/_extensions/griffe_bibtex_docstring.py` matches citations with:
```python
cite_pattern = re.compile(r"\[@([\w]+(?:;@[\w]+)*)\]")
...
keys = [k.lstrip("@") for k in keys_str.split(";")]
```
The comma+space separator does not match this pattern at all, so the four affected multi-key citations render as literal `[@keyA, @keyB]` text in the built docs instead of resolving to numbered references.

## Changes
Convert the four multi-key citations from `, @` to `;@`:
- `toqito/matrices/standard_basis.py` (`seshadri2021git;theory;versatile`)
- `toqito/measurements/pretty_bad_measurement.py` (`belavkin1975optimal;hughston1993complete`)
- `toqito/measurements/pretty_good_measurement.py` (same pair)
- `toqito/nonlocal_games/quantum_hedging.py` (`arunachalam2017quantum;molina2012hedging`)

All referenced keys already exist in `docs/content/refs.bib`. Verified the new forms match the extension regex and split into the correct key lists, and that no comma-separated multi-key citations remain in the codebase.

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures.