### PR TITLE
fix(channel_ops): accept stacked-ndarray Kraus input in empty checks

### DIFF
--- a/toqito/channel_ops/kraus_to_choi.py
+++ b/toqito/channel_ops/kraus_to_choi.py
@@ -58,7 +58,7 @@ def kraus_to_choi(kraus_ops: list[np.ndarray] | list[list[np.ndarray]], sys: int
     if sys < 0:
         raise ValueError("The `sys` parameter must be non-negative.")
 
-    if not kraus_ops:
+    if len(kraus_ops) == 0:
         raise ValueError("The list of Kraus operators cannot be empty.")
 
     if sys == 2:

--- a/toqito/channel_ops/natural_representation.py
+++ b/toqito/channel_ops/natural_representation.py
@@ -22,7 +22,7 @@ def natural_representation(kraus_ops: list[np.ndarray]) -> np.ndarray:
         ```
 
     """
-    if not kraus_ops:
+    if len(kraus_ops) == 0:
         raise ValueError("The list of Kraus operators cannot be empty.")
 
     dim = kraus_ops[0].shape

--- a/toqito/channel_ops/tests/test_kraus_to_choi.py
+++ b/toqito/channel_ops/tests/test_kraus_to_choi.py
@@ -149,3 +149,10 @@ def test_kraus_to_choi_raises_on_empty_kraus_list():
     """Ensure empty Kraus lists raise ValueError."""
     with pytest.raises(ValueError, match="The list of Kraus operators cannot be empty."):
         kraus_to_choi([])
+
+
+def test_kraus_to_choi_accepts_stacked_ndarray():
+    """A 3D ndarray of stacked Kraus operators is accepted like the equivalent list."""
+    kraus_list = [np.array([[1, 0], [0, 0]], dtype=complex), np.array([[0, 0], [0, 1]], dtype=complex)]
+    stacked = np.stack(kraus_list)
+    np.testing.assert_allclose(kraus_to_choi(stacked), kraus_to_choi(kraus_list))

--- a/toqito/channel_ops/tests/test_natural_representataion.py
+++ b/toqito/channel_ops/tests/test_natural_representataion.py
@@ -63,6 +63,12 @@ def test_natural_representation_empty_kraus_list():
         natural_representation([])
 
 
+def test_natural_representation_accepts_stacked_ndarray():
+    """A 3D ndarray of stacked Kraus operators is accepted like the equivalent list."""
+    stacked = np.stack(bit_flip_channel)
+    np.testing.assert_allclose(natural_representation(stacked), natural_representation(bit_flip_channel))
+
+
 def test_natural_representation_trace_preserving():
     """Test that the natural representation produces a trace-preserving map."""
     nat_rep = natural_representation(depol_channel)

--- a/toqito/matrix_ops/tensor_comb.py
+++ b/toqito/matrix_ops/tensor_comb.py
@@ -61,10 +61,10 @@ def tensor_comb(
         ```
 
     """
-    if not states:
+    if len(states) == 0:
         raise ValueError("Input list of states cannot be empty.")
 
-    if k <= 0:
+    if not isinstance(k, (int, np.integer)) or k <= 0:
         raise ValueError("k must be a positive integer.")
 
     if mode not in ("injective", "non-injective", "diagonal"):

--- a/toqito/matrix_ops/tests/test_tensor_comb.py
+++ b/toqito/matrix_ops/tests/test_tensor_comb.py
@@ -196,6 +196,8 @@ def test_tensor_comb_density_matrix(states, k, mode, expected_comb_keys, expecte
         ([np.array([1, 0]), np.array([0, 1])], 0, False, "injective", "k must be a positive integer."),
         # invalid sequence length
         ([np.array([1, 0]), np.array([0, 1])], -1, False, "injective", "k must be a positive integer."),
+        # non-integer sequence length
+        ([np.array([1, 0]), np.array([0, 1])], 1.5, False, "injective", "k must be a positive integer."),
     ],
 )
 def test_raised_errors(test_input, test_k, test_density_matrix, test_mode, expected_msg):


### PR DESCRIPTION
## Description
Retroactive fix for a regression introduced by #1736 (already merged).

## Problem
#1736 added empty-collection validation using `if not kraus_ops:` (in `kraus_to_choi` and `natural_representation`) and `if not states:` (in `tensor_comb`). For a single **stacked 3-D ndarray** of Kraus operators, `not ndarray` raises NumPy's ambiguous-truth-value error:

```
>>> kraus_to_choi(np.stack([k0, k1]))
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

Both functions otherwise accept that form (their fast paths index the array), so this was a functional regression for stacked-ndarray input.

Separately, `tensor_comb` validated `k <= 0` but raised "k must be a positive integer"; a non-integer `k` (e.g. `1.5`) slipped past and later failed inside `itertools` with a raw `TypeError`, so the message overstated what was enforced.

## Changes
- `kraus_to_choi` / `natural_representation`: `if not kraus_ops:` -> `if len(kraus_ops) == 0:` (rejects empty list or empty ndarray, accepts stacked ndarrays).
- `tensor_comb`: `if not states:` -> `if len(states) == 0:`, and validate `k` is an integer so the message matches enforcement.
- Regression tests: stacked-ndarray acceptance for both channel_ops functions (output equals the list form) and non-integer `k` rejection for `tensor_comb`.

Verified the empty-input errors are unchanged and 38 tests across the three touched test files pass.

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures.