### PR TITLE
perf(channel_ops): contract Kraus operators via BLAS in apply_channel (#1761)

### DIFF
--- a/toqito/channel_ops/apply_channel.py
+++ b/toqito/channel_ops/apply_channel.py
@@ -101,13 +101,24 @@ def apply_channel(mat: np.ndarray, phi_op: np.ndarray | list[list[np.ndarray]]) 
     # The superoperator was given as a list of Kraus operators:
     if isinstance(phi_op, list):
         phi_0_list, phi_1_raw, _ = normalize_kraus(phi_op)
-        phi_1_list = [k_mat.conj().T for k_mat in phi_1_raw]
 
-        k_1 = np.concatenate(phi_0_list, axis=1)
-        k_2 = np.concatenate(phi_1_list, axis=0)
+        # Contract the Kraus operators against `mat` with two plain 2D BLAS matmuls instead of
+        # building the dense block-diagonal `kron(I_r, mat)` (mostly zeros). For left operators
+        # `A_i` and right operators `B_i` of shape ``(d_out, d_in)`` this computes
+        # ``sum_i A_i @ mat @ B_i.conj().T`` exactly.
+        num_ops = len(phi_0_list)
+        d_out, d_in = phi_0_list[0].shape
+        a_stack = np.stack(phi_0_list)
+        b_stack = np.stack(phi_1_raw)
 
-        a_mat = np.kron(np.identity(len(phi_0_list)), mat)
-        return k_1 @ a_mat @ k_2
+        left = (
+            (a_stack.reshape(num_ops * d_out, d_in) @ mat)
+            .reshape(num_ops, d_out, d_in)
+            .transpose(1, 0, 2)
+            .reshape(d_out, num_ops * d_in)
+        )
+        right = b_stack.conj().transpose(0, 2, 1).reshape(num_ops * d_in, d_out)
+        return left @ right
 
     # The superoperator was given as a Choi matrix:
     if isinstance(phi_op, np.ndarray):


### PR DESCRIPTION
## Summary

Replaces the dense `kron(I_r, mat)` Kraus path in `apply_channel` with two plain 2D BLAS matmuls. The old path built a block-diagonal matrix of size `(r*d_in)^2` that is mostly zeros (`O(r^2 * d^3)` work, `O(r^2 * d^2)` memory) and multiplied through it. The new path stacks the Kraus operators and contracts them via reshapes + two `@` calls, computing `sum_i A_i @ mat @ B_i.conj().T` exactly.

This is core infrastructure: `partial_channel`, the `kraus_to_choi` general fallback, and several `is_*` channel checks route through it.

## Equivalence

Verified against `origin/master` over 140 combinations covering:
- flat CP lists `[K1, ...]`, wrapped `[[K1], ...]`, single-wrapper `[[K1, ..., Kr]]`, and paired general form `[[A1, B1], ...]`
- square and rectangular Kraus operators (d_out != d_in): (4,4), (3,5), (6,2), (1,4), (8,8)
- r in {1, 2, 3, 5}
- real and complex data

Worst absolute difference: **2.56e-14** (well under the 1e-10 tolerance).

## Measured speedup

| case | master | new | speedup |
|------|--------|-----|---------|
| d=32, r=6 | 40.3 ms | 23.1 ms | 1.7x |
| d=96, r=6 | 107.0 ms | 60.5 ms | 1.8x |
| d=128, r=4 | 124.3 ms | 66.2 ms | 1.9x |

(Gains grow with r and d, as the dense `kron` block scales with `r^2 * d^2`.)

## Testing

- `test_apply_channel.py`, `test_partial_channel.py`, `test_kraus_to_choi.py`: 29 passed
- Full `channel_ops/tests` + `channel_props/tests`: 146 passed
- `ruff check` + `ruff format --check`: clean

Closes #1761

## Checklist

- [x] Behavior-preserving (numerically verified identical to master)
- [x] Existing tests pass
- [x] Handles flat CP and paired Kraus forms
- [x] Handles non-square (rectangular) Kraus operators
- [x] Other branches (Choi, error path) unchanged
- [x] `ruff` clean
