### PR TITLE
perf(state_opt): hoist constant kron out of symmetric_extension_hierarchy loop (#1765)

### DIFF
--- a/toqito/state_opt/symmetric_extension_hierarchy.py
+++ b/toqito/state_opt/symmetric_extension_hierarchy.py
@@ -216,13 +216,14 @@ def symmetric_extension_hierarchy(
     sym = symmetric_projection(dim_y, level)
 
     dim_xyy = np.prod(dim_list)
+    i_kron_sym = np.kron(np.identity(dim_x), sym)
     for k, item in enumerate(states):
         meas.append(cvxpy.Variable((dim_xy, dim_xy), hermitian=True))
         x_var.append(cvxpy.Variable((dim_xyy, dim_xyy), hermitian=True))
         constraints.append(partial_trace(x_var[k], sys_list, dim_list) == meas[k])
         constraints.append(x_var[k] >> 0)
         constraints.append(meas[k] >> 0)
-        constraints.append(np.kron(np.identity(dim_x), sym) @ x_var[k] @ np.kron(np.identity(dim_x), sym) == x_var[k])
+        constraints.append(i_kron_sym @ x_var[k] @ i_kron_sym == x_var[k])
         constraints.append(partial_transpose(x_var[k], [0], dim_list) >> 0)
         for sys in range(level - 1):
             constraints.append(partial_transpose(x_var[k], [sys + 2], dim_list) >> 0)


### PR DESCRIPTION
## Summary

Hoists the constant projector `np.kron(np.identity(dim_x), sym)` out of the per-state `for k, item in enumerate(states)` loop in `symmetric_extension_hierarchy`. It was previously rebuilt twice per state even though it depends only on `dim_x` and `sym`, both fixed before the loop. It is now precomputed once as `i_kron_sym` and reused in both occurrences of the `(I⊗Π) X (I⊗Π) == X` constraint.

Pure precompute; behavior-preserving, no numerical change. At higher hierarchy levels `dim_y^level` grows fast, so this avoids repeatedly allocating the same large dense matrix.

## Verification

- Ran `symmetric_extension_hierarchy` on small Bell states before/after: identical result (~1.0).
- `pytest toqito/state_opt/tests/test_symmetric_extension_hierarchy.py`: 15 passed, 2 skipped.
- `ruff check` + `ruff format --check`: clean.

## Checklist

- [x] Behavior-preserving (pure hoist, no numerical difference)
- [x] Existing tests pass
- [x] Ruff check and format clean

Closes #1765
