### PR TITLE
perf(state_metrics): Hermitian trace-norm via eigvalsh in trace_distance and helstrom_holevo (#1757)

### DIFF
--- a/toqito/state_metrics/helstrom_holevo.py
+++ b/toqito/state_metrics/helstrom_holevo.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from toqito.matrix_props import is_density, trace_norm
+from toqito.matrix_props import is_density
 
 
 def helstrom_holevo(rho: np.ndarray, sigma: np.ndarray) -> float | np.floating:
@@ -65,4 +65,4 @@ def helstrom_holevo(rho: np.ndarray, sigma: np.ndarray) -> float | np.floating:
     """
     if not is_density(rho) or not is_density(sigma):
         raise ValueError("Helstrom-Holevo is only defined for density operators.")
-    return 1 / 2 + 1 / 2 * (trace_norm(rho - sigma)) / 2
+    return 1 / 2 + 1 / 2 * (np.sum(np.abs(np.linalg.eigvalsh(rho - sigma)))) / 2


### PR DESCRIPTION
## Summary

Both `trace_distance` and `helstrom_holevo` compute the trace norm of `rho - sigma`, which is a **Hermitian** matrix (a difference of two density operators). The trace norm previously routed through `trace_norm(...)` → `np.linalg.norm(., ord="nuc")`, a full SVD. For a Hermitian matrix the trace norm equals `sum(|eigvalsh|)`, a Hermitian eigenvalue solve that is cheaper and avoids complex-SVD overhead.

`trace_distance` was already migrated on `master`; this PR completes the pair by switching `helstrom_holevo` to compute `np.sum(np.abs(np.linalg.eigvalsh(rho - sigma)))` in place of `trace_norm(rho - sigma)`, preserving the exact surrounding arithmetic (`1/2 + 1/2 * (...) / 2`) and dropping the now-unused `trace_norm` import.

The general-purpose `matrix_ops`/`matrix_props.trace_norm` helper is left unchanged.

## Equivalence

Verified against the `master` (nuclear-norm SVD) form on random real and complex density-matrix pairs, sizes 2..64:

- `helstrom_holevo` max abs diff: `2.22e-16`
- `trace_distance` max abs diff: `0.0`

Well under the `1e-9` tolerance.

## Measured speedup (Hermitian eigvalsh vs nuclear-norm SVD, single-threaded, complex input)

| n | SVD (`ord="nuc"`) | `eigvalsh` | speedup |
|----|------|------|---------|
| 16 | 0.263 ms | 0.186 ms | 1.42x |
| 64 | 3.189 ms | 0.829 ms | 3.84x |
| 256 | 44.249 ms | 20.480 ms | 2.16x |

## Tests

`test_trace_distance.py` + `test_helstrom_holevo.py`: 6 passed.

## Checklist

- [x] Behavior preserving (numerically equivalent to prior output, max diff 2.22e-16)
- [x] Existing tests pass
- [x] `ruff check` and `ruff format --check` clean on changed files
- [x] Applied only where the argument is provably Hermitian (`rho - sigma` of two density matrices)

Closes #1757
