### PR TITLE
perf(state_props): vectorize abs_ppt_constraints criss-cross check (#1766)

### DIFF
--- a/toqito/state_props/abs_ppt_constraints.py
+++ b/toqito/state_props/abs_ppt_constraints.py
@@ -140,20 +140,39 @@ def abs_ppt_constraints(
                 available[k] = True
 
     def _check_cross(order_matrix: np.ndarray, p: int) -> bool:
-        r"""Check if the order matrix satisfies the "criss-cross" check in [@johnston2014counting]."""
-        for j in range(p - 3):
-            for k in range(2, p):
-                for m in range(p - 2):
-                    for n in range(1, p):
-                        for x in range(p - 1):
-                            for g in range(1, p):
-                                if (
-                                    order_matrix[min(j, k)][max(j, k)] > order_matrix[min(m, n)][max(m, n)]
-                                    and order_matrix[min(n, g)][max(n, g)] > order_matrix[min(k, x)][max(k, x)]
-                                    and order_matrix[min(j, g)][max(j, g)] < order_matrix[min(m, x)][max(m, x)]
-                                ):
-                                    return False
-        return True
+        r"""Check if the order matrix satisfies the "criss-cross" check in [@johnston2014counting].
+
+        This is a vectorized reformulation of the six-nested ``O(p^6)`` loop. Because only the upper
+        triangle (plus diagonal) of ``order_matrix`` is populated, every ``order_matrix[min(a, b)][max(a, b)]``
+        access is a lookup into the symmetric completion ``sym`` of ``order_matrix``. The check fails iff there
+        exists a triple of index pairs ``(j, k), (m, n), (x, g)`` in the loop ranges such that all three
+        comparisons hold simultaneously; numpy broadcasting evaluates every such combination at once.
+        """
+        # Symmetric completion: sym[a, b] == order_matrix[min(a, b)][max(a, b)] since the lower triangle is 0.
+        sym = order_matrix + order_matrix.T - np.diag(np.diag(order_matrix))
+
+        # Loop ranges, matching the original nested loops exactly.
+        j = np.arange(0, p - 3)  # range(p - 3)
+        k = np.arange(2, p)  # range(2, p)
+        m = np.arange(0, p - 2)  # range(p - 2)
+        n = np.arange(1, p)  # range(1, p)
+        x = np.arange(0, p - 1)  # range(p - 1)
+        g = np.arange(1, p)  # range(1, p)
+
+        # Any empty range means there are no triples to check, so the matrix trivially passes.
+        if min(len(j), len(k), len(m), len(n), len(x), len(g)) == 0:
+            return True
+
+        # Pairwise value blocks; reshape onto distinct broadcast axes (j, k, m, n, x, g).
+        s_jk = sym[np.ix_(j, k)].reshape(len(j), len(k), 1, 1, 1, 1)
+        s_mn = sym[np.ix_(m, n)].reshape(1, 1, len(m), len(n), 1, 1)
+        s_ng = sym[np.ix_(n, g)].reshape(1, 1, 1, len(n), 1, len(g))
+        s_kx = sym[np.ix_(k, x)].reshape(1, len(k), 1, 1, len(x), 1)
+        s_jg = sym[np.ix_(j, g)].reshape(len(j), 1, 1, 1, 1, len(g))
+        s_mx = sym[np.ix_(m, x)].reshape(1, 1, len(m), 1, len(x), 1)
+
+        violation = (s_jk > s_mn) & (s_ng > s_kx) & (s_jg < s_mx)
+        return not violation.any()
 
     def _create_constraint(eigs: np.ndarray, order_matrix: np.ndarray, p: int) -> np.ndarray:
         r"""Return constraint matrix from order matrix."""


### PR DESCRIPTION
## Summary

`_check_cross` in `abs_ppt_constraints.py` was a six-deep pure-Python `O(p^6)` loop run in full for every candidate order matrix during the `use_check=True` backtracking enumeration, defeating its own purpose of shrinking the SDP.

This replaces the loop body with an equivalent numpy-broadcast reformulation. Because only the upper triangle (plus diagonal) of `order_matrix` is populated, every `order_matrix[min(a,b)][max(a,b)]` access is a lookup into the symmetric completion `sym`. The six loop ranges become index arrays and the three-way comparison is evaluated over all combinations at once via broadcasting; the function fails iff any combination violates, exactly as before.

## Set-equality verification (behavior preserving)

Enumerated the full constraint set from `abs_ppt_constraints(..., use_check=True)` before (origin/master) and after, hashing the ordered list of emitted constraint matrices:

| p | count (before) | count (after) | SHA-256 match |
|---|---|---|---|
| 3 | 2 | 2 | identical |
| 4 | 10 | 10 | identical |
| 5 | 114 | 114 | identical |

Output is byte-for-byte identical (same matrices, same order, same count). Counts match the documented `use_check=True` values `[..., 2, 10, 114, ...]`.

Additionally, a direct brute-force comparison of the old and new `_check_cross` over 15,000 random order matrices (p=3..7, ~79% rejected) found **0 mismatches**.

## Measured speedup

- p=5, `use_check=True` full pipeline: ~1079ms -> ~324ms (~3.3x).
- p=6, `use_check=True`: previously did not finish within 3 minutes; now completes in ~17s.

## Tests

`test_abs_ppt_constraints.py` + `test_is_abs_ppt.py`: 22 passed. `ruff@0.15.0 check` and `format --check`: clean.

Closes #1766

## Checklist
- [x] Behavior preserving (output set verified identical)
- [x] Existing tests pass
- [x] Linting/formatting pass
