### PR TITLE
perf: closed-form purity, hadamard, cyclic_permutation_matrix, gen_pauli (#1768)

### DIFF
--- a/toqito/matrices/cyclic_permutation_matrix.py
+++ b/toqito/matrices/cyclic_permutation_matrix.py
@@ -45,9 +45,7 @@ def cyclic_permutation_matrix(n: int, k: int = 1) -> np.ndarray:
     if not isinstance(k, int):
         raise TypeError("'k' must be an integer.")
 
-    p_mat = np.zeros((n, n), dtype=int)
-    np.fill_diagonal(p_mat[1:], 1)
-    p_mat[0, -1] = 1
-
-    result_mat = np.linalg.matrix_power(p_mat, k)
-    return result_mat
+    # P^k cyclically shifts the rows of the identity down by k, equivalent to rolling the identity
+    # by k % n along axis 0. This matches np.linalg.matrix_power(P, k), including negative k, since
+    # Python's modulo maps -k to n - k.
+    return np.roll(np.identity(n, dtype=int), k % n, axis=0)

--- a/toqito/matrices/gen_pauli.py
+++ b/toqito/matrices/gen_pauli.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from toqito.matrices import gen_pauli_x, gen_pauli_z
+from toqito.matrices import gen_pauli_z
 
 
 def gen_pauli(k_1: int, k_2: int, dim: int) -> np.ndarray:
@@ -66,9 +66,12 @@ def gen_pauli(k_1: int, k_2: int, dim: int) -> np.ndarray:
         ```
 
     """
-    gpx_val = gen_pauli_x(dim)
     gpz_val = gen_pauli_z(dim)
 
-    gen_pauli_w = np.linalg.matrix_power(gpx_val, k_1) @ np.linalg.matrix_power(gpz_val, k_2)
+    # X^{k_1} is a cyclic column shift of the identity, and Z^{k_2} is the entrywise power of the
+    # diagonal gen_pauli_z operator. Right-multiplication by the diagonal Z^{k_2} scales column j,
+    # so the product X^{k_1} Z^{k_2} is the shifted identity times the diagonal broadcast over rows.
+    z_diag = np.diag(gpz_val) ** k_2
+    gen_pauli_w = np.roll(np.identity(dim), -k_1 % dim, axis=1) * z_diag
 
     return gen_pauli_w

--- a/toqito/matrices/hadamard.py
+++ b/toqito/matrices/hadamard.py
@@ -1,5 +1,7 @@
 """Generates a Hadamard matrix."""
 
+import functools
+
 import numpy as np
 
 
@@ -37,26 +39,7 @@ def hadamard(n_param: int = 1) -> np.ndarray:
     if n_param < 1:
         raise ValueError("Provided parameter for matrix dimensions is invalid.")
 
-    return 2 ** (-n_param / 2) * np.array(
-        [[(-1) ** _hamming_distance(i & j) for i in range(2**n_param)] for j in range(2**n_param)]
-    )
-
-
-def _hamming_distance(x_param: int) -> int:
-    """Calculate the bit-wise Hamming distance of `x_param` from 0.
-
-    The Hamming distance is the number of 1s in the integer `x_param`.
-
-    Args:
-        n_param: A non-negative integer (default = 1).
-        x_param: A non-negative integer.
-
-    Returns:
-        The Hamming distance of `x_param` from 0.
-
-    """
-    tot = 0
-    while x_param:
-        tot += 1
-        x_param &= x_param - 1
-    return tot
+    # H_n is the n-fold Kronecker product of the unnormalized 1-qubit Hadamard matrix, scaled
+    # by 2^{-n/2}. This has entries 2^{-n/2} (-1)^{i . j} with the bitwise dot product i . j.
+    h_1 = np.array([[1, 1], [1, -1]])
+    return 2 ** (-n_param / 2) * functools.reduce(np.kron, [h_1] * n_param)

--- a/toqito/state_props/purity.py
+++ b/toqito/state_props/purity.py
@@ -59,4 +59,5 @@ def purity(rho: np.ndarray) -> float:
     if not is_density(rho):
         raise ValueError("Purity is only defined for density operators.")
     # "np.real" get rid of the close-to-0 imaginary part.
-    return np.real(np.trace(np.linalg.matrix_power(rho, 2)))
+    # Tr(rho^2) = sum_{i, j} rho_{i, j} rho_{j, i}, computed entrywise to avoid the O(n^3) matmul.
+    return np.real(np.sum(rho * rho.T))


### PR DESCRIPTION
Replaces four `matrix_power`/Python-loop constructions with behavior-preserving closed forms. All four were verified numerically equivalent to the `master` output across a range of sizes/parameters (worst abs diff reported below), and the existing test suites pass unchanged.

## Fixes
- **`state_props/purity.py`** — `Tr(rho^2)` via `np.real(np.sum(rho * rho.T))` instead of `np.trace(np.linalg.matrix_power(rho, 2))`. (~7x/24x/422x at n=1024/256/64)
- **`matrices/hadamard.py`** — n-fold `functools.reduce(np.kron, [[[1, 1], [1, -1]]] * n)` scaled by `2^{-n/2}`, instead of the `4^n` Python comprehension with a per-entry popcount. (~5-31x)
- **`matrices/cyclic_permutation_matrix.py`** — `np.roll(np.identity(n, dtype=int), k % n, axis=0)` instead of `np.linalg.matrix_power(P, k)`. (~360x)
- **`matrices/gen_pauli.py`** — `X^{k_1}` as a cyclic column roll and `Z^{k_2}` as an entrywise power of the diagonal `gen_pauli_z` operator, combined as `np.roll(identity, -k_1 % dim, axis=1) * z_diag`, instead of two `matrix_power` calls. (orders of magnitude)

## Equivalence verification (worst absolute difference vs `master`)
- purity (random density matrices, n up to 100): 1.1e-16
- hadamard (n = 1..8): 0 (exact)
- cyclic_permutation_matrix (various n, k incl. k > n, k = 0): 0 (exact)
- gen_pauli (dim 2..7, all k_1, k_2): 3.7e-16

Note: for `cyclic_permutation_matrix` the only behavioral difference is dtype for *negative* `k` (an undocumented use where `master` returned a float inverse); values are identical and non-negative `k` returns `int` exactly as before and as asserted by the tests.

## Checklist
- [x] Behavior-preserving; equivalence verified across a range of sizes/parameters
- [x] Existing tests pass: `test_purity.py`, `test_hadamard.py`, `test_cyclic_permutation_matrix.py`, `test_gen_pauli.py` (24 passed)
- [x] `ruff check` and `ruff format --check` pass on all four files
- [x] Signatures and return dtypes preserved

Closes #1768
