### PR TITLE
perf(perms): build symmetric/antisymmetric_projection via numpy index accumulation (#1763)

### DIFF
--- a/toqito/perms/antisymmetric_projection.py
+++ b/toqito/perms/antisymmetric_projection.py
@@ -1,11 +1,12 @@
 """Antisymmetric projection operator produces an orthogonal projection onto an anti-symmetric subspace."""
 
+import math
 from itertools import permutations
 
 import numpy as np
 from scipy.linalg import orth
 
-from toqito.perms import perm_sign, permutation_operator
+from toqito.perms import perm_sign
 
 
 def antisymmetric_projection(dim: int, p_param: int = 2, partial: bool = False) -> np.ndarray:
@@ -78,15 +79,19 @@ def antisymmetric_projection(dim: int, p_param: int = 2, partial: bool = False) 
     if dim < p_param:
         return np.zeros((dimp, dimp * (1 - partial)))
 
-    p_list = np.array(list(permutations(np.arange(p_param))))
-    p_fac = p_list.shape[0]
-
+    p_fac = math.factorial(p_param)
     anti_proj = np.zeros((dimp, dimp))
-    for j in range(p_fac):
-        # `perm_sign` expects 1-based permutation labels, while `p_list` is 0-based, so shift by 1.
-        anti_proj += perm_sign(p_list[j, :] + 1) * permutation_operator(
-            dim * np.ones(p_param), p_list[j, :], False, True
-        )
+
+    # Accumulate the projector directly by indexing rather than summing `p_fac` dense
+    # permutation operators. Each permutation `perm` of the `p_param` subsystems corresponds
+    # to the permutation matrix `identity[rows, :]`, where `rows` reorders the tensor axes;
+    # adding its sign to entry `(rows[k], k)` for every permutation builds the same sum.
+    base = np.arange(dimp)
+    idx = base.reshape((dim,) * p_param)
+    for perm in permutations(range(p_param)):
+        # `perm_sign` expects 1-based permutation labels, while `perm` is 0-based, so shift by 1.
+        anti_proj_sign = perm_sign(np.array(perm) + 1)
+        anti_proj[np.transpose(idx, perm).ravel(), base] += anti_proj_sign
     anti_proj = anti_proj / p_fac
 
     if partial:

--- a/toqito/perms/symmetric_projection.py
+++ b/toqito/perms/symmetric_projection.py
@@ -6,8 +6,6 @@ from itertools import permutations
 import numpy as np
 from scipy.linalg import orth
 
-from toqito.perms import permutation_operator
-
 
 def symmetric_projection(dim: int, p_val: int = 2, partial: bool = False) -> np.ndarray:
     r"""Produce the projection onto the symmetric subspace [@chen2014symmetric].
@@ -85,12 +83,17 @@ def symmetric_projection(dim: int, p_val: int = 2, partial: bool = False) -> np.
     if p_val == 1:
         return np.eye(dim)
 
-    p_list = np.array(list(permutations(np.arange(p_val))))
     p_fac = math.factorial(p_val)
     sym_proj = np.zeros((dimp, dimp))
 
-    for perm in p_list:
-        sym_proj += permutation_operator(dim * np.ones(p_val), perm, False, True)
+    # Accumulate the projector directly by indexing rather than summing `p_fac` dense
+    # permutation operators. Each permutation `perm` of the `p_val` subsystems corresponds
+    # to the permutation matrix `identity[rows, :]`, where `rows` reorders the tensor axes;
+    # adding one to entry `(rows[k], k)` for every permutation builds the same sum.
+    base = np.arange(dimp)
+    idx = base.reshape((dim,) * p_val)
+    for perm in permutations(range(p_val)):
+        sym_proj[np.transpose(idx, perm).ravel(), base] += 1
     sym_proj /= p_fac
 
     if partial:


### PR DESCRIPTION
## Summary

Rebuilds `symmetric_projection` and `antisymmetric_projection` by direct numpy index accumulation over permutations, instead of summing `p!` dense `permutation_operator` / `permute_systems` calls. The previous code materialized a dense `d^p` identity per permutation and ran a Python-level `functools.reduce(iconcat)` over all `d^p` elements each time (the bottleneck).

Now, for each permutation `perm` of the `p` subsystems, the corresponding permutation matrix `identity[rows, :]` is accumulated in place via `acc[np.transpose(idx, perm).ravel(), base] += 1` (or `+= perm_sign(...)` for the antisymmetric case), then divided by `p!`. Summing over all permutations (and, for antisymmetric, since `sign(perm) == sign(perm^{-1})`) makes the accumulated matrix identical to the original sum regardless of per-permutation orientation convention.

## Measured speedup

| Function | dim, p | old | new | speedup |
|---|---|---|---|---|
| `symmetric_projection` | 3, 6 | 11.87 s | 0.074 s | ~159x |
| `symmetric_projection` | 4, 5 | 8.94 s | 0.019 s | ~472x |
| `antisymmetric_projection` | 4, 4 | 0.033 s | 0.0015 s | ~22x |

## Equivalence

Verified against `origin/master` for `dim in {2,3,4}`, `p in {2,3,4,5}` (skipping `d^p > 4096`):

- `symmetric_projection`, `partial=False`: worst abs diff `0.0`.
- `symmetric_projection`, `partial=True` (orthonormal-basis path, unchanged code): compared the derived projectors `B @ B^H` to be robust to column ordering/sign; worst abs diff `0.0`.
- `antisymmetric_projection`, both `partial=False` and `partial=True` (same `B @ B^H` comparison, including empty-subspace shapes): worst abs diff `0.0`.

Overall worst absolute difference across all combos: `0.0` (threshold `1e-10`). Dtype (`float64`), the `1/p!` normalization, the `p == 1` and `dim < p` early returns, and the `partial` behavior are all preserved.

Existing tests `toqito/perms/tests/test_symmetric_projection.py` and `test_antisymmetric_projection.py` pass (20 passed). `ruff@0.15.0 check` and `format --check` clean.

Closes #1763

## Checklist

- [x] Behavior-preserving; numerically verified equivalent to `origin/master`.
- [x] Existing unit tests pass.
- [x] `ruff check` and `ruff format --check` pass.
