### PR TITLE
perf(cones): use psd_matrix_power for numeric matrix powers in trace_matrix_power and lieb_ando (#1756)

### DIFF
--- a/toqito/cones/lieb_ando.py
+++ b/toqito/cones/lieb_ando.py
@@ -5,12 +5,12 @@ r"""Computes \(f(A, B, K, t) = \operatorname{tr}(K^{\dagger} A^{1-t} K B^{t})\) 
 
 import cvxpy
 import numpy as np
-from scipy.linalg import fractional_matrix_power
 
 from toqito.cones._utils import _require_2d, _require_square_2d
 from toqito.cones.geometric_mean_epi_cone import geometric_mean_epi_cone
 from toqito.cones.geometric_mean_hypo_cone import geometric_mean_hypo_cone
 from toqito.cones.trace_matrix_power import trace_matrix_power
+from toqito.matrix_ops import psd_matrix_power
 from toqito.matrix_props import is_positive_semidefinite
 
 
@@ -76,19 +76,19 @@ def lieb_ando(
     if isinstance(mat_a, np.ndarray) and isinstance(mat_b, np.ndarray):
         if not is_positive_semidefinite(mat_a) or not is_positive_semidefinite(mat_b):
             raise ValueError("mat_a and mat_b must be positive semidefinite.")
-        a_raised = fractional_matrix_power(mat_a, 1 - t)
-        b_raised = fractional_matrix_power(mat_b, t)
+        a_raised = psd_matrix_power(mat_a, 1 - t)
+        b_raised = psd_matrix_power(mat_b, t)
         return float(np.real(np.trace(mat_k.conj().T @ a_raised @ mat_k @ b_raised)))
     elif isinstance(mat_a, np.ndarray):
         if not is_positive_semidefinite(mat_a) or not is_positive_semidefinite(mat_b.value):
             raise ValueError("mat_a and mat_b must be positive semidefinite.")
-        mat_kak = mat_k.conj().T @ fractional_matrix_power(mat_a, 1 - t) @ mat_k
+        mat_kak = mat_k.conj().T @ psd_matrix_power(mat_a, 1 - t) @ mat_k
         mat_kak = (mat_kak + mat_kak.conj().T) / 2
         return trace_matrix_power(mat_b, t, mat_kak)
     elif isinstance(mat_b, np.ndarray):
         if not is_positive_semidefinite(mat_a.value) or not is_positive_semidefinite(mat_b):
             raise ValueError("mat_a and mat_b must be positive semidefinite.")
-        mat_kkb = mat_k @ fractional_matrix_power(mat_b, t) @ mat_k.conj().T
+        mat_kkb = mat_k @ psd_matrix_power(mat_b, t) @ mat_k.conj().T
         mat_kkb = (mat_kkb + mat_kkb.conj().T) / 2
         return trace_matrix_power(mat_a, 1 - t, mat_kkb)
     else:

--- a/toqito/cones/trace_matrix_power.py
+++ b/toqito/cones/trace_matrix_power.py
@@ -5,11 +5,11 @@ r"""Computes the trace of \(C A^{t}\) for positive semidefinite matrices \(A\) a
 
 import cvxpy
 import numpy as np
-from scipy.linalg import fractional_matrix_power
 
 from toqito.cones._utils import _require_square_2d
 from toqito.cones.geometric_mean_epi_cone import geometric_mean_epi_cone
 from toqito.cones.geometric_mean_hypo_cone import geometric_mean_hypo_cone
+from toqito.matrix_ops import psd_matrix_power
 from toqito.matrix_props import is_positive_semidefinite
 
 
@@ -76,7 +76,7 @@ def trace_matrix_power(mat_a: np.ndarray | cvxpy.Expression, t: float, mat_c: np
     if isinstance(mat_a, np.ndarray):
         if not is_positive_semidefinite(mat_a):
             raise ValueError("The matrix mat_a must be positive semidefinite.")
-        return float(np.real(np.trace(mat_c @ fractional_matrix_power(mat_a, t))))
+        return float(np.real(np.trace(mat_c @ psd_matrix_power(mat_a, t))))
 
     # Affine path
     if isinstance(mat_a, cvxpy.Expression):


### PR DESCRIPTION
## Summary

Routes the numeric Hermitian-PSD matrix-power computations in the cones module through the existing `toqito/matrix_ops/psd_matrix_power.py` helper (`psd_matrix_power(A, t) = V diag(w**t) V^H` via `eigh`) instead of `scipy.linalg.fractional_matrix_power` (Schur-based).

- `toqito/cones/trace_matrix_power.py`: numeric branch (`A^t` for validated-PSD `mat_a`).
- `toqito/cones/lieb_ando.py`: numpy branch (`A^{1-t}`, `B^t`) and both mixed numpy/cvxpy branches (`A^{1-t}`, `B^t`).

All substituted matrices are already validated positive semidefinite before the power is taken. The cvxpy (SDP) branches are untouched.

## Motivation

For Hermitian PSD input, `A^t` via `eigh` is materially cheaper than the Schur-based `fractional_matrix_power` and avoids its spurious imaginary parts (the analogous `geometric_mean` benchmark showed 9-27x). Behavior-preserving.

## Verification

- Equivalence vs `origin/master` on random Hermitian PSD inputs (real and complex, sizes 2..32, `t` in `[-1, 2]`): **max relative diff = 5.9e-15** (machine precision). Absolute diff scales with matrix size only because the trace magnitudes grow with `n` (e.g. n=2: 1.4e-12, n=32: 6.0e-8); the relative agreement is at floating-point roundoff throughout.
- `test_trace_matrix_power.py` + `test_lieb_ando.py`: **160 passed**.
- `ruff check` and `ruff format --check`: clean on both files.

Closes #1756

## Checklist

- [x] Behavior preserved (numeric equivalence verified to machine precision)
- [x] Only numeric PSD branches changed; cvxpy branches untouched
- [x] Existing tests pass
- [x] Lint/format clean
