### PR TITLE
perf(matrix_props): avoid redundant decompositions in unitary/incoherent/majorizes checks (#1758)

### DIFF
--- a/toqito/matrix_props/is_absolutely_k_incoherent.py
+++ b/toqito/matrix_props/is_absolutely_k_incoherent.py
@@ -65,7 +65,9 @@ def is_absolutely_k_incoherent(mat: np.ndarray, k: int, tol: float = 1e-15) -> b
 
     # Compute eigenvalues and rank.
     eigvals = np.linalg.eigvalsh(mat)
-    rankX = np.linalg.matrix_rank(mat, tol=tol)
+    # For a Hermitian matrix the singular values equal the absolute eigenvalues, so the rank (number
+    # of singular values above ``tol``) can be read off the already-computed eigenvalues.
+    rankX = int(np.count_nonzero(np.abs(eigvals) > tol))
     lmax = np.max(eigvals)
 
     # Trivial: only the maximally mixed state is absolutely 1-incoherent.

--- a/toqito/matrix_props/is_unitary.py
+++ b/toqito/matrix_props/is_unitary.py
@@ -87,10 +87,7 @@ def is_unitary(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> boo
         return False
 
     uc_u_mat = mat.conj().T @ mat
-    u_uc_mat = mat @ mat.conj().T
     id_mat = np.eye(len(mat))
 
-    # If U^* @ U = I U @ U^*, the matrix "U" is unitary.
-    return bool(
-        np.allclose(uc_u_mat, id_mat, rtol=rtol, atol=atol) and np.allclose(u_uc_mat, id_mat, rtol=rtol, atol=atol)
-    )
+    # For a square matrix, U^* @ U = I implies U @ U^* = I, so checking one product suffices.
+    return bool(np.allclose(uc_u_mat, id_mat, rtol=rtol, atol=atol))

--- a/toqito/matrix_props/majorizes.py
+++ b/toqito/matrix_props/majorizes.py
@@ -63,13 +63,13 @@ def majorizes(a_var: np.ndarray | list[int], b_var: np.ndarray | list[int]) -> b
         a_var = np.sort(a_var)[::-1]
     # Otherwise, just sort in descending order.
     else:
-        _, a_var, _ = np.linalg.svd(a_var)
+        a_var = np.linalg.svd(a_var, compute_uv=False)
 
     # Do the same for second input argument.
     if len(b_var.shape) == 1:
         b_var = np.sort(b_var)[::-1]
     else:
-        _, b_var, _ = np.linalg.svd(b_var)
+        b_var = np.linalg.svd(b_var, compute_uv=False)
 
     la_var = len(a_var)
     lb_var = len(b_var)


### PR DESCRIPTION
Behavior-preserving performance cleanup from the computational-efficiency audit, avoiding redundant matrix decompositions in three `matrix_props` predicates.

## Fixes included

- **`is_unitary.py`** — the square case is already guaranteed by the `is_square` guard, so `UᴴU = I` alone certifies unitarity. Drops the second `U Uᴴ` matmul and one `allclose` pass.
- **`is_absolutely_k_incoherent.py`** — the rank is now read from the Hermitian eigenvalues already computed via `eigvalsh` (`int(np.count_nonzero(np.abs(eigvals) > tol))`) instead of a separate `np.linalg.matrix_rank` (full SVD). For a Hermitian matrix the singular values equal the absolute eigenvalues and the `> tol` threshold is identical.
- **`majorizes.py`** — both `np.linalg.svd(x)` calls now pass `compute_uv=False`, since only the singular values are used; `U`/`Vh` were discarded.

## Not included: `is_pseudo_hermitian`

The proposed `is_pseudo_hermitian` change (replace the `matrix_rank` invertibility test with a guarded `inv`, or with an `eigvalsh`-based threshold) was **dropped after verification**. `np.linalg.matrix_rank` uses a full SVD with a relative default threshold; neither a guarded `inv` (which only raises on a bit-exact singular pivot) nor an `eigvalsh`-based check reproduces it exactly:

- Guarded `inv` fails to raise the documented `ValueError("Signature is not invertible.")` for ~77% of rank-deficient signatures (they slip through with a garbage inverse).
- The `eigvalsh` threshold matches `matrix_rank` on the full standard battery but still disagrees on a handful of knife-edge inputs whose eigenvalues sit exactly at the numerical-rank threshold (`eigvalsh` |λ| vs SVD σ differ by roundoff there), which cannot be eliminated without doing the SVD.

To preserve the documented error path exactly, `is_pseudo_hermitian` is left unchanged.

## Verification

Each shipped function was compared against `origin/master` on random inputs (real + complex, square/non-square, boundary and invalid cases):

| Function | Cases | Mismatches |
|---|---|---|
| `is_unitary` | 400 | 0 |
| `is_absolutely_k_incoherent` | 400 | 0 |
| `majorizes` | 400 | 0 |

- Tests: `pytest` on `test_is_unitary.py`, `test_is_absolutely_k_incoherent.py`, `test_majorizes.py`, `test_is_pseudo_hermitian.py` → **47 passed**.
- `ruff check` and `ruff format --check` on the changed files → clean.

Addresses #1758 (the `is_pseudo_hermitian` item is intentionally not applied; see above).

## Checklist

- [x] Behavior verified equivalent to `origin/master` on random inputs (0 mismatches for all shipped fixes)
- [x] Existing tests pass (47 passed)
- [x] `ruff check` passes on changed files
- [x] `ruff format --check` passes on changed files
