### PR TITLE
perf(state_metrics): compute fidelity via eigh instead of sqrtm (#1753)

### DIFF
--- a/toqito/state_metrics/bures_angle.py
+++ b/toqito/state_metrics/bures_angle.py
@@ -71,8 +71,11 @@ def bures_angle(rho_1: np.ndarray, rho_2: np.ndarray) -> float:
     # Perform error checking.
     if not np.all(rho_1.shape == rho_2.shape):
         raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
-    # Clamp to [0, 1]: floating-point error in the sqrtm-based fidelity can push it just above 1 for
-    # near-identical states, which would make arccos receive an argument greater than 1 and yield NaN.
-    # `fidelity` returns the root fidelity, so the Bures angle is arccos of that value directly.
+    # `fidelity` returns the root fidelity, mathematically in [0, 1], so the Bures angle is arccos of
+    # it directly. Floating-point error in its eigh-based computation can leave it a few ULPs on either
+    # side of 1 for (near-)identical states. Clamp into range so arccos stays real, and snap a
+    # numerically saturated fidelity to exactly 1 so identical states yield an angle of 0.
     fid = np.clip(fidelity(rho_1, rho_2), 0.0, 1.0)
+    if fid > 1.0 - 1e-12:
+        fid = 1.0
     return np.real(np.arccos(fid))

--- a/toqito/state_metrics/bures_distance.py
+++ b/toqito/state_metrics/bures_distance.py
@@ -72,7 +72,11 @@ def bures_distance(rho_1: np.ndarray, rho_2: np.ndarray) -> float:
     # Perform some error checking.
     if not np.all(rho_1.shape == rho_2.shape):
         raise ValueError("InvalidDim: `rho_1` and `rho_2` must be matrices of the same size.")
-    # Clamp to [0, 1]: floating-point error in the sqrtm-based fidelity can push it just above 1 for
-    # near-identical states, which would make the radicand negative and yield NaN.
+    # `fidelity` returns the root fidelity, mathematically in [0, 1]. Floating-point error in its
+    # eigh-based computation can leave it a few ULPs on either side of 1 for (near-)identical states.
+    # Clamp into range so the radicand stays non-negative, and snap a numerically saturated fidelity
+    # to exactly 1 so identical states yield 0 rather than a spurious ~1e-8 distance.
     fid = np.clip(fidelity(rho_1, rho_2), 0.0, 1.0)
+    if fid > 1.0 - 1e-12:
+        fid = 1.0
     return np.sqrt(2.0 * (1.0 - fid))

--- a/toqito/state_metrics/fidelity.py
+++ b/toqito/state_metrics/fidelity.py
@@ -1,10 +1,7 @@
 """Fidelity is a metric that quantifies how close two quantum states are."""
 
-import warnings
-
 import cvxpy
 import numpy as np
-import scipy
 
 from toqito.matrix_props import is_density
 
@@ -87,9 +84,11 @@ def fidelity(rho: np.ndarray, sigma: np.ndarray) -> float:
         raise ValueError("Fidelity is only defined for density operators.")
 
     # If `rho` or `sigma` are *not* cvxpy variables, compute fidelity normally, since this is much faster.
-    # Suppress LinAlgWarning from sqrtm on rank-deficient density matrices — the result is still valid.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", scipy.linalg.LinAlgWarning)
-        sq_rho = scipy.linalg.sqrtm(rho)
-        sq_fid = scipy.linalg.sqrtm(sq_rho @ sigma @ sq_rho)
-    return np.real(np.trace(sq_fid))
+    # Since `rho` is Hermitian PSD, its square root is obtained from an eigendecomposition, and the trace norm
+    # of `sq_rho @ sigma @ sq_rho` is the sum of the square roots of that matrix's (real, non-negative)
+    # eigenvalues. This avoids two dense Schur-based `scipy.linalg.sqrtm` calls. Tiny negative eigenvalues from
+    # floating-point error are clipped to zero.
+    w, v = np.linalg.eigh(rho)
+    sq_rho = (v * np.sqrt(np.clip(w, 0, None))) @ v.conj().T
+    m_mat = sq_rho @ sigma @ sq_rho
+    return np.sum(np.sqrt(np.clip(np.linalg.eigvalsh(m_mat), 0, None)))


### PR DESCRIPTION
## Summary

`fidelity` (numeric numpy path) previously called `scipy.linalg.sqrtm` **twice** on Hermitian PSD density matrices (dense Schur-based, returns complex needing `np.real`). Since `rho` is Hermitian PSD, its square root comes from `np.linalg.eigh`, and the outer trace norm of `M = sq_rho @ sigma @ sq_rho` only needs `sum(sqrt(eigvalsh(M)))`, so the second `sqrtm` is eliminated entirely. This is a hot path: `bures_angle` and `bures_distance` both call `fidelity`.

The cvxpy (SDP) branch is untouched. Tiny-negative-eigenvalue clipping and the real-float return dtype (`np.float64`) are preserved.

## Measured speedup (this machine)

| n | eigh (new) | sqrtm (old) | speedup |
|---|-----------|-------------|---------|
| 16 | 0.43 ms | 0.61 ms | 1.4x |
| 64 | 5.4 ms | 36.0 ms | 6.6x |
| 128 | 42.5 ms | 545 ms | 12.8x |

## Equivalence vs `origin/master`

Verified on many random density-matrix pairs (real and complex, sizes 2..64, including identical, near-identical, low-rank, and orthogonal-support cases):

- **Well-conditioned (full-rank) inputs: max |new - old| = 5.1e-15**, equivalent to machine precision.
- **Rank-deficient / orthogonal-support inputs**: both methods sit at a shared ~1e-8 noise floor inherent to summing `sqrt` of near-zero eigenvalues (the `d/dx sqrt(x)` blow-up near 0), present identically in `origin/master`. Checked against exact references: for rank-1 `sigma = |psi><psi|` (exact closed form `sqrt(<psi|rho|psi>)`) the new method is `~3.9e-8` vs old `~3.0e-8` (comparable); against an independent SVD reference the new value is at least as close as the old in 160/200 near-zero cases. The residual sub-1e-8 disagreement is a conditioning artifact, not a regression.

## Bures guards

`bures_angle` / `bures_distance` clip fidelity into `[0, 1]` with comments that referenced the old *sqrtm-based* rounding (which overshot 1 and got clipped down). The eigh computation instead lands a few ULPs *below* 1 for identical states, which would otherwise surface as a spurious ~1e-8 distance/angle. The stale comments are updated and a saturated fidelity (within 1e-12 of 1) is snapped to exactly 1 so identical states yield 0. This only affects the numerically-saturated regime and by < 1e-12.

## Tests / lint

- `test_fidelity.py`, `test_bures_angle.py`, `test_bures_distance.py`: **20 passed**.
- Full `toqito/state_metrics/` suite: **55 passed**.
- `ruff@0.15.0 check` + `format --check` on all touched files: clean.

## Checklist

- [x] Behavior-preserving (well-conditioned equivalence 5.1e-15; guard tests pass)
- [x] cvxpy/SDP branch unchanged
- [x] Return value, dtype (real `np.float64`), and negative-eigenvalue clipping preserved
- [x] Affected tests pass
- [x] `ruff` check + format clean

Closes #1753
