### PR TITLE
perf(nonlocal_games,state_opt): reuse cvxpy problems across see-saw steps via Parameters (#1764)

### DIFF
--- a/toqito/nonlocal_games/extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/extended_nonlocal_game.py
@@ -310,6 +310,13 @@ class ExtendedNonlocalGame:
             solver_params = {"eps_abs": tol, "eps_rel": tol, "max_iters": 50000, "verbose": False}
         rng = np.random.default_rng(seed) if seed is not None else None
 
+        # Both alternating SDPs have identical variables and constraints on every see-saw step; only the fixed opponent
+        # operators (constants in the objective) change. `__optimize_alice`/`__optimize_bob` build their `cvxpy.Problem`
+        # once and cache it here, exposing the fixed operators as `cvxpy.Parameter`s reassigned each step. Reset the
+        # cache so a fresh call rebuilds from the current game dimensions.
+        self._seesaw_alice = None
+        self._seesaw_bob = None
+
         # Get number of inputs and outputs for Bob's measurements.
         _, _, _, num_outputs_bob, _, num_inputs_bob = self.pred_mat.shape
 
@@ -426,45 +433,56 @@ class ExtendedNonlocalGame:
         # `dim`-by-`dim` cvxpy variables.
         self.__get_game_dims()
 
-        rho_xa_cvxpy_vars = defaultdict(cvxpy.Variable)
-        for x_ques in range(self.num_alice_in):
-            for a_ans in range(self.num_alice_out):
-                rho_xa_cvxpy_vars[x_ques, a_ans] = cvxpy.Variable(
-                    (self.referee_dim * self.num_bob_out, self.referee_dim * self.num_bob_out),
-                    hermitian=True,
-                    name=f"rho_A_{x_ques}{a_ans}",
-                )
-        tau_A_cvxpy_var = cvxpy.Variable(
-            (self.referee_dim * self.num_bob_out, self.referee_dim * self.num_bob_out), hermitian=True, name="tau_A"
-        )
+        # Build the SDP once and cache it; only the fixed Bob operators (constant objective coefficients) change between
+        # see-saw steps. They enter through one `cvxpy.Parameter` per (x, a): the coefficient
+        # `sum_{y, b} pi(x, y) (v_xyab kron B_b^y)`, matched to the original per-term `op_for_trace.conj().T` by storing
+        # its conjugate transpose. This collapses the 4-nested objective loop to one term per (x, a).
+        if getattr(self, "_seesaw_alice", None) is None:
+            dim = self.referee_dim * self.num_bob_out
+            rho_xa_cvxpy_vars = defaultdict(cvxpy.Variable)
+            for x_ques in range(self.num_alice_in):
+                for a_ans in range(self.num_alice_out):
+                    rho_xa_cvxpy_vars[x_ques, a_ans] = cvxpy.Variable(
+                        (dim, dim), hermitian=True, name=f"rho_A_{x_ques}{a_ans}"
+                    )
+            tau_A_cvxpy_var = cvxpy.Variable((dim, dim), hermitian=True, name="tau_A")
 
-        win_objective = cvxpy.Constant(0)
-        for x_q in range(self.num_alice_in):
-            for y_q in range(self.num_bob_in):
-                if self.prob_mat[x_q, y_q] == 0:
-                    continue
+            coeff_params = {}
+            win_objective = cvxpy.Constant(0)
+            for x_q in range(self.num_alice_in):
                 for a_ans_alice in range(self.num_alice_out):
+                    coeff_params[x_q, a_ans_alice] = cvxpy.Parameter((dim, dim), complex=True)
+                    win_objective += cvxpy.trace(coeff_params[x_q, a_ans_alice] @ rho_xa_cvxpy_vars[x_q, a_ans_alice])
+
+            objective = cvxpy.Maximize(cvxpy.real(win_objective))
+            constraints = []
+            for x_q_constr in range(self.num_alice_in):
+                rho_sum_a_constr = 0
+                for a_ans_constr in range(self.num_alice_out):
+                    constraints.append(rho_xa_cvxpy_vars[x_q_constr, a_ans_constr] >> 0)
+                    rho_sum_a_constr += rho_xa_cvxpy_vars[x_q_constr, a_ans_constr]
+                constraints.append(rho_sum_a_constr == tau_A_cvxpy_var)
+            constraints.append(cvxpy.trace(tau_A_cvxpy_var) == 1)
+            constraints.append(tau_A_cvxpy_var >> 0)
+
+            self._seesaw_alice = (cvxpy.Problem(objective, constraints), rho_xa_cvxpy_vars, coeff_params)
+
+        problem, rho_xa_cvxpy_vars, coeff_params = self._seesaw_alice
+
+        # Refresh the fixed-Bob coefficients for the current Bob POVMs.
+        dim = self.referee_dim * self.num_bob_out
+        for x_q in range(self.num_alice_in):
+            for a_ans_alice in range(self.num_alice_out):
+                coeff = np.zeros((dim, dim), dtype=complex)
+                for y_q in range(self.num_bob_in):
+                    if self.prob_mat[x_q, y_q] == 0:
+                        continue
                     for b_ans_bob in range(self.num_bob_out):
-                        # fixed_bob_povms_np is guaranteed to be np.ndarray here
                         v_xyab = self.pred_mat[:, :, a_ans_alice, b_ans_bob, x_q, y_q]
                         b_yb = fixed_bob_povms_np[y_q, b_ans_bob]
-                        op_for_trace = np.kron(v_xyab, b_yb)
-                        win_objective += self.prob_mat[x_q, y_q] * cvxpy.trace(
-                            op_for_trace.conj().T @ rho_xa_cvxpy_vars[x_q, a_ans_alice]
-                        )
+                        coeff += self.prob_mat[x_q, y_q] * np.kron(v_xyab, b_yb)
+                coeff_params[x_q, a_ans_alice].value = coeff.conj().T
 
-        objective = cvxpy.Maximize(cvxpy.real(win_objective))
-        constraints = []
-        for x_q_constr in range(self.num_alice_in):
-            rho_sum_a_constr = 0
-            for a_ans_constr in range(self.num_alice_out):
-                constraints.append(rho_xa_cvxpy_vars[x_q_constr, a_ans_constr] >> 0)
-                rho_sum_a_constr += rho_xa_cvxpy_vars[x_q_constr, a_ans_constr]
-            constraints.append(rho_sum_a_constr == tau_A_cvxpy_var)
-        constraints.append(cvxpy.trace(tau_A_cvxpy_var) == 1)
-        constraints.append(tau_A_cvxpy_var >> 0)
-
-        problem = cvxpy.Problem(objective, constraints)
         problem.solve(solver=solver, **solver_params)  # Use passed solver and params
 
         return rho_xa_cvxpy_vars, problem
@@ -480,40 +498,54 @@ class ExtendedNonlocalGame:
         # To overcome this, we use a dictionary to index between the questions and
         # answers, while the cvxpy variables held at this positions are
         # `dim`-by-`dim` cvxpy variables.
+        #
+        # Build the SDP once and cache it; only the fixed Alice operators `rho_xa` (constants in the objective) change
+        # between see-saw steps, so they enter as one `cvxpy.Parameter` per (x, a) whose `.value` is reassigned below.
+        if getattr(self, "_seesaw_bob", None) is None:
+            rho_dim = self.referee_dim * self.num_bob_out
+            bob_povm_cvxpy_vars = defaultdict(cvxpy.Variable)
+            for y_ques in range(self.num_bob_in):
+                for b_ans in range(self.num_bob_out):
+                    bob_povm_cvxpy_vars[y_ques, b_ans] = cvxpy.Variable(
+                        (self.num_bob_out, self.num_bob_out), hermitian=True, name=f"B_POVM_{y_ques}{b_ans}"
+                    )
 
-        bob_povm_cvxpy_vars = defaultdict(cvxpy.Variable)
-        for y_ques in range(self.num_bob_in):
-            for b_ans in range(self.num_bob_out):
-                bob_povm_cvxpy_vars[y_ques, b_ans] = cvxpy.Variable(
-                    (self.num_bob_out, self.num_bob_out), hermitian=True, name=f"B_POVM_{y_ques}{b_ans}"
-                )
-
-        win_objective = cvxpy.Constant(0)
-
-        for x_q in range(self.num_alice_in):
-            for y_q in range(self.num_bob_in):
-                if self.prob_mat[x_q, y_q] == 0:
-                    continue
+            rho_params = {}
+            for x_q in range(self.num_alice_in):
                 for a_ans_alice in range(self.num_alice_out):
-                    rho_xa_val = alice_rho_cvxpy_vars[x_q, a_ans_alice].value
+                    rho_params[x_q, a_ans_alice] = cvxpy.Parameter((rho_dim, rho_dim), complex=True)
 
-                    for b_ans_bob in range(self.num_bob_out):
-                        v_xyab = self.pred_mat[:, :, a_ans_alice, b_ans_bob, x_q, y_q]
-                        win_objective += self.prob_mat[x_q, y_q] * cvxpy.trace(
-                            cvxpy.kron(v_xyab, bob_povm_cvxpy_vars[y_q, b_ans_bob]) @ rho_xa_val
-                        )
+            win_objective = cvxpy.Constant(0)
+            for x_q in range(self.num_alice_in):
+                for y_q in range(self.num_bob_in):
+                    if self.prob_mat[x_q, y_q] == 0:
+                        continue
+                    for a_ans_alice in range(self.num_alice_out):
+                        for b_ans_bob in range(self.num_bob_out):
+                            v_xyab = self.pred_mat[:, :, a_ans_alice, b_ans_bob, x_q, y_q]
+                            win_objective += self.prob_mat[x_q, y_q] * cvxpy.trace(
+                                cvxpy.kron(v_xyab, bob_povm_cvxpy_vars[y_q, b_ans_bob]) @ rho_params[x_q, a_ans_alice]
+                            )
 
-        objective = cvxpy.Maximize(cvxpy.real(win_objective))
-        constraints = []
-        ident_bob_space = np.identity(self.num_bob_out)
-        for y_q_constr in range(self.num_bob_in):
-            sum_b_povm = 0
-            for b_ans_constr in range(self.num_bob_out):
-                constraints.append(bob_povm_cvxpy_vars[y_q_constr, b_ans_constr] >> 0)
-                sum_b_povm += bob_povm_cvxpy_vars[y_q_constr, b_ans_constr]
-            constraints.append(sum_b_povm == ident_bob_space)
+            objective = cvxpy.Maximize(cvxpy.real(win_objective))
+            constraints = []
+            ident_bob_space = np.identity(self.num_bob_out)
+            for y_q_constr in range(self.num_bob_in):
+                sum_b_povm = 0
+                for b_ans_constr in range(self.num_bob_out):
+                    constraints.append(bob_povm_cvxpy_vars[y_q_constr, b_ans_constr] >> 0)
+                    sum_b_povm += bob_povm_cvxpy_vars[y_q_constr, b_ans_constr]
+                constraints.append(sum_b_povm == ident_bob_space)
 
-        problem = cvxpy.Problem(objective, constraints)
+            self._seesaw_bob = (cvxpy.Problem(objective, constraints), bob_povm_cvxpy_vars, rho_params)
+
+        problem, bob_povm_cvxpy_vars, rho_params = self._seesaw_bob
+
+        # Refresh the fixed-Alice operators for the current Alice solution.
+        for x_q in range(self.num_alice_in):
+            for a_ans_alice in range(self.num_alice_out):
+                rho_params[x_q, a_ans_alice].value = alice_rho_cvxpy_vars[x_q, a_ans_alice].value
+
         problem.solve(solver=solver, **solver_params)  # Use passed solver and params
 
         return bob_povm_cvxpy_vars, problem

--- a/toqito/nonlocal_games/nonlocal_game.py
+++ b/toqito/nonlocal_games/nonlocal_game.py
@@ -327,7 +327,12 @@ class NonlocalGame:
 
         """
         # Get number of inputs and outputs.
-        _, num_outputs_bob, _, num_inputs_bob = self.pred_mat.shape
+        (
+            num_outputs_alice,
+            num_outputs_bob,
+            num_inputs_alice,
+            num_inputs_bob,
+        ) = self.pred_mat.shape
 
         # A master generator yields an independent, reproducible seed for each random restart so the whole routine is
         # deterministic when `seed` is provided.
@@ -336,6 +341,79 @@ class NonlocalGame:
         # Cap the inner alternating loop so a non-converging instance cannot spin forever.
         max_seesaw_steps = 100
 
+        # Both alternating SDPs have identical variables and constraints on every see-saw step and restart; only the
+        # fixed opponent operators (constants in the objective) change. Build each `cvxpy.Problem` exactly once with
+        # the opponent operators exposed as `cvxpy.Parameter`s, then re-solve after assigning `.value` each step. This
+        # avoids re-canonicalizing (which dominates the runtime of these small SDPs) on every iteration.
+
+        # --- Alice's SDP: optimize Alice's measurements with Bob's fixed. ---
+        # `bob_params[y, b]` holds the conjugate transpose of Bob's fixed operator B_b^y, matching the original
+        # `bob_val = B_b^y.conj().T` used inside the trace.
+        alice_povms = defaultdict(cvxpy.Variable)
+        for x_ques in range(num_inputs_alice):
+            for a_ans in range(num_outputs_alice):
+                alice_povms[x_ques, a_ans] = cvxpy.Variable((dim, dim), hermitian=True)
+        tau = cvxpy.Variable((dim, dim), hermitian=True)
+        bob_params = {}
+        for y_ques in range(num_inputs_bob):
+            for b_ans in range(num_outputs_bob):
+                bob_params[y_ques, b_ans] = cvxpy.Parameter((dim, dim), complex=True)
+
+        # .. math::
+        #    \sum_{(x,y) \in \Sigma} \pi(x, y) V(a,b|x,y) \ip{B_b^y}{A_a^x}
+        alice_win = 0
+        for x_ques in range(num_inputs_alice):
+            for y_ques in range(num_inputs_bob):
+                for a_ans in range(num_outputs_alice):
+                    for b_ans in range(num_outputs_bob):
+                        alice_win += (
+                            self.prob_mat[x_ques, y_ques]
+                            * self.pred_mat[a_ans, b_ans, x_ques, y_ques]
+                            * cvxpy.trace(bob_params[y_ques, b_ans] @ alice_povms[x_ques, a_ans])
+                        )
+
+        alice_constraints = []
+        for x_ques in range(num_inputs_alice):
+            alice_sum_a = 0
+            for a_ans in range(num_outputs_alice):
+                alice_sum_a += alice_povms[x_ques, a_ans]
+                alice_constraints.append(alice_povms[x_ques, a_ans] >> 0)
+            alice_constraints.append(alice_sum_a == tau)
+        alice_constraints.append(cvxpy.trace(tau) == 1)
+        alice_constraints.append(tau >> 0)
+        alice_problem = cvxpy.Problem(cvxpy.Maximize(cvxpy.real(alice_win)), alice_constraints)
+
+        # --- Bob's SDP: optimize Bob's measurements with Alice's fixed. ---
+        # `alice_params[x, a]` holds Alice's fixed operator A_a^x.
+        bob_povms = defaultdict(cvxpy.Variable)
+        for y_ques in range(num_inputs_bob):
+            for b_ans in range(num_outputs_bob):
+                bob_povms[y_ques, b_ans] = cvxpy.Variable((dim, dim), hermitian=True)
+        alice_params = {}
+        for x_ques in range(num_inputs_alice):
+            for a_ans in range(num_outputs_alice):
+                alice_params[x_ques, a_ans] = cvxpy.Parameter((dim, dim), complex=True)
+
+        bob_win = 0
+        for x_ques in range(num_inputs_alice):
+            for y_ques in range(num_inputs_bob):
+                for a_ans in range(num_outputs_alice):
+                    for b_ans in range(num_outputs_bob):
+                        bob_win += (
+                            self.prob_mat[x_ques, y_ques]
+                            * self.pred_mat[a_ans, b_ans, x_ques, y_ques]
+                            * cvxpy.trace(bob_povms[y_ques, b_ans].H @ alice_params[x_ques, a_ans])
+                        )
+
+        bob_constraints = []
+        for y_ques in range(num_inputs_bob):
+            bob_sum_b = 0
+            for b_ans in range(num_outputs_bob):
+                bob_sum_b += bob_povms[y_ques, b_ans]
+                bob_constraints.append(bob_povms[y_ques, b_ans] >> 0)
+            bob_constraints.append(bob_sum_b == np.identity(dim))
+        bob_problem = cvxpy.Problem(cvxpy.Maximize(cvxpy.real(bob_win)), bob_constraints)
+
         best_lower_bound = float("-inf")
         for _ in range(iters):
             # Generate a set of random POVMs for Bob. These measurements serve
@@ -343,10 +421,10 @@ class NonlocalGame:
             # algorithm.
             restart_seed = int(rng.integers(0, 2**32 - 1))
             bob_tmp = random_povm(dim, num_inputs_bob, num_outputs_bob, seed=restart_seed)
-            bob_povms = defaultdict(int)
+            bob_ops = {}
             for y_ques in range(num_inputs_bob):
                 for b_ans in range(num_outputs_bob):
-                    bob_povms[y_ques, b_ans] = bob_tmp[:, :, y_ques, b_ans]
+                    bob_ops[y_ques, b_ans] = bob_tmp[:, :, y_ques, b_ans]
 
             # Run the alternating projection algorithm between the two SDPs.
             prev_win = float("-inf")
@@ -356,8 +434,18 @@ class NonlocalGame:
                 # Bob's. If this is the first iteration, then the previously
                 # randomly generated operators in the outer loop are Bob's.
                 # Otherwise, Bob's operators come from running the next SDP.
-                alice_povms, _ = self.__optimize_alice(dim, bob_povms)
-                bob_povms, lower_bound = self.__optimize_bob(dim, alice_povms)
+                for y_ques in range(num_inputs_bob):
+                    for b_ans in range(num_outputs_bob):
+                        bob_params[y_ques, b_ans].value = bob_ops[y_ques, b_ans].conj().T
+                alice_problem.solve(verbose=False)
+                for x_ques in range(num_inputs_alice):
+                    for a_ans in range(num_outputs_alice):
+                        alice_params[x_ques, a_ans].value = alice_povms[x_ques, a_ans].value
+
+                lower_bound = bob_problem.solve(verbose=False)
+                for y_ques in range(num_inputs_bob):
+                    for b_ans in range(num_outputs_bob):
+                        bob_ops[y_ques, b_ans] = bob_povms[y_ques, b_ans].value
 
                 # As the SDPs keep alternating, check if the winning probability
                 # becomes any higher. If so, replace with new best.
@@ -371,109 +459,6 @@ class NonlocalGame:
             best_lower_bound = max(best, best_lower_bound)
 
         return best_lower_bound
-
-    def __optimize_alice(self, dim, bob_povms) -> tuple[dict, float]:
-        """Fix Bob's measurements and optimize over Alice's measurements."""
-        # Get number of inputs and outputs.
-        (
-            num_outputs_alice,
-            num_outputs_bob,
-            num_inputs_alice,
-            num_inputs_bob,
-        ) = self.pred_mat.shape
-
-        # The cvxpy package does not support optimizing over 4-dimensional
-        # objects. To overcome this, we use a dictionary to index between the
-        # questions and answers, while the cvxpy variables held at this
-        # positions are `dim`-by-`dim` cvxpy variables.
-        alice_povms = defaultdict(cvxpy.Variable)
-        for x_ques in range(num_inputs_alice):
-            for a_ans in range(num_outputs_alice):
-                alice_povms[x_ques, a_ans] = cvxpy.Variable((dim, dim), hermitian=True)
-
-        tau = cvxpy.Variable((dim, dim), hermitian=True)
-
-        # .. math::
-        #    \sum_{(x,y) \in \Sigma} \pi(x, y) V(a,b|x,y) \ip{B_b^y}{A_a^x}
-        win = 0
-        for x_ques in range(num_inputs_alice):
-            for y_ques in range(num_inputs_bob):
-                for a_ans in range(num_outputs_alice):
-                    for b_ans in range(num_outputs_bob):
-                        bob_povm = bob_povms[y_ques, b_ans]
-                        if isinstance(bob_povm, np.ndarray):
-                            bob_val = bob_povm.conj().T
-                        else:
-                            bob_val = bob_povm.value.conj().T
-                        win += (
-                            self.prob_mat[x_ques, y_ques]
-                            * self.pred_mat[a_ans, b_ans, x_ques, y_ques]
-                            * cvxpy.trace(bob_val @ alice_povms[x_ques, a_ans])
-                        )
-
-        objective = cvxpy.Maximize(cvxpy.real(win))
-
-        constraints = []
-
-        # Sum over "a" for all "x" for Alice's measurements.
-        for x_ques in range(num_inputs_alice):
-            alice_sum_a = 0
-            for a_ans in range(num_outputs_alice):
-                alice_sum_a += alice_povms[x_ques, a_ans]
-                constraints.append(alice_povms[x_ques, a_ans] >> 0)
-            constraints.append(alice_sum_a == tau)
-
-        constraints.append(cvxpy.trace(tau) == 1)
-        constraints.append(tau >> 0)
-
-        problem = cvxpy.Problem(objective, constraints)
-
-        lower_bound = problem.solve(verbose=False)
-        return alice_povms, lower_bound
-
-    def __optimize_bob(self, dim, alice_povms) -> tuple[dict, float]:
-        """Fix Alice's measurements and optimize over Bob's measurements."""
-        # Get number of inputs and outputs.
-        (
-            num_outputs_alice,
-            num_outputs_bob,
-            num_inputs_alice,
-            num_inputs_bob,
-        ) = self.pred_mat.shape
-
-        # Now, optimize over Bob's measurement operators and fix Alice's
-        # operators as those are coming from the previous SDP.
-        bob_povms = defaultdict(cvxpy.Variable)
-        for y_ques in range(num_inputs_bob):
-            for b_ans in range(num_outputs_bob):
-                bob_povms[y_ques, b_ans] = cvxpy.Variable((dim, dim), hermitian=True)
-
-        win = 0
-        for x_ques in range(num_inputs_alice):
-            for y_ques in range(num_inputs_bob):
-                for a_ans in range(num_outputs_alice):
-                    for b_ans in range(num_outputs_bob):
-                        win += (
-                            self.prob_mat[x_ques, y_ques]
-                            * self.pred_mat[a_ans, b_ans, x_ques, y_ques]
-                            * cvxpy.trace(bob_povms[y_ques, b_ans].H @ alice_povms[x_ques, a_ans].value)
-                        )
-
-        objective = cvxpy.Maximize(cvxpy.real(win))
-        constraints = []
-
-        # Sum over "b" for all "y" for Bob's measurements.
-        for y_ques in range(num_inputs_bob):
-            bob_sum_b = 0
-            for b_ans in range(num_outputs_bob):
-                bob_sum_b += bob_povms[y_ques, b_ans]
-                constraints.append(bob_povms[y_ques, b_ans] >> 0)
-            constraints.append(bob_sum_b == np.identity(dim))
-
-        problem = cvxpy.Problem(objective, constraints)
-
-        lower_bound = problem.solve(verbose=False)
-        return bob_povms, lower_bound
 
     def nonsignaling_value(self) -> float:
         """Compute the non-signaling value of the nonlocal game.

--- a/toqito/nonlocal_games/tests/test_nonlocal_game.py
+++ b/toqito/nonlocal_games/tests/test_nonlocal_game.py
@@ -98,6 +98,18 @@ class TestNonlocalGame(unittest.TestCase):
         res = chsh.quantum_value_lower_bound(4)
         self.assertLessEqual(res, np.cos(np.pi / 8) ** 2 + 1e-2)
 
+    def test_chsh_lower_bound_converges_early(self):
+        """With a loose tolerance the see-saw stabilizes and stops before the step cap.
+
+        This exercises the early-convergence break in the see-saw loop: after the first
+        step the winning probability changes by less than ``tol`` between steps, so the
+        optimization terminates early rather than running every step.
+        """
+        prob_mat, pred_mat = self.chsh_nonlocal_game()
+        chsh = NonlocalGame(prob_mat, pred_mat)
+        res = chsh.quantum_value_lower_bound(tol=1e-1, seed=42)
+        self.assertLessEqual(res, np.cos(np.pi / 8) ** 2 + 1e-2)
+
     def test_chsh_lower_bound_seed_reproducible(self):
         """A fixed seed makes the see-saw lower bound reproducible and a valid bound."""
         prob_mat, pred_mat = self.chsh_nonlocal_game()

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -645,6 +645,13 @@ def _locc_min_error(
     num_states = len(states)
     num_a = num_states if num_alice_outcomes is None else num_alice_outcomes
 
+    # Both alternating SDPs have identical variables and constraints on every see-saw step and restart; only the fixed
+    # opponent operators (constants in the objective) change. Build each `cvxpy.Problem` once with those operators
+    # exposed as `cvxpy.Parameter`s, then re-solve after assigning `.value` each step. This avoids re-canonicalizing
+    # (which dominates the runtime of these small SDPs) on every iteration.
+    bob_problem, bob_vars, bob_params = _locc_build_bob(probs, num_a, num_states, dim_b)
+    alice_problem, alice_vars, alice_params = _locc_build_alice(num_a, dim_a)
+
     best = float("inf")
     best_strategy: tuple[list[np.ndarray], dict, int] | None = None
     for rep in range(reps):
@@ -655,8 +662,8 @@ def _locc_min_error(
         prev = float("inf")
         current = float("inf")
         for _ in range(max_iters):
-            bob = _locc_optimize_bob(states, probs, dim_a, dim_b, alice)
-            alice = _locc_optimize_alice(states, probs, dim_a, dim_b, bob, num_a)
+            bob = _locc_optimize_bob(bob_problem, bob_vars, bob_params, states, dim_a, dim_b, alice)
+            alice = _locc_optimize_alice(alice_problem, alice_vars, alice_params, states, probs, dim_a, dim_b, bob)
             current = _locc_error(states, probs, alice, bob, num_a)
             if abs(prev - current) < tol:
                 break
@@ -671,45 +678,73 @@ def _locc_min_error(
     return best, measurements
 
 
-def _locc_optimize_bob(states, probs, dim_a, dim_b, alice):
-    """Fix Alice's POVM and optimize Bob's conditional exclusion POVMs."""
-    num_a, num_states = len(alice), len(states)
+def _locc_build_bob(probs, num_a, num_states, dim_b):
+    """Build Bob's exclusion SDP once, exposing Alice's fixed conditional states as parameters.
+
+    Returns the problem together with Bob's POVM variables and the per-``(a, k)`` conditional-state parameters
+    (``partial_trace`` of Alice's outcome ``a`` on state ``k``) whose ``.value`` is refreshed each see-saw step.
+    """
     bob = {(a, k): cvxpy.Variable((dim_b, dim_b), hermitian=True) for a in range(num_a) for k in range(num_states)}
+    conditionals = {
+        (a, k): cvxpy.Parameter((dim_b, dim_b), complex=True) for a in range(num_a) for k in range(num_states)
+    }
 
     constraints = []
     error = 0
     for a in range(num_a):
-        conditional = [
-            partial_trace(np.kron(alice[a], np.identity(dim_b)) @ states[k], [0], [dim_a, dim_b])
-            for k in range(num_states)
-        ]
         for k in range(num_states):
             constraints.append(bob[a, k] >> 0)
-            error += probs[k] * cvxpy.trace(bob[a, k] @ conditional[k])
+            error += probs[k] * cvxpy.trace(bob[a, k] @ conditionals[a, k])
         constraints.append(sum(bob[a, k] for k in range(num_states)) == np.identity(dim_b))
 
-    cvxpy.Problem(cvxpy.Minimize(cvxpy.real(error)), constraints).solve()
-    return {key: np.array(var.value) for key, var in bob.items()}
+    problem = cvxpy.Problem(cvxpy.Minimize(cvxpy.real(error)), constraints)
+    return problem, bob, conditionals
 
 
-def _locc_optimize_alice(states, probs, dim_a, dim_b, bob, num_a):
-    """Fix Bob's conditional POVMs and optimize Alice's POVM."""
-    num_states = len(states)
+def _locc_optimize_bob(problem, bob_vars, conditionals, states, dim_a, dim_b, alice):
+    """Fix Alice's POVM and optimize Bob's conditional exclusion POVMs by re-solving the prebuilt SDP."""
+    num_a, num_states = len(alice), len(states)
+    for a in range(num_a):
+        for k in range(num_states):
+            conditionals[a, k].value = partial_trace(
+                np.kron(alice[a], np.identity(dim_b)) @ states[k], [0], [dim_a, dim_b]
+            )
+
+    problem.solve()
+    return {key: np.array(var.value) for key, var in bob_vars.items()}
+
+
+def _locc_build_alice(num_a, dim_a):
+    """Build Alice's exclusion SDP once, exposing Bob's fixed operators as per-outcome ``tau`` parameters.
+
+    Returns the problem together with Alice's POVM variables and the per-outcome ``tau`` parameters (the
+    probability-weighted partial traces induced by Bob's conditional POVMs) whose ``.value`` is refreshed each step.
+    """
     alice = [cvxpy.Variable((dim_a, dim_a), hermitian=True) for _ in range(num_a)]
+    taus = [cvxpy.Parameter((dim_a, dim_a), complex=True) for _ in range(num_a)]
 
     constraints = [a >> 0 for a in alice]
     constraints.append(sum(alice) == np.identity(dim_a))
 
     error = 0
     for a in range(num_a):
-        tau = sum(
+        error += cvxpy.trace(alice[a] @ taus[a])
+
+    problem = cvxpy.Problem(cvxpy.Minimize(cvxpy.real(error)), constraints)
+    return problem, alice, taus
+
+
+def _locc_optimize_alice(problem, alice_vars, taus, states, probs, dim_a, dim_b, bob):
+    """Fix Bob's conditional POVMs and optimize Alice's POVM by re-solving the prebuilt SDP."""
+    num_a, num_states = len(alice_vars), len(states)
+    for a in range(num_a):
+        taus[a].value = sum(
             probs[k] * partial_trace(np.kron(np.identity(dim_a), bob[a, k]) @ states[k], [1], [dim_a, dim_b])
             for k in range(num_states)
         )
-        error += cvxpy.trace(alice[a] @ tau)
 
-    cvxpy.Problem(cvxpy.Minimize(cvxpy.real(error)), constraints).solve()
-    return [np.array(a.value) for a in alice]
+    problem.solve()
+    return [np.array(a.value) for a in alice_vars]
 
 
 def _locc_error(states, probs, alice, bob, num_a):


### PR DESCRIPTION
## Summary

Each alternating (see-saw) optimization in these routines rebuilt two cvxpy `Problem`s from scratch on every step and restart. The variables and constraints are identical on every step; only the fixed opponent operators change, and they enter **only as constant objective coefficients**. With defaults this meant up to ~1000 full problem constructions + canonicalizations per call, and canonicalization (not the numeric solve) dominates the runtime of these small SDPs.

This PR builds each SDP **once**, exposes the fixed operators as `cvxpy.Parameter` blocks, and re-solves after assigning `.value` on each step. All parametrized problems are DPP-compliant (`is_dcp(dpp=True) == True`), so cvxpy caches the canonicalization and only refreshes parameter data per solve. This turns ~1000 canonicalizations into ~2.

## Files converted

- **`toqito/nonlocal_games/nonlocal_game.py`** — `quantum_value_lower_bound`. The two per-iteration builders `__optimize_alice`/`__optimize_bob` are inlined; Alice's and Bob's `Problem`s are built once before the restart/see-saw loops with the fixed opponent operators as `Parameter`s.
- **`toqito/nonlocal_games/extended_nonlocal_game.py`** — `quantum_value_lower_bound`. `__optimize_alice`/`__optimize_bob` keep their signatures and return types (so the existing mock-based unit tests are unaffected) but now build their `Problem` once, cache it on the instance, and reassign parameters each step. Alice's 4-nested objective loop is collapsed to a single precomputed coefficient per `(x, a)`.
- **`toqito/state_opt/state_exclusion.py`** — one-way LOCC see-saw (`_locc_min_error`). Both SDPs are built once (`_locc_build_bob`, `_locc_build_alice`) and re-solved via parameter updates each step.

RNG usage and seeding order are preserved exactly (random draws happen once per restart, before the see-saw loop, in unchanged order), as are the convergence criteria, iteration caps, and all return values.

## Equivalence verification

For each entry point the returned value was compared before (origin/master) and after, on small fixed-seed instances (CHSH, a random 2-in/2-out game, the MUB 3-in/2-out extended game, and the two-qubit LOCC exclusion ensembles).

**With the default SCS solver**, before/after values match within SCS's own tolerance:

| case | master | refactor | abs diff |
| --- | --- | --- | --- |
| chsh (worst seed) | 0.749999099 | 0.750011197 | 1.2e-05 |
| rand_game (worst) | 1.000002093 | 1.000009632 | 7.5e-06 |
| ext_mub | 0.788675134 | 0.788675149 | 1.5e-08 |
| locc_gap (worst) | 0.081455709 | 0.081450748 | 5.0e-06 |
| locc_prod | -7.7e-07 | ~0 | 7.7e-07 |

Overall max abs diff (default SCS): **1.2e-05**. These small differences are pure solver noise: the see-saw is a chaotic alternating heuristic, and swapping constant coefficients for mathematically-identical `Parameter` coefficients makes SCS (default tolerance ~1e-4/1e-5) take a slightly different but equally valid path.

**To isolate construction equivalence from solver noise**, the identical full see-saw was re-run before/after with a high-accuracy solver (CLARABEL), forced via monkeypatch:

- `nonlocal_game` (CHSH, 4 seeds): abs diff **7.8e-16 – 1.1e-10**
- `state_exclusion` LOCC (3 seeds): abs diff **~1e-9**
- `extended_nonlocal_game` (3 seeds): abs diff **1.6e-15**

A single Alice-step SDP built the old way vs. the new way with CLARABEL returned identical optimal values and identical operators (diff `0.0`). This confirms the refactor is mathematically equivalent; the default-solver differences are solver tolerance, not a behavior change.

## Performance

Extended game (`iters=10`, 3 seeds): master 1.14s → refactor 0.56s (**~2.0x**).

## Tests

- `toqito/nonlocal_games/tests/test_nonlocal_game.py`: 22 passed, 1 skipped
- `toqito/nonlocal_games/tests/test_extended_nonlocal_game.py`: 27 passed, 10 skipped, 1 xfailed
- `toqito/state_opt/tests/test_state_exclusion_locc.py`: 10 passed, 1 skipped

`ruff@0.15.0 check` and `format --check` pass on all three files.

Closes #1764

## Checklist

- [x] I have read the CONTRIBUTING guidelines.
- [x] Existing tests pass locally with these changes.
- [x] The behavior is verified numerically equivalent to the previous implementation.
- [x] `ruff check` and `ruff format --check` pass on changed files.
