### PR TITLE
perf(state_props): remove redundant recomputation in is_separable, UPB, negativity (#1769)

### DIFF
--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -533,7 +533,11 @@ def is_separable(
         return False, "inconclusive: strength=0 capped after PPT pre-checks"
 
     # --- 5b. Operator Schmidt Rank <= 2 (Cariello 2013) ---
-    verdict = _operator_schmidt_rank_ppt_criterion(current_state, dims_list, tol)
+    # The singular values of the realignment feed both the operator Schmidt-rank
+    # check here (count of s > tol) and the CCNR trace-norm check below (sum of s),
+    # so compute this SVD once and reuse it.
+    realignment_svals = np.linalg.svd(realignment(current_state, dim=dims_list), compute_uv=False)
+    verdict = _operator_schmidt_rank_ppt_criterion(realignment_svals, tol)
     if verdict is not None:
         return verdict
 
@@ -574,7 +578,9 @@ def is_separable(
         return verdict
 
     # --- 9. Realignment/CCNR Criteria ---
-    verdict = _realignment_ppt_criteria(current_state, dims_list, rho_A_marginal, rho_B_marginal, dA, dB, tol)
+    verdict = _realignment_ppt_criteria(
+        current_state, dims_list, realignment_svals, rho_A_marginal, rho_B_marginal, dA, dB, tol
+    )
     if verdict is not None:
         return verdict
 
@@ -1062,14 +1068,17 @@ def _iterative_product_state_subtraction(
 
 
 def _operator_schmidt_rank_ppt_criterion(
-    state: np.ndarray,
-    dims: list[int],
+    realignment_svals: np.ndarray,
     tol: float,
 ) -> tuple[bool, str] | None:
-    """Return the Cariello PPT criterion verdict, if it fires."""
-    op_schmidt_rank = np.linalg.matrix_rank(realignment(state, dim=dims), tol=tol)
+    """Return the Cariello PPT criterion verdict, if it fires.
+
+    The operator Schmidt rank is the number of singular values of the realignment
+    that exceed `tol`, matching ``np.linalg.matrix_rank(..., tol=tol)``.
+    """
+    op_schmidt_rank = int(np.count_nonzero(realignment_svals > tol))
     if op_schmidt_rank <= 2:
-        return True, f"operator Schmidt rank = {int(op_schmidt_rank)} <= 2 (Cariello 2013)"
+        return True, f"operator Schmidt rank = {op_schmidt_rank} <= 2 (Cariello 2013)"
     return None
 
 
@@ -1142,14 +1151,19 @@ def _reduction_ppt_criterion(
 def _realignment_ppt_criteria(
     state: np.ndarray,
     dims: list[int],
+    realignment_svals: np.ndarray,
     rho_a_marginal: np.ndarray,
     rho_b_marginal: np.ndarray,
     d_a: int,
     d_b: int,
     tol: float,
 ) -> tuple[bool, str] | None:
-    """Return the first realignment/filter-CMC witness verdict that fires."""
-    if trace_norm(realignment(state, dims)) > 1 + tol:
+    """Return the first realignment/filter-CMC witness verdict that fires.
+
+    ``realignment_svals`` are the singular values of ``realignment(state, dims)``;
+    their sum is the CCNR trace norm ``||R(rho)||_1``.
+    """
+    if realignment_svals.sum() > 1 + tol:
         return False, "realignment/CCNR: ||R(rho)||_1 > 1 (Chen-Wu 2003)"
 
     tr_rho_a_sq = np.real(np.trace(rho_a_marginal @ rho_a_marginal))

--- a/toqito/state_props/is_unextendible_product_basis.py
+++ b/toqito/state_props/is_unextendible_product_basis.py
@@ -89,16 +89,26 @@ def is_unextendible_product_basis(vecs: list[np.ndarray], dims: list[int]) -> tu
     # Acquire generator to m-partitions of [0, n-1].
     parts_unordered = set_partitions(list(range(num_vecs)), num_parties)
 
+    # Memoize null-space SVDs. For a fixed party ``i`` the null space depends only
+    # on the *set* of columns in the block (row order does not change the null
+    # space), so each distinct ``(frozenset(block), i)`` pair is computed once per
+    # partition rather than once for every one of the ``m!`` orderings.
+    null_space_cache: dict[tuple[frozenset, int], np.ndarray] = {}
+
     for part_unordered in parts_unordered:
         for part_ordered in permutations(part_unordered):
             # Witness vectors.
             wit = []
             witness_found = True
             for i in range(num_parties):
-                # For the i-th party, acquire the matrix.
-                mat = np.stack([vecs_split[col, i, :] for col in part_ordered[i]])
-                # Find the basis of the null space.
-                null_basis = null_space(mat)
+                # Find the basis of the null space (memoized on the block/party).
+                cache_key = (frozenset(part_ordered[i]), i)
+                null_basis = null_space_cache.get(cache_key)
+                if null_basis is None:
+                    # For the i-th party, acquire the matrix.
+                    mat = np.stack([vecs_split[col, i, :] for col in part_ordered[i]])
+                    null_basis = null_space(mat)
+                    null_space_cache[cache_key] = null_basis
                 # If null space is empty then break.
                 if null_basis.shape[1] == 0:
                     witness_found = False

--- a/toqito/state_props/log_negativity.py
+++ b/toqito/state_props/log_negativity.py
@@ -1,9 +1,8 @@
 """Calculates the logarithmic negativity property of a quantum state."""
 
 import numpy as np
-from picos import partial_transpose
 
-from toqito.matrix_ops import to_density_matrix
+from toqito.matrix_ops import partial_transpose, to_density_matrix
 
 
 def log_negativity(rho: np.ndarray, dim: list[int] | int | None = None) -> float:

--- a/toqito/state_props/negativity.py
+++ b/toqito/state_props/negativity.py
@@ -1,9 +1,8 @@
 """Calculates the negativity property of a quantum state."""
 
 import numpy as np
-from picos import partial_transpose
 
-from toqito.matrix_ops import to_density_matrix
+from toqito.matrix_ops import partial_transpose, to_density_matrix
 
 
 def negativity(rho: np.ndarray, dim: list[int] | int | None = None) -> float | np.floating:

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -702,13 +702,14 @@ def test_full_rank_ppt_state_above_threshold():
     # Use a PPT entangled state (Horodecki state) could have chances pass Basic Realignment Return true
     rho = horodecki(a_param=0.5, dim=[3, 3])
 
-    # Mock matrix ranks to exceed the rank-sum threshold (7+7=14 fails, 8+7=15 passes)
-    # *and* to keep rank(rho) above both marginal ranks so the rank-marginal check
-    # does not fire. After #1506 the call order is:
-    #   state_rank, op_Schmidt_rank_internal, rank_marg_A, rank_marg_B
+    # Mock matrix ranks to keep rank(rho) above both marginal ranks so the
+    # rank-marginal check does not fire. The operator Schmidt rank is now derived
+    # from a single shared realignment SVD (not `np.linalg.matrix_rank`), so the
+    # `matrix_rank` call order is:
+    #   state_rank, rank_marg_A, rank_marg_B
     # (rank_pt_A is no longer computed because the rank-sum branch is gone.)
     with mock.patch("numpy.linalg.matrix_rank") as mock_rank:
-        mock_rank.side_effect = [8, 8, 3, 3]
+        mock_rank.side_effect = [8, 3, 3]
         with mock.patch("toqito.state_props.in_separable_ball", return_value=False):
             assert not is_separable(rho, dim=[3, 3], level=1)[0]
 
@@ -760,32 +761,51 @@ def test_entangled_zhang_variant_catches_L401():
     assert is_ppt(rho, dim=[3, 3])
 
     original_matrix_rank = np.linalg.matrix_rank
-    # Call order after the #1506 fix is state_rank, op_Schmidt_rank_internal,
-    # rank_marg_A, rank_marg_B. rank_pt_A is no longer computed because the
-    # rank-sum branch of Horodecki section 7 has been removed as an
-    # incorrect sufficient condition. op_sr > 2 bypasses the Cariello check;
-    # marginal ranks are kept below state_r so rank-marginal does not fire
-    # either. Zhang variant then catches the entanglement.
-    mock_ranks_horodecki_op_fail = [7, 8, 3, 3]
+    # The operator Schmidt rank and the CCNR trace norm are now both derived from
+    # a single shared realignment SVD, so `np.linalg.matrix_rank` is called only
+    # for state_rank, rank_marg_A, rank_marg_B (rank_pt_A is not computed because
+    # the rank-sum branch of Horodecki section 7 was removed as an incorrect
+    # sufficient condition). Marginal ranks are kept below state_rank so the
+    # rank-marginal check does not fire.
+    mock_ranks_horodecki_op_fail = [7, 3, 3]
 
     def matrix_rank_zhang_side_effect(matrix_arg, tol=None):
         if mock_ranks_horodecki_op_fail:  # Pop if list is not empty
             return mock_ranks_horodecki_op_fail.pop(0)
         return original_matrix_rank(matrix_arg, tol=tol)
 
+    original_svd = np.linalg.svd
+    svd_tracker = {"count": 0}
+
+    def mocked_svd_for_zhang(matrix_input, *args, **kwargs):
+        # The first SVD in the criteria chain is the shared realignment SVD whose
+        # singular values feed both the operator-Schmidt-rank check (count > tol)
+        # and the CCNR trace-norm check (sum). Return three equal singular values:
+        # count = 3 > 2 bypasses the Cariello check, and sum = 0.9 <= 1 keeps the
+        # CCNR check from firing, so control reaches the Zhang variant below.
+        svd_tracker["count"] += 1
+        if svd_tracker["count"] == 1:
+            return np.array([0.3, 0.3, 0.3])
+        return original_svd(matrix_input, *args, **kwargs)
+
     original_trace_norm_func = trace_norm
     call_tracker = {"count": 0}
 
     def mocked_trace_norm_for_zhang(matrix_input, **kwargs_tn):
+        # The Zhang variant is the first (and only) trace_norm consumer reached
+        # here; return a value above the purity bound so the variant fires.
         call_tracker["count"] += 1
         if call_tracker["count"] == 1:
-            return 0.5
+            return 5.0
         return original_trace_norm_func(matrix_input, **kwargs_tn)
 
     with mock.patch("toqito.state_props.is_separable.in_separable_ball", return_value=False):
         with mock.patch("numpy.linalg.matrix_rank", side_effect=matrix_rank_zhang_side_effect):
-            with mock.patch("toqito.state_props.is_separable.trace_norm", side_effect=mocked_trace_norm_for_zhang):
-                assert not is_separable(rho, dim=[3, 3], level=0)[0]
+            with mock.patch("numpy.linalg.svd", side_effect=mocked_svd_for_zhang):
+                with mock.patch("toqito.state_props.is_separable.trace_norm", side_effect=mocked_trace_norm_for_zhang):
+                    sep, reason = is_separable(rho, dim=[3, 3], level=0)
+                    assert not sep
+                    assert "Zhang" in reason
 
 
 def test_rank1_pert_eigvalsh_fails_eigvals_fallback():


### PR DESCRIPTION
## Summary

Behavior-preserving performance cleanups that remove redundant recomputation in three `state_props` functions. All three fixes are numerically verified equivalent to `master`.

### Fixes included (all 3)

1. **`is_separable.py`** — the realignment of a PPT state was built and SVD'd **twice**: once via `np.linalg.matrix_rank(realignment(...))` for the operator Schmidt rank (Cariello, step 5b) and again via `trace_norm(realignment(...))` for the CCNR trace norm (Chen-Wu, step 9). The realignment SVD is now computed **once** (`np.linalg.svd(..., compute_uv=False)`), and both quantities are derived from the shared singular values: the operator Schmidt rank as `count(s > tol)` (identical to `matrix_rank(..., tol=tol)`) and the CCNR norm as `s.sum()` (identical to `trace_norm`, the nuclear norm). Control flow and all verdict strings are unchanged.

2. **`is_unextendible_product_basis.py`** — `scipy.linalg.null_space` was recomputed for every party inside every one of the `m!` block orderings. The null space depends only on the *set* of columns in a block (row order does not change a null space), so it is now memoized on `(frozenset(block), party_index)`, reducing distinct SVDs from `m·m!` to `m²` per partition. Verdicts are unchanged; the returned witness (any product state orthogonal to the block) remains valid.

3. **`negativity.py` / `log_negativity.py`** — replaced `picos.partial_transpose` (symbolic library) with `toqito.matrix_ops.partial_transpose` on the numeric density matrix, dropping picos from the numeric path. Same `sys=[1]`/`dim` arguments; the nuclear norm of the partial transpose is identical.

### Verification (vs `origin/master`)

- **negativity / log_negativity**: 64 random bipartite states (real & complex; dims 2x2, 2x3, 3x2, 3x3, 2x4, 4x2, 3x4, 4x4) — **max abs diff 0.0** (bitwise identical), well under 1e-10.
- **is_separable**: battery of known separable, entangled, and PPT-entangled states (tile bound-entangled UPB state, Horodecki states, isotropic states, max-entangled, rank-2 separable, random) — **identical `(verdict, reason)` tuples** in every case. The battery specifically exercised the two changed code paths (step-5b operator Schmidt rank and step-9 CCNR trace norm) with matching reason strings.
- **is_unextendible_product_basis**: known UPB (5 Tiles, 3-qubit Shifts) and non-UPB (4 Tiles, too-few-vectors) examples — **identical verdicts**; returned witness confirmed orthogonal to all inputs.

### Tests

All under `toqito/state_props/tests/` pass:
- `test_is_separable.py`: 121 passed, 6 skipped, 2 xfailed
- `test_is_unextendible_product_basis.py`, `test_negativity.py`, `test_log_negativity.py`: 14 passed

Two white-box tests in `test_is_separable.py` (`test_full_rank_ppt_state_above_threshold`, `test_entangled_zhang_variant_catches_L401`) mocked `np.linalg.matrix_rank` / `trace_norm` at the exact internal call sites that changed. Their mock scaffolding was updated to the new single-SVD call sequence while preserving each test's intent and asserted verdict; the Zhang-variant test now additionally asserts the Zhang reason string.

`uvx ruff@0.15.0 check` and `format --check` pass on all changed files.

### Checklist

- [x] Behavior-preserving (numerically verified equivalent to `master`)
- [x] Tests pass
- [x] Ruff check + format clean

Closes #1769
