### PR TITLE
docs: add root CONTRIBUTING.md, issue templates, and repository layout

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📖 Contributing Guide
+    url: https://vprusso.github.io/toqito/contributing-guide/
+    about: Dev setup, testing, code style, and how to add a new feature.
+  - name: 🧑‍🔬 Good first issues
+    url: https://github.com/vprusso/toqito/labels/good%20first%20issue
+    about: Small, self-contained tasks to get started.
+  - name: 💬 Questions and usage help
+    url: https://github.com/vprusso/toqito/discussions
+    about: For questions about using toqito, please open a discussion.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,20 @@
+---
+name: Documentation improvement
+about: Report missing, unclear, or incorrect documentation (docstrings, guides, examples)
+title: ''
+labels: documentation
+assignees: ''
+
+---
+
+## Where is the documentation?
+*Link or path: a function docstring (`toqito/.../foo.py`), a docs page, a gallery example, or the README.*
+
+## What is wrong or missing?
+*e.g. missing `Examples` section, unclear parameter description, a broken/rendered-wrong code block, a missing `References` entry, or a typo.*
+
+## Suggested improvement
+*What should it say instead? If you are proposing an example, sketch the input and expected output.*
+
+## Additional context
+*Anything else that would help, such as a screenshot of the rendered page.*

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: feature request
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/new_function.md
+++ b/.github/ISSUE_TEMPLATE/new_function.md
@@ -1,0 +1,27 @@
+---
+name: New function request
+about: Request a new quantum-information routine to be added to toqito
+title: ''
+labels: feature request
+assignees: ''
+
+---
+
+## What function would you like added?
+*Name and a one-line description of the routine (e.g. "compute the geometric measure of entanglement of a pure state").*
+
+## Mathematical definition
+*State the quantity precisely. Include the defining formula and the spaces/objects it acts on (states, channels, measurements, dimensions).*
+
+## Reference
+*A paper, textbook (with section), or arXiv link that defines the quantity. If a standard convention is ambiguous, say which one you want.*
+
+## Proposed API (optional)
+*A sketch of the signature and where it would live, e.g. `toqito/state_props/my_function.py`.*
+
+```python
+# def my_function(rho: np.ndarray, ...) -> float:
+```
+
+## Additional context
+*Existing related functions in toqito, alternative conventions, or example inputs/expected outputs.*

--- a/.github/ISSUE_TEMPLATE/performance.md
+++ b/.github/ISSUE_TEMPLATE/performance.md
@@ -1,0 +1,20 @@
+---
+name: Performance improvement
+about: Suggest a way to make a function faster or more memory-efficient
+title: ''
+labels: enhancement, refactor
+assignees: ''
+
+---
+
+## Which function?
+*Path and symbol, e.g. `toqito/matrix_ops/partial_trace.py::partial_trace`.*
+
+## What is inefficient?
+*Describe the wasteful work: a redundant decomposition, a dense operation where structure is sparse, a Python loop that could be vectorized, an SDP rebuilt inside a loop, an `O(n^3)` where `O(n^2)` suffices, etc.*
+
+## Proposed change
+*The cheaper approach. If you have measured it, include a before/after timing and the input sizes used.*
+
+## Correctness
+*Confirm the change is behavior-preserving (same output up to floating-point roundoff), or note any edge case that differs. Existing tests should still pass.*

--- a/.github/ISSUE_TEMPLATE/reference_correction.md
+++ b/.github/ISSUE_TEMPLATE/reference_correction.md
@@ -1,0 +1,20 @@
+---
+name: Mathematical / reference correction
+about: Report an incorrect formula, convention, citation, or numerical result
+title: ''
+labels: documentation
+assignees: ''
+
+---
+
+## What is incorrect?
+*The function, docstring formula, or citation in question (path / link).*
+
+## The issue
+*Describe the error precisely: a wrong formula or inequality direction, a mismatched convention (e.g. log base, Choi ordering, root vs squared fidelity), a citation pointing to the wrong paper, or a numerically wrong result.*
+
+## Correct statement
+*What it should be, with the supporting reference (paper / textbook section / arXiv). Where relevant, include a small worked example or expected numeric value.*
+
+## Impact
+*Does this affect the returned values of a function, or only the documentation/text?*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to `toqito`
+
+Thanks for your interest in contributing to `|toqito⟩`! Contributions of every
+size are welcome — fixing a typo, sharpening an error message, adding a missing
+docstring example, writing a test, or implementing a new quantum-information
+routine.
+
+This file is a quick entry point. The **full, authoritative guide** lives in the
+documentation:
+
+- 📖 **[Contributing Guide](https://vprusso.github.io/toqito/contributing-guide/)**
+  — dev setup, testing, code style, docstring/reference conventions, and how to
+  add a new feature.
+
+## Good first issues
+
+If you are looking for a small, self-contained place to start, browse the
+[**`good first issue`** queue](https://github.com/vprusso/toqito/labels/good%20first%20issue).
+These are scoped so you can finish them without deep knowledge of the codebase —
+adding an example, improving a docstring, tightening an error message, covering
+an edge case with a test, or benchmarking a function.
+
+Issues are labelled by **type** (`bug`, `documentation`, `enhancement`,
+`refactor`, …) and by **area** (`examples`, `gallery`, `benchmarking`, …), so you
+can filter to what interests you. If something is unclear, comment on the issue —
+we are happy to help you get started.
+
+## Quick start
+
+```bash
+# Fork and clone your fork, then from the repository root:
+uv sync                 # create the environment and install toqito (editable)
+
+uv run pytest           # run the test suite
+uv run ruff check       # lint
+uv run ruff format      # auto-format
+```
+
+`toqito` targets **Python >= 3.12** and uses [`uv`](https://docs.astral.sh/uv/)
+for environment management.
+
+## Making a change
+
+1. Create a branch off `master`.
+2. Make your change with a matching test. Code lives in `toqito/<module>/` and
+   its tests in `toqito/<module>/tests/`. See the
+   [repository layout](https://vprusso.github.io/toqito/contributing-guide/#repository-layout).
+3. New public functions need a docstring with a theoretical description, an
+   `Examples` section using a `markdown-exec` fenced block, and a `References`
+   section, and must be exported from the module's `__init__.py`. See
+   [Adding a new feature](https://vprusso.github.io/toqito/contributing-guide/#adding-a-new-feature).
+4. Before opening the PR, confirm locally:
+   - [ ] `uv run ruff check` and `uv run ruff format --check` pass.
+   - [ ] `uv run pytest` passes, and new lines are covered.
+   - [ ] The docs build cleanly (`uv sync --group docs && uv run mkdocs build -f docs/mkdocs.yml`).
+5. Open the pull request and fill in the template. Reference any issue it closes
+   with `Closes #<number>`.
+
+## Reporting issues
+
+Use the [issue templates](https://github.com/vprusso/toqito/issues/new/choose):
+bug report, new function request, documentation improvement, mathematical /
+reference correction, or performance improvement.
+
+## Code of conduct and licensing
+
+By contributing you agree that your contributions are licensed under the
+project's [MIT License](LICENSE). Please keep interactions respectful and
+constructive.

--- a/docs/content/contributing-guide.md
+++ b/docs/content/contributing-guide.md
@@ -45,6 +45,40 @@ uv sync
 
 You are now free to make the desired changes in your fork of `|toqito⟩`.
 
+## Repository layout
+
+The library lives under `toqito/`, organised into subpackages by the kind of
+object they act on. Each subpackage `toqito/<module>/` contains one public
+function per file and its unit tests under `toqito/<module>/tests/`.
+
+| Subpackage | Contents |
+| --- | --- |
+| `states` | Named quantum states (Bell, GHZ, W, Werner, ...). |
+| `state_props` | Predicates and quantities on states (separability, entanglement, entropy, PPT, ...). |
+| `state_metrics` | Distances and fidelities between states (fidelity, trace distance, Bures, ...). |
+| `state_opt` | Optimisation over states (distinguishability, exclusion, symmetric extension, ...). |
+| `state_ops` | Operations that produce or transform states. |
+| `channels` | Named quantum channels (depolarizing, dephasing, amplitude damping, ...). |
+| `channel_props` | Predicates and dimensions of channels (`channel_dim`, `is_completely_positive`, ...). |
+| `channel_metrics` | Distances and norms between channels (diamond norm, CB norms, channel fidelity, ...). |
+| `channel_ops` | Channel representations and application (`kraus_to_choi`, `apply_channel`, ...). |
+| `matrices` | Named matrices (Pauli, Hadamard, generalized Gell-Mann, ...). |
+| `matrix_props` | Matrix predicates (`is_positive_semidefinite`, `is_unitary`, ...). |
+| `matrix_ops` | Matrix operations (`partial_trace`, `partial_transpose`, `tensor`, ...). |
+| `perms` | Permutation and symmetric/antisymmetric-subspace operators. |
+| `measurements`, `measurement_ops`, `measurement_props` | POVMs and measurement utilities. |
+| `nonlocal_games` | Nonlocal and extended nonlocal games, XOR games. |
+| `cones` | Matrix-analysis cones used by the SDP-based routines. |
+| `rand` | Random states, channels, unitaries, and POVMs. |
+
+Documentation sources live in `docs/` (this guide, the getting-started page, the
+`docs/content/examples/` gallery, and `docs/content/refs.bib` bibliography).
+Tooling configuration lives in `pyproject.toml`.
+
+When adding a function, put it in the subpackage that matches what it operates
+on, add a test beside it under that subpackage's `tests/` directory, and export
+it from the subpackage `__init__.py`.
+
 ## Making Changes
 
 1.  Add some really awesome code to your local fork. It's usually a


### PR DESCRIPTION
## Description
Improves the contributor on-ramp so newcomers can self-select small tasks and know where things go.

## Changes
- **Root `CONTRIBUTING.md`** — GitHub surfaces this on the repo page and in the new-issue/PR flow. It links to the full [contributing guide](https://vprusso.github.io/toqito/contributing-guide/), points at the [`good first issue`](https://github.com/vprusso/toqito/labels/good%20first%20issue) queue, and lists the quick `uv` dev/test/lint/docs commands and the PR checklist.
- **Issue templates** (with auto-applied labels, so triage starts labeled):
  - New function request (`feature request`) — with fields for the mathematical definition, reference, and proposed API.
  - Documentation improvement (`documentation`).
  - Mathematical / reference correction (`documentation`).
  - Performance improvement (`enhancement`, `refactor`).
  - A template-chooser `config.yml` with contact links (contributing guide, good-first-issues, discussions).
  - Gave the existing bug-report and feature-request templates their labels (`bug`, `feature request`).
- **Repository layout** section added to the contributing guide: a table mapping each `toqito` subpackage to what it contains, plus a note that a new function goes in the matching subpackage with a test beside it and an `__init__.py` export.

Follow-up (separate): seeding the `good first issue` queue with concrete small tasks.

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures.