### PR TITLE
docs: add channel_dim example

### DIFF
--- a/toqito/channel_props/channel_dim.py
+++ b/toqito/channel_props/channel_dim.py
@@ -41,6 +41,24 @@ def channel_dim(
     Returns:
         The input, output, and environment dimensions of a channel.
 
+    Examples:
+        The dimensions of a channel can be computed from a list of Kraus operators.
+        For example, the following Kraus operators describe a qubit bit-flip
+        channel:
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.channel_props import channel_dim
+
+        kraus_ops = [
+            np.sqrt(0.5) * np.eye(2),
+            np.sqrt(0.5) * np.array([[0, 1], [1, 0]]),
+        ]
+        dim_in, dim_out, dim_env = channel_dim(kraus_ops)
+
+        print(dim_in, dim_out, dim_env)
+        ```
+
     """
     dim_in = np.zeros(2, dtype=int)
     dim_out = np.zeros(2, dtype=int)


### PR DESCRIPTION
## Summary

- Adds an `Examples` section to `channel_dim`.
- Uses the existing executable docs style with a small qubit bit-flip Kraus-operator example.
- Prints the input, output, and environment dimensions returned by `channel_dim`.

Closes #1800

## Verification

- `git diff --check origin/master...HEAD`
- `python3 -m py_compile toqito/channel_props/channel_dim.py`
- Ran the example code locally:

```text
[2 2] [2 2] 2
```

## Local limitation

- `python3 -m pytest toqito/channel_props/tests/test_channel_dim.py` could not run locally because `pytest` is not installed.
- `uv run mkdocs build -f docs/mkdocs.yml` could not run locally because `uv` is not installed.