### PR TITLE
docs: add quantum conditional entropy example

### DIFF
--- a/toqito/state_props/quantum_conditional_entropy.py
+++ b/toqito/state_props/quantum_conditional_entropy.py
@@ -55,8 +55,6 @@ def quantum_conditional_entropy(
         Compute \(H(A|B)\) for a Bell state and for a product state:
 
         ```python exec="1" source="above" result="text"
-        import warnings
-
         import numpy as np
 
         from toqito.state_props import quantum_conditional_entropy
@@ -65,10 +63,8 @@ def quantum_conditional_entropy(
         bell_state = np.outer(psi, psi.conj())
         product_state = np.diag([1 / 2, 0, 1 / 2, 0])
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message="The logm input matrix is exactly singular.")
-            bell_entropy = quantum_conditional_entropy(bell_state, [2, 2], sys=0)
-            product_entropy = quantum_conditional_entropy(product_state, [2, 2], sys=0)
+        bell_entropy = quantum_conditional_entropy(bell_state, [2, 2], sys=0)
+        product_entropy = quantum_conditional_entropy(product_state, [2, 2], sys=0)
 
         print(f"Bell state H(A|B): {bell_entropy:.6f}")
         print(f"Product state H(A|B): {product_entropy:.6f}")

--- a/toqito/state_props/quantum_conditional_entropy.py
+++ b/toqito/state_props/quantum_conditional_entropy.py
@@ -51,6 +51,29 @@ def quantum_conditional_entropy(
     Returns:
         The conditional entropy in nats.
 
+    Examples:
+        Compute \(H(A|B)\) for a Bell state and for a product state:
+
+        ```python exec="1" source="above" result="text"
+        import warnings
+
+        import numpy as np
+
+        from toqito.state_props import quantum_conditional_entropy
+
+        psi = np.array([1, 0, 0, 1]) / np.sqrt(2)
+        bell_state = np.outer(psi, psi.conj())
+        product_state = np.diag([1 / 2, 0, 1 / 2, 0])
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="The logm input matrix is exactly singular.")
+            bell_entropy = quantum_conditional_entropy(bell_state, [2, 2], sys=0)
+            product_entropy = quantum_conditional_entropy(product_state, [2, 2], sys=0)
+
+        print(f"Bell state H(A|B): {bell_entropy:.6f}")
+        print(f"Product state H(A|B): {product_entropy:.6f}")
+        ```
+
     """
     if sys not in [0, 1]:
         raise ValueError("sys must be 0 or 1")


### PR DESCRIPTION
Solved: vprusso/toqito#1799.
I added a runnable documentation example for quantum_conditional_entropy showing conditional entropy for a Bell state and a product state. The clean branch is pushed to your fork as docs-quantum-conditional-entropy-example-pr; no PR has been opened yet.
Validation completed: focused ruff, direct example execution, target pytest, and docs build from docs/.