### PR TITLE
fix(state_props): silence cosmetic singular-logm warning in quantum_relative_entropy

### DIFF
--- a/toqito/state_props/quantum_relative_entropy.py
+++ b/toqito/state_props/quantum_relative_entropy.py
@@ -3,6 +3,8 @@ r"""Quantum relative entropy for positive semidefinite matrices."""
 # Adapted from CVXQUAD (https://github.com/hfawzi/cvxquad), BSD-2-Clause.
 # Original implementation by Fawzi, Saunderson, et al.
 
+import contextlib
+import warnings
 from typing import Any
 
 import cvxpy
@@ -17,6 +19,22 @@ from toqito.cones.operator_relative_entropy_epi_cone import (
 )
 from toqito.cones.trace_matrix_log import trace_matrix_log
 from toqito.matrix_props import is_hermitian, is_positive_semidefinite
+
+
+@contextlib.contextmanager
+def _silence_singular_logm_warning():
+    """Silence scipy's cosmetic "logm input matrix is exactly singular" warning.
+
+    The numeric relative-entropy paths evaluate ``scipy.linalg.logm`` (directly and via
+    ``ln_quantum_entropy``/``trace_matrix_log``) on rank-deficient density matrices, which is
+    routine for pure states and for the reduced/lifted operators used by callers such as
+    ``quantum_conditional_entropy``. The singular directions contribute the correct
+    ``0 * (-inf) = 0`` to the trace, so the returned value is valid and the warning is noise. The
+    filter matches only that exact message, so genuine warnings still propagate.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="The logm input matrix is exactly singular.")
+        yield
 
 
 def quantum_relative_entropy(
@@ -140,8 +158,9 @@ def quantum_relative_entropy(
             mat_y_log = np.asarray(mat_y.value)
         else:
             mat_y_log = mat_y
-        tr_a_log_b = trace_matrix_log(mat_y_log, x_val, m, k, -apx)
-        return -ln_quantum_entropy(x_val, m, k) - tr_a_log_b
+        with _silence_singular_logm_warning():
+            tr_a_log_b = trace_matrix_log(mat_y_log, x_val, m, k, -apx)
+            return -ln_quantum_entropy(x_val, m, k) - tr_a_log_b
     elif isinstance(mat_y, cvxpy.Expression) and mat_y.is_constant():
         if mat_y.value is None:
             raise ValueError(
@@ -158,10 +177,11 @@ def quantum_relative_entropy(
             raise ValueError("mat_x has no numeric value; pass a numpy.ndarray or set `.value`.")
         else:
             x_eval = np.asarray(mat_x.value)
-        ent_part = -ln_quantum_entropy(mat_x, m, k, -apx)
-        log_y = logm(y_val)
-        tr_a_log_b = float(np.real(np.trace(x_eval @ log_y)))
-        return ent_part - tr_a_log_b
+        with _silence_singular_logm_warning():
+            ent_part = -ln_quantum_entropy(mat_x, m, k, -apx)
+            log_y = logm(y_val)
+            tr_a_log_b = float(np.real(np.trace(x_eval @ log_y)))
+            return ent_part - tr_a_log_b
 
     if not isinstance(mat_x, cvxpy.Expression) or not isinstance(mat_y, cvxpy.Expression):
         raise ValueError("mat_x and mat_y must be numpy arrays or cvxpy expressions")

--- a/toqito/state_props/tests/test_quantum_conditional_entropy.py
+++ b/toqito/state_props/tests/test_quantum_conditional_entropy.py
@@ -1,5 +1,7 @@
 """Tests for quantum_conditional_entropy."""
 
+import warnings
+
 import cvxpy
 import numpy as np
 import pytest
@@ -162,3 +164,18 @@ def test_sdp_maximize_over_density_matrices():
     val = prob.solve(solver=cvxpy.SCS, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val is not None
+
+
+def test_pure_state_does_not_leak_singular_logm_warning():
+    """A rank-deficient input must not surface scipy's singular-logm warning.
+
+    ``quantum_conditional_entropy`` routes through ``quantum_relative_entropy``'s numeric ``logm``
+    path, which is evaluated on singular operators for pure and reduced states. The result is valid,
+    so the cosmetic ``"The logm input matrix is exactly singular."`` warning must be suppressed at
+    the source rather than by callers.
+    """
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        result = quantum_conditional_entropy(MAX_ENTANGLED_STATE, _DIM, sys=0)
+    assert np.isclose(result, -np.log(2))
+    assert not any("logm input matrix is exactly singular" in str(w.message) for w in record)


### PR DESCRIPTION
## Description
The numeric paths of `quantum_relative_entropy` call `scipy.linalg.logm` (directly, and via `ln_quantum_entropy` / `trace_matrix_log`) on rank-deficient density matrices. This is routine for pure states and for the reduced/lifted operators used by callers such as `quantum_conditional_entropy`. scipy emits a `"The logm input matrix is exactly singular."` warning in those cases, even though the singular directions contribute the correct $0 \cdot (-\infty) = 0$ to the trace and the returned value is valid.

For example, `quantum_conditional_entropy` on a Bell state emits one such warning and on a rank-deficient product state emits two, leaking scipy noise into user output and rendered docs.

## Change
Wrap the two numeric `logm` computations in a small documented context manager that filters **only** that exact message (so genuine warnings still propagate), mirroring how `matsumoto_fidelity` already suppresses its expected `sqrtm` `LinAlgWarning`. Note: `LogmExactlySingularWarning` is *not* a subclass of `scipy.linalg.LinAlgWarning`, so a category filter does not catch it; a message filter is required.

Values are unchanged (only warning emission is affected): verified `quantum_conditional_entropy` returns $-\ln 2$ (Bell) and $+\ln 2$ (product) with **zero** singular-logm warnings, down from 1 and 2 respectively.

## Follow-up
This removes the need for the `warnings.catch_warnings()` boilerplate in the docstring example added by #1804; that example can be simplified once this merges.

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest` (added a regression test asserting a pure state yields the correct value with no singular-logm warning).
  -  [x] Check the documentation build does not lead to any failures.