### PR TITLE
docs: renumber trine state labels to u_1, u_2, u_3

### DIFF
--- a/toqito/states/trine.py
+++ b/toqito/states/trine.py
@@ -12,8 +12,8 @@ def trine() -> list[np.ndarray]:
 
     \[
         u_1 = |0\rangle, \quad
-        u_1 = -\frac{1}{2}\left(|0\rangle + \sqrt{3}|1\rangle\right), \quad \text{and} \quad
-        u_2 = -\frac{1}{2}\left(|0\rangle - \sqrt{3}|1\rangle\right).
+        u_2 = -\frac{1}{2}\left(|0\rangle + \sqrt{3}|1\rangle\right), \quad \text{and} \quad
+        u_3 = -\frac{1}{2}\left(|0\rangle - \sqrt{3}|1\rangle\right).
     \]
 
     Returns:


### PR DESCRIPTION
## Description
Closes #1817

The `trine` docstring labeled the three states `u_1`, `u_1`, `u_2`, reusing the first subscript. Renumbered to `u_1`, `u_2`, `u_3` so each state has a distinct label.

## Changes
  -  [x] Renumber the state labels in the `trine` docstring math block

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures.