### PR TITLE
docs: fix typo and stale Raises note in w_state

### DIFF
--- a/toqito/states/w_state.py
+++ b/toqito/states/w_state.py
@@ -20,10 +20,10 @@ def w_state(num_qubits: int, coeff: list[int] | None = None) -> np.ndarray:
 
     Args:
         num_qubits: An integer representing the number of qubits.
-        coeff: default is `[1, 1, ..., 1]/sqrt(num_qubits)`: a 1-by-`num_qubts` vector of coefficients.
+        coeff: default is `[1, 1, ..., 1]/sqrt(num_qubits)`: a 1-by-`num_qubits` vector of coefficients.
 
     Raises:
-        ValueError: The number of qubits must be greater than or equal to 1.
+        ValueError: The number of qubits must be at least 2.
 
     Examples:
         Using `|toqito⟩`, we can generate the \(3\)-qubit W-state


### PR DESCRIPTION
## Description
Closes #1816

Two docstring fixes in `toqito/states/w_state.py`:
- `num_qubts` → `num_qubits` in the `coeff` description
- the Raises note said the number of qubits must be ≥ 1, but the code raises when `num_qubits < 2`; the note now says at least 2

## Changes
  -  [x] Fix `num_qubts` typo
  -  [x] Align the Raises note with the actual validation

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures.