### PR TITLE
polish: echo the invalid mode value in tensor_comb's error

### DIFF
--- a/toqito/matrix_ops/tensor_comb.py
+++ b/toqito/matrix_ops/tensor_comb.py
@@ -68,7 +68,7 @@ def tensor_comb(
         raise ValueError("k must be a positive integer.")
 
     if mode not in ("injective", "non-injective", "diagonal"):
-        raise ValueError("mode must be injective, non-injective, or diagonal.")
+        raise ValueError(f"mode must be injective, non-injective, or diagonal; got {mode!r}.")
 
     if mode == "injective" and k > len(states):
         raise ValueError("k must be less than or equal to the number of states for injective sequences.")

--- a/toqito/matrix_ops/tests/test_tensor_comb.py
+++ b/toqito/matrix_ops/tests/test_tensor_comb.py
@@ -188,7 +188,7 @@ def test_tensor_comb_density_matrix(states, k, mode, expected_comb_keys, expecte
             2,
             False,
             "invalid",
-            "mode must be injective, non-injective, or diagonal.",
+            "mode must be injective, non-injective, or diagonal; got 'invalid'.",
         ),
         # empty input
         ([], 2, False, "injective", "Input list of states cannot be empty."),


### PR DESCRIPTION
## Description
Closes #1815

The `ValueError` for an unrecognized `mode` now echoes what was passed: `mode must be injective, non-injective, or diagonal; got 'invalid'.` The original phrasing is kept as a prefix, and the existing parametrized test now pins the full message including the echoed value.

## Changes
  -  [x] Append `; got {mode!r}.` to the error message in `tensor_comb`
  -  [x] Update the invalid-mode test expectation to the clearer message

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest` (16/16 in `test_tensor_comb.py`).
  -  [x] Check the documentation build does not lead to any failures.