### PR TITLE
polish: include the offending t value in geometric_mean's range error

### DIFF
--- a/toqito/cones/geometric_mean.py
+++ b/toqito/cones/geometric_mean.py
@@ -42,7 +42,7 @@ def geometric_mean(mat_a: np.ndarray, mat_b: np.ndarray, t: float) -> np.ndarray
         raise ValueError("The matrices must be the same size.")
     _require_square_2d(mat_a, "The matrices")
     if t < -1 or t > 2:
-        raise ValueError("The weight must be in the range [-1, 2].")
+        raise ValueError(f"The weight t must be in the range [-1, 2]; got {t}.")
     if not is_positive_definite(mat_a) or not is_positive_definite(mat_b):
         raise ValueError("The matrices must be positive definite.")
 

--- a/toqito/cones/tests/test_geometric_mean.py
+++ b/toqito/cones/tests/test_geometric_mean.py
@@ -110,8 +110,8 @@ non_hermitian = np.array([[1.0, 2.0], [0.0, 1.0]])
         # same shape but not 2D
         (A_not2d, B_not2d, 0.5, "The matrices must be 2D."),
         # weight out of range
-        (A_diag, B_diag, -1.01, "The weight must be in the range [-1, 2]."),
-        (A_diag, B_diag, 2.01, "The weight must be in the range [-1, 2]."),
+        (A_diag, B_diag, -1.01, "The weight t must be in the range [-1, 2]; got -1.01."),
+        (A_diag, B_diag, 2.01, "The weight t must be in the range [-1, 2]; got 2.01."),
         # positive semidefinite but not positive definite
         (rho_psd, sigma_pd, 0.5, "The matrices must be positive definite."),
         # non-Hermitian: fails Hermitian check in ``is_positive_definite``).


### PR DESCRIPTION
## Description
Closes #1814

The out-of-range weight error now reports the value that was passed: `The weight t must be in the range [-1, 2]; got 2.01.` Both out-of-range test rows pin the exact message (the test already matches with `re.escape`).

## Changes
  -  [x] Include the offending `t` in the `ValueError` message
  -  [x] Pin the new message in the two out-of-range test cases

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest` (20/20 in `test_geometric_mean.py`).
  -  [x] Check the documentation build does not lead to any failures.