### PR TITLE
polish: report the mismatched shapes in vectors_to_gram_matrix

### DIFF
--- a/toqito/matrix_ops/tests/test_vectors_to_gram_matrix.py
+++ b/toqito/matrix_ops/tests/test_vectors_to_gram_matrix.py
@@ -1,5 +1,7 @@
 """Test vectors_to_gram_matrix."""
 
+import re
+
 import numpy as np
 import pytest
 
@@ -44,15 +46,21 @@ def test_vectors_to_gram_matrix_mixed_states(states, expected_result):
 
 
 @pytest.mark.parametrize(
-    "vectors",
+    "vectors, expected_msg",
     [
         # Vectors of different sizes.
-        ([np.array([1, 2, 3]), np.array([1, 2])]),
+        (
+            [np.array([1, 2, 3]), np.array([1, 2])],
+            "All vectors must have the same shape; expected (3,), got (2,).",
+        ),
         # Density matrices of different sizes.
-        ([np.eye(2), np.eye(3)]),
+        (
+            [np.eye(2), np.eye(3)],
+            "All vectors must have the same shape; expected (2, 2), got (3, 3).",
+        ),
     ],
 )
-def test_vectors_to_gram_matrix_invalid_input(vectors):
+def test_vectors_to_gram_matrix_invalid_input(vectors, expected_msg):
     """Test function works as expected for an invalid input."""
-    with np.testing.assert_raises(ValueError):
+    with pytest.raises(ValueError, match=re.escape(expected_msg)):
         vectors_to_gram_matrix(vectors)

--- a/toqito/matrix_ops/vectors_to_gram_matrix.py
+++ b/toqito/matrix_ops/vectors_to_gram_matrix.py
@@ -60,8 +60,10 @@ def vectors_to_gram_matrix(vectors: list[np.ndarray]) -> np.ndarray:
 
     """
     # Check that all vectors are of the same shape
-    if not all(v.shape == vectors[0].shape for v in vectors):
-        raise ValueError("All vectors must be of the same shape.")
+    expected_shape = vectors[0].shape
+    for v in vectors:
+        if v.shape != expected_shape:
+            raise ValueError(f"All vectors must have the same shape; expected {expected_shape}, got {v.shape}.")
 
     first_input = vectors[0]
 


### PR DESCRIPTION
## Description
Closes #1813

The shape-mismatch error now tells the caller which shape differs: `All vectors must have the same shape; expected (3,), got (2,).` The check walks the list and reports the first offending shape. The invalid-input tests switched from a bare `assert_raises` to `pytest.raises(..., match=re.escape(...))` asserting the exact message for both the vector and density-matrix cases.

## Changes
  -  [x] Report expected and offending shapes in the `ValueError`
  -  [x] Assert the exact message in `test_vectors_to_gram_matrix_invalid_input`

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest` (6/6 in `test_vectors_to_gram_matrix.py`).
  -  [x] Check the documentation build does not lead to any failures.