### PR TITLE
test: pin exact messages for XORGame constructor validation

### DIFF
--- a/toqito/nonlocal_games/tests/test_xor_game.py
+++ b/toqito/nonlocal_games/tests/test_xor_game.py
@@ -1,8 +1,10 @@
 """Tests for XORGame class."""
 
+import re
 import unittest
 
 import numpy as np
+import pytest
 
 from toqito.nonlocal_games.xor_game import XORGame
 
@@ -195,3 +197,32 @@ class TestXORGame(unittest.TestCase):
         nlg_chsh = xor_chsh.to_nonlocal_game()
 
         self.assertEqual(xor_chsh.classical_value(), nlg_chsh.classical_value())
+
+
+@pytest.mark.parametrize(
+    "prob_mat, pred_mat, expected_msg",
+    [
+        # prob_mat and pred_mat shapes differ
+        (
+            1 / 4 * np.ones((2, 2)),
+            np.array([[0, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            "Invalid: The matrices `prob_mat` and `pred_mat` must be matrices of the same size.",
+        ),
+        # prob_mat has a negative entry
+        (
+            np.array([[1 / 2, 1 / 2], [1 / 2, -1 / 2]]),
+            np.array([[0, 0], [0, 1]]),
+            "Invalid: The variable `prob_mat` must be a probability matrix: its entries must be non-negative.",
+        ),
+        # prob_mat entries do not sum to 1
+        (
+            1 / 2 * np.ones((2, 2)),
+            np.array([[0, 0], [0, 1]]),
+            "Invalid: The variable `prob_mat` must be a probability matrix: its entries must sum to 1.",
+        ),
+    ],
+)
+def test_xor_game_invalid_input(prob_mat, pred_mat, expected_msg):
+    """Constructor raises for a shape mismatch or an invalid probability matrix."""
+    with pytest.raises(ValueError, match=re.escape(expected_msg)):
+        XORGame(prob_mat, pred_mat)


### PR DESCRIPTION
## Description
Closes #1811

One note on the issue premise: `test_xor_game.py` does already exercise these branches, but only through loose `self.assertRaises(ValueError)` blocks (`test_negative_prob_mat`, `test_invalid_prob_mat`, `test_non_square_prob_mat`, `test_zero_prob_mat`) that pass no matter which of the three errors fires — the earlier grep for `assert_raises` misses the camelCase `assertRaises`. What was genuinely missing is exact-message coverage, which this PR adds as requested: parametrized `pytest.raises(ValueError, match=re.escape(...))` tests for each branch.

## Changes
  -  [x] Parametrized test triggering the shape-mismatch, negative-entry, and sum-to-1 branches, each pinned to its exact error message

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest` (19/19 in `test_xor_game.py`).
  -  [x] Check the documentation build does not lead to any failures.