### PR TITLE
test: pin from_bcs_game validation and cover the degenerate branch

### DIFF
--- a/toqito/nonlocal_games/tests/test_nonlocal_game.py
+++ b/toqito/nonlocal_games/tests/test_nonlocal_game.py
@@ -1,5 +1,6 @@
 """Tests for NonlocalGame class."""
 
+import re
 import unittest
 
 import numpy as np
@@ -80,7 +81,15 @@ class TestNonlocalGame(unittest.TestCase):
 
     def test_bcs_game_without_constraint(self):
         """Empty list of constraints raises exception."""
-        self.assertRaises(ValueError, NonlocalGame.from_bcs_game, [])
+        with pytest.raises(ValueError, match="At least 1 constraint is required"):
+            NonlocalGame.from_bcs_game([])
+
+    def test_bcs_game_degenerate_constraint(self):
+        """A constraint with no dependent variables raises exception."""
+        # A constant constraint tensor does not depend on any variable.
+        constraint = np.ones((2, 2))
+        with pytest.raises(ValueError, match=re.escape("Constraint 0 is degenerate (has no dependent variables).")):
+            NonlocalGame.from_bcs_game([constraint])
 
     def test_chsh_lower_bound(self):
         """Calculate the lower bound on the quantum value for the CHSH game."""


### PR DESCRIPTION
## Description
Closes #1812

The empty-constraints case was already loosely covered (`test_bcs_game_without_constraint` used `self.assertRaises(ValueError, ...)`); this upgrades it to `pytest.raises(..., match="At least 1 constraint is required")`. The bonus item from the issue is also done: the degenerate-constraint branch now has a test — a constant constraint tensor (`np.ones((2, 2))`) has no dependent variables (`np.diff` along every axis is zero), so `from_bcs_game` raises `Constraint 0 is degenerate (has no dependent variables).`, asserted exactly.

## Changes
  -  [x] Pin the exact message in the empty-constraints test
  -  [x] Add a test covering the degenerate-constraint `ValueError` branch

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest` (24 passed, 1 skipped in `test_nonlocal_game.py`).
  -  [x] Check the documentation build does not lead to any failures.