### PR TITLE
Report the mismatched shapes in vectors_to_gram_matrix

### DIFF
--- a/toqito/matrix_ops/tests/test_vectors_to_gram_matrix.py
+++ b/toqito/matrix_ops/tests/test_vectors_to_gram_matrix.py
@@ -1,5 +1,7 @@
 """Test vectors_to_gram_matrix."""
 
+import re
+
 import numpy as np
 import pytest
 
@@ -44,15 +46,21 @@ def test_vectors_to_gram_matrix_mixed_states(states, expected_result):
 
 
 @pytest.mark.parametrize(
-    "vectors",
+    "vectors, expected_message",
     [
         # Vectors of different sizes.
-        ([np.array([1, 2, 3]), np.array([1, 2])]),
+        (
+            [np.array([1, 2, 3]), np.array([1, 2])],
+            "All vectors must have the same shape; expected (3,), got (2,).",
+        ),
         # Density matrices of different sizes.
-        ([np.eye(2), np.eye(3)]),
+        (
+            [np.eye(2), np.eye(3)],
+            "All vectors must have the same shape; expected (2, 2), got (3, 3).",
+        ),
     ],
 )
-def test_vectors_to_gram_matrix_invalid_input(vectors):
-    """Test function works as expected for an invalid input."""
-    with np.testing.assert_raises(ValueError):
+def test_vectors_to_gram_matrix_invalid_input(vectors, expected_message):
+    """Test function reports the expected and offending shapes for mismatched input."""
+    with pytest.raises(ValueError, match=re.escape(expected_message)):
         vectors_to_gram_matrix(vectors)

--- a/toqito/matrix_ops/vectors_to_gram_matrix.py
+++ b/toqito/matrix_ops/vectors_to_gram_matrix.py
@@ -60,8 +60,9 @@ def vectors_to_gram_matrix(vectors: list[np.ndarray]) -> np.ndarray:
 
     """
     # Check that all vectors are of the same shape
-    if not all(v.shape == vectors[0].shape for v in vectors):
-        raise ValueError("All vectors must be of the same shape.")
+    for v in vectors:
+        if v.shape != vectors[0].shape:
+            raise ValueError(f"All vectors must have the same shape; expected {vectors[0].shape}, got {v.shape}.")
 
     first_input = vectors[0]
 


### PR DESCRIPTION
Closes #1813

The `ValueError` raised in `vectors_to_gram_matrix` when input vectors or
density matrices have inconsistent shapes gave no indication of which
shapes actually differed. Now reports the expected shape (from the first
input) and the offending one, e.g.:

  All vectors must have the same shape; expected (3,), got (2,).

Also pinned the message in the existing invalid-input test with `match=`
(previously it only asserted `ValueError` was raised, not its content).

## Checklist
- [x] `uv run ruff check` and `uv run ruff format --check` pass
- [x] `uv run pytest` passes (full suite: 3442 passed, 59 skipped, 3 xfailed)
- [x] New/changed lines are covered by the updated test