### PR TITLE
fix(channel_metrics): correct completely_bounded_trace_norm for CP non-trace-preserving maps

### DIFF
--- a/toqito/channel_metrics/completely_bounded_trace_norm.py
+++ b/toqito/channel_metrics/completely_bounded_trace_norm.py
@@ -8,7 +8,6 @@ import picos as pc
 from toqito.channel_ops import apply_channel, dual_channel
 from toqito.channel_props import is_completely_positive, is_trace_preserving
 from toqito.channel_props.channel_dim import channel_dim
-from toqito.matrix_props import trace_norm
 
 
 def completely_bounded_trace_norm(
@@ -67,8 +66,12 @@ def completely_bounded_trace_norm(
         # Quantum channels have a completely bounded trace norm of 1.
         if is_trace_preserving(phi, dim=[dim_in, dim_out]):
             return 1
-        v = apply_channel(np.eye(dim_ly), dual_channel(phi, dims=[dim_in, dim_out]))
-        return trace_norm(v)
+        # For a completely positive map, the completely bounded trace norm equals the operator
+        # (spectral) norm of the adjoint applied to the identity, ||Phi^*(I_out)||_inf (Watrous,
+        # The Theory of Quantum Information, Section 3.3). `dual_channel` gives Phi^*, and the
+        # identity is on the output space of dimension `dim_out`.
+        v = apply_channel(np.eye(dim_out), dual_channel(phi, dims=[dim_in, dim_out]))
+        return np.linalg.norm(v, 2)
 
     # SDP
     sdp = pc.Problem()

--- a/toqito/channel_metrics/tests/test_completely_bounded_trace_norm.py
+++ b/toqito/channel_metrics/tests/test_completely_bounded_trace_norm.py
@@ -34,8 +34,9 @@ solvers = ["cvxopt"]
     [
         # The diamond norm of a quantum channel is 1
         (dephasing(2), 1),
-        # the diamond norm of a CP map
-        (np.eye(4), 4.0),
+        # A completely positive, non-trace-preserving map: the CB trace norm is the spectral norm
+        # of Phi^*(I). Here the Choi is I_4, i.e. Phi(rho) = Tr(rho) I_2, so the value is 2, not 4.
+        (np.eye(4), 2.0),
         # unitaries channel, phi, diameter in terms of the eigenvalues of U
         (phi, diameter),
         # qutrit unitaries channel (non-power-of-2 dimension)
@@ -81,3 +82,14 @@ def test_cb_trace_norm_invalid_input():
     ):
         phi1 = np.array([[1, 2, 3], [4, 5, 6]])
         completely_bounded_trace_norm(phi1)
+
+
+def test_cb_trace_norm_cp_non_trace_preserving():
+    """CB trace norm of a completely positive, non-trace-preserving map.
+
+    For ``Phi(rho) = A rho A^dagger`` with ``A = diag(1, 2)``, the completely bounded trace norm is
+    the spectral norm of ``Phi^*(I) = A^dagger A = diag(1, 4)``, i.e. 4. Regression for the
+    CP-branch bug that returned the trace norm of a wrongly-sized operator.
+    """
+    a_op = np.diag([1.0, 2.0])
+    assert abs(completely_bounded_trace_norm(kraus_to_choi([a_op])) - 4.0) <= 1e-6


### PR DESCRIPTION
## Description
The completely-positive short-circuit in `completely_bounded_trace_norm` returned a wrong value for CP, non-trace-preserving maps, due to two bugs in that branch:

1. It fed `np.eye(dim_ly)` (the **full Choi dimension**) into the dual channel instead of `np.eye(dim_out)` (the identity on the **output space**), producing a degenerate operator.
2. It returned the **trace (nuclear) norm** where the completely bounded (diamond) trace norm of a CP map is the **spectral / operator norm** of $\Phi^*(I)$ (Watrous, *The Theory of Quantum Information*, Section 3.3).

**Symptom:** `completely_bounded_trace_norm(np.eye(4))` returned `4.0`. That Choi is the map $\Phi(\rho)=\mathrm{Tr}(\rho)\,I_2$, whose diamond norm is provably **2.0** — confirmed analytically ($\|I_2\otimes\rho_B\|_1=2$), by brute-force maximization over pure input states, and consistent with the function's own SDP path.

## Fix
The CP branch now computes `np.linalg.norm(apply_channel(np.eye(dim_out), dual_channel(phi, dims=[dim_in, dim_out])), 2)` = $\|\Phi^*(I_{\text{out}})\|_\infty$. The now-unused `trace_norm` import is removed.

## Scope / safety
- **Trace-preserving channels** still return `1` (handled by the earlier `is_trace_preserving` branch).
- **The SDP path is untouched** and remains correct: verified `diamond_distance` still returns the textbook `2.0` (perfectly distinguishable channels) and `1.0` (identity vs. full dephasing). `diamond_distance` passes a non-CP difference, so it never hits the CP branch.
- Random CP non-TP maps: the fixed value matches an independent brute-force lower bound.

## Tests
- Updated the `(np.eye(4), 4.0)` parametrized case to `2.0` (it encoded the buggy value).
- Added a regression test with an independently hand-computed value: $\Phi(\rho)=A\rho A^\dagger$ with $A=\mathrm{diag}(1,2)$ gives $\|\Phi^*(I)\|_\infty=\|\mathrm{diag}(1,4)\|_\infty=4$.

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures.