### PR TITLE
docs: flesh out is_real description (and add Returns) in random_orthonormal_basis

### DIFF
--- a/toqito/rand/random_orthonormal_basis.py
+++ b/toqito/rand/random_orthonormal_basis.py
@@ -13,8 +13,11 @@ def random_orthonormal_basis(dim: int, is_real: bool = False, seed: int | None =
 
     Args:
         dim: Number of elements in the random orthonormal basis.
-        is_real: Bool
+        is_real: Boolean denoting whether the returned basis vectors will have all real entries or not.
         seed: A seed used to instantiate numpy's random number generator.
+
+    Returns:
+        A list of `dim` orthonormal basis vectors, each of dimension `dim`.
 
     Examples:
         To generate a random orthonormal basis of dimension \(4\),


### PR DESCRIPTION
## Description
Closes #1818

Brings `random_orthonormal_basis`'s `is_real` parameter description in line with the sibling `rand` functions (`random_density_matrix`, `random_state_vector`, `random_unitary`, `random_psd_operator`), which use the fuller "Boolean denoting whether the returned ... will have all real entries or not." Also adds the missing **Returns:** section.

## Changes
  -  [x] Expand the `is_real` description to match sibling functions
  -  [x] Add a `Returns:` section (list of `dim` orthonormal basis vectors)

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures (`mkdocs build`).