### PR TITLE
docs: add a Returns section to diamond_distance

### DIFF
--- a/toqito/channel_metrics/diamond_distance.py
+++ b/toqito/channel_metrics/diamond_distance.py
@@ -30,6 +30,10 @@ def diamond_distance(
         ValueError: If matrices are not of equal dimension.
         ValueError: If matrices are not square.
 
+    Returns:
+        The diamond-norm distance between the two channels, i.e. the diamond norm of the
+        difference of their Choi matrices (a float between 0 and 2).
+
     Examples:
         Consider the depolarizing and identity channels in a 2-dimensional space. The depolarizing channel parameter is
         set to 0.2:


### PR DESCRIPTION
## Description
Closes #1810

`diamond_distance` had Args, Raises, and Examples but no **Returns:** section. Adds one describing the returned diamond-norm distance between the two channels (a float).

## Changes
  -  [x] Add a `Returns:` section

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures (`mkdocs build`).