### PR TITLE
docs: add a Returns section to pauli

### DIFF
--- a/toqito/matrices/pauli.py
+++ b/toqito/matrices/pauli.py
@@ -50,6 +50,11 @@ def pauli(ind: int | str | list[int] | list[str], is_sparse: bool = False) -> np
         is_sparse: Returns a compressed sparse row array if set to True and a non compressed sparse row array if set to
             False.
 
+    Returns:
+        The requested Pauli operator: a single 2-by-2 Pauli matrix when `ind` is a scalar, or the
+        tensor product of the indicated Pauli matrices when `ind` is a list. Returned as a
+        `scipy.sparse.csr_array` if `is_sparse` is True and as a `np.ndarray` otherwise.
+
     Examples:
         Example for identity Pauli matrix.
 


### PR DESCRIPTION
## Description
Closes #1809

`pauli` documented `ind` and `is_sparse` and had Examples but no **Returns:** section. Adds one describing the returned Pauli operator: a single Pauli, or the tensor product when `ind` is a list; type `np.ndarray | scipy.sparse.csr_array` depending on `is_sparse`.

## Changes
  -  [x] Add a `Returns:` section

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures (`mkdocs build`).