### PR TITLE
docs: add a Returns section to gen_bell

### DIFF
--- a/toqito/states/gen_bell.py
+++ b/toqito/states/gen_bell.py
@@ -29,6 +29,11 @@ def gen_bell(k_1: int, k_2: int, dim: int) -> np.ndarray:
         k_2: An integer 0 <= k_2 <= n.
         dim: The dimension of the generalized Bell state.
 
+    Returns:
+        The `dim^2`-by-`dim^2` density matrix of the generalized Bell state, i.e.
+        \(\frac{1}{d} \text{vec}(W_{k_1, k_2}) \text{vec}(W_{k_1, k_2})^*\) for the
+        corresponding generalized Pauli (Weyl) operator \(W_{k_1, k_2}\).
+
     Examples:
         For \(d = 2\) and \(k_1 = k_2 = 0\), this generates the following matrix
 


### PR DESCRIPTION
## Description
Closes #1808

`gen_bell` documented its parameters and had an Examples block but no **Returns:** section. Adds one describing the returned generalized Bell density matrix (`1/dim * vec(...) @ vec(...).conj().T`), following the Google-style docstring format used across the package.

## Changes
  -  [x] Add a `Returns:` section

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures (`mkdocs build`).