### PR TITLE
docs: add an Examples section to geometric_mean

### DIFF
--- a/toqito/cones/geometric_mean.py
+++ b/toqito/cones/geometric_mean.py
@@ -37,6 +37,20 @@ def geometric_mean(mat_a: np.ndarray, mat_b: np.ndarray, t: float) -> np.ndarray
     Returns:
       A matrix with the same shape as the inputs.
 
+    Examples:
+        For the commuting positive definite matrices \(A = \text{diag}(2, 4)\) and
+        \(B = \text{diag}(8, 16)\), the weighted mean reduces to \(G_t(A, B) = A^{1-t}B^t\),
+        so for \(t = 1/2\) the result is \(\text{diag}(\sqrt{2 \cdot 8}, \sqrt{4 \cdot 16})\):
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.cones import geometric_mean
+
+        mat_a = np.diag([2.0, 4.0])
+        mat_b = np.diag([8.0, 16.0])
+        print(geometric_mean(mat_a, mat_b, 1 / 2))
+        ```
+
     """
     if mat_a.shape != mat_b.shape:
         raise ValueError("The matrices must be the same size.")


### PR DESCRIPTION
## Description
Closes #1806

`geometric_mean` had a full docstring (Args/Raises/Returns) but no **Examples** section. Adds a runnable `python exec` block computing the \(t=1/2\) weighted geometric mean of two commuting positive definite matrices. Because they commute, the closed form \(A^{1-t}B^t\) applies, so the printed output (`diag(4, 8)` for \(A=\text{diag}(2,4)\), \(B=\text{diag}(8,16)\)) is easy to verify by hand and deterministic (pure numpy, no SDP).

## Changes
  -  [x] Add an `Examples:` section with a runnable, deterministic example

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures (`mkdocs build`).