### PR TITLE
docs: add Examples sections to expr_as_np_array and np_array_as_expr

### DIFF
--- a/toqito/matrix_ops/expr_as_np_array.py
+++ b/toqito/matrix_ops/expr_as_np_array.py
@@ -13,6 +13,20 @@ def expr_as_np_array(cvx_expr: Expression) -> np.ndarray:
     Returns:
         The numpy array of the cvxpy expression.
 
+    Examples:
+        Convert a 2-by-2 cvxpy variable into a numpy array whose entries are the
+        scalar cvxpy expressions indexing into it:
+
+        ```python exec="1" source="above" result="text"
+        import cvxpy
+        from toqito.matrix_ops import expr_as_np_array
+
+        x_var = cvxpy.Variable((2, 2), name="X")
+        arr = expr_as_np_array(x_var)
+        print(arr.shape)
+        print(arr[0, 1])
+        ```
+
     """
     if cvx_expr.is_scalar():
         return np.array(cvx_expr)

--- a/toqito/matrix_ops/np_array_as_expr.py
+++ b/toqito/matrix_ops/np_array_as_expr.py
@@ -14,6 +14,19 @@ def np_array_as_expr(np_arr: np.ndarray) -> Expression:
     Returns:
         The cvxpy expression of the numpy array.
 
+    Examples:
+        Convert a 2-by-2 numpy array into a constant cvxpy expression:
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.matrix_ops import np_array_as_expr
+
+        arr = np.array([[1, 2], [3, 4]])
+        expr = np_array_as_expr(arr)
+        print(expr.shape)
+        print(expr.value)
+        ```
+
     """
     as_list = np_arr.tolist()
     expr = bmat(as_list)


### PR DESCRIPTION
## Description
Closes #1807

The two mirror conversion helpers had Args/Returns but no **Examples** blocks. Adds one to each: a named 2x2 cvxpy variable converted to a numpy array of scalar expressions, and a constant numpy array converted back to a cvxpy expression. The cvxpy variable is named so the printed output is deterministic across builds.

## Changes
  -  [x] Add an `Examples:` section to `expr_as_np_array`
  -  [x] Add an `Examples:` section to `np_array_as_expr`

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures (`mkdocs build`).