### PR TITLE
docs: add Examples sections to expr_as_np_array and np_array_as_expr (#1807)

### DIFF
--- a/toqito/matrix_ops/expr_as_np_array.py
+++ b/toqito/matrix_ops/expr_as_np_array.py
@@ -10,6 +10,20 @@ def expr_as_np_array(cvx_expr: Expression) -> np.ndarray:
     Args:
         cvx_expr: The cvxpy expression to be converted.
 
+    Examples:
+        Convert a 2x2 CVXPY variable into a NumPy array.
+
+        ```python exec="1" source="above"
+        import cvxpy as cp
+
+        from toqito.matrix_ops import expr_as_np_array
+
+        x = cp.Variable((2, 2))
+        arr = expr_as_np_array(x)
+
+        print(arr.shape)
+        ```
+
     Returns:
         The numpy array of the cvxpy expression.
 

--- a/toqito/matrix_ops/np_array_as_expr.py
+++ b/toqito/matrix_ops/np_array_as_expr.py
@@ -11,6 +11,22 @@ def np_array_as_expr(np_arr: np.ndarray) -> Expression:
     Args:
         np_arr: The numpy array to be converted.
 
+    Examples:
+        Convert a CVXPY variable to a NumPy array and back into a CVXPY
+        expression.
+
+        ```python exec="1" source="above"
+        import cvxpy as cp
+
+        from toqito.matrix_ops import expr_as_np_array, np_array_as_expr
+
+        x = cp.Variable((2, 2))
+        arr = expr_as_np_array(x)
+        expr = np_array_as_expr(arr)
+
+        print(expr.shape)
+        ```
+
     Returns:
         The cvxpy expression of the numpy array.
 


### PR DESCRIPTION
Closes #1807

Adds `Examples` sections to the docstrings of `expr_as_np_array` and `np_array_as_expr` with runnable `python exec` blocks following the existing documentation style.

Examples added:
- `expr_as_np_array` — demonstrates converting a 2*2 CVXPY variable expression into a NumPy array.
- `np_array_as_expr` — demonstrates the round-trip conversion from a CVXPY variable to a NumPy array and back into a CVXPY expression.