### PR TITLE
Consolidate redundant XORGame constructor validation tests

### DIFF
--- a/toqito/nonlocal_games/tests/test_xor_game.py
+++ b/toqito/nonlocal_games/tests/test_xor_game.py
@@ -136,42 +136,6 @@ class TestXORGame(unittest.TestCase):
         res = game.classical_value()
         self.assertEqual(res, 0.625)
 
-    def test_negative_prob_mat(self):
-        """Tests for invalid negative probability matrix."""
-        with self.assertRaises(ValueError):
-            prob_mat = np.array([[1 / 4, -1 / 4], [1 / 4, 1 / 4]])
-            pred_mat = np.array([[0, 0], [0, 1]])
-
-            game = XORGame(prob_mat, pred_mat)
-            game.quantum_value()
-
-    def test_invalid_prob_mat(self):
-        """Tests for invalid probability matrix."""
-        with self.assertRaises(ValueError):
-            prob_mat = np.array([[1 / 4, 1], [1 / 4, 1 / 4]])
-            pred_mat = np.array([[0, 0], [0, 1]])
-
-            game = XORGame(prob_mat, pred_mat)
-            game.quantum_value()
-
-    def test_non_square_prob_mat(self):
-        """Tests for invalid non-square probability matrix."""
-        with self.assertRaises(ValueError):
-            prob_mat = np.array([[1 / 4, 1 / 4, 1 / 4], [1 / 4, 1 / 4, 1 / 4]])
-            pred_mat = np.array([[0, 0], [0, 1]])
-
-            game = XORGame(prob_mat, pred_mat)
-            game.quantum_value()
-
-    def test_zero_prob_mat(self):
-        """Tests for zero probability matrix."""
-        with self.assertRaises(ValueError):
-            prob_mat = np.array([[1 / 4, 0], [1 / 4, 0]])
-            pred_mat = np.array([[0, 0], [0, 1]])
-
-            game = XORGame(prob_mat, pred_mat)
-            game.quantum_value()
-
     def test_chsh_game_nonsignaling_value(self):
         """Non-signaling value for the CHSH game."""
         prob_mat = 1 / 4 * np.ones((2, 2))


### PR DESCRIPTION
Follow-up to #1811, per maintainer feedback there.

test_negative_prob_mat, test_invalid_prob_mat, test_non_square_prob_mat,
and test_zero_prob_mat each covered one of the three ValueError branches
in XORGame.__init__ without asserting message content, and called
quantum_value() after the expected exception (dead code that never runs).

test_xor_game_invalid_input (#1824) already covers the same three
branches with pytest.raises(..., match=...), making these four redundant.
Removed them, no coverage loss (verified: same 3 branches still exercised,
full toqito/nonlocal_games/ suite still passes).

## Checklist
- [x] `uv run ruff check` and `uv run ruff format --check` pass
- [x] `uv run pytest toqito/nonlocal_games/tests/test_xor_game.py` - 15 passed
- [x] `uv run pytest toqito/nonlocal_games/` — 81 passed, 11 skipped, 1 xfailed