### PR TITLE
fix(perms): handle row vectors in permute_systems with explicit dim (#1827)

### DIFF
--- a/toqito/perms/permute_systems.py
+++ b/toqito/perms/permute_systems.py
@@ -152,12 +152,15 @@ def permute_systems(
         dim_arr = dim
 
     if is_vec:
-        # 1 if column vector
-        if len(input_mat.shape) > 1:
-            vec_orien = 0
-        # 2 if row vector
-        else:
+        if len(input_mat.shape) == 1:
+            # 1-D array: treat as row vector
             vec_orien = 1
+        elif input_mat.shape[0] == 1:
+            # (1, D) row vector
+            vec_orien = 1
+        else:
+            # (D, 1) column vector
+            vec_orien = 0
 
     if len(dim_arr.shape) == 1:
         # Force dim to be a row vector.

--- a/toqito/perms/tests/test_permute_systems.py
+++ b/toqito/perms/tests/test_permute_systems.py
@@ -166,4 +166,3 @@ def test_permute_systems_invalid_dim_mismatch_perm():
     with np.testing.assert_raises(ValueError):
         test_input_mat = np.array([1, 2, 3, 4])
         permute_systems(test_input_mat, [2, 1, 3, 4])
-

--- a/toqito/perms/tests/test_permute_systems.py
+++ b/toqito/perms/tests/test_permute_systems.py
@@ -169,6 +169,7 @@ def test_permute_systems_invalid_dim_mismatch_perm():
 
 
 def test_permute_systems_row_vector_with_explicit_dim():
+    """Ensure row-vector input with explicit subsystem dimensions is permuted correctly."""
     assert np.array_equal(
         permute_systems(
             np.arange(8).reshape(1, 8),

--- a/toqito/perms/tests/test_permute_systems.py
+++ b/toqito/perms/tests/test_permute_systems.py
@@ -166,3 +166,4 @@ def test_permute_systems_invalid_dim_mismatch_perm():
     with np.testing.assert_raises(ValueError):
         test_input_mat = np.array([1, 2, 3, 4])
         permute_systems(test_input_mat, [2, 1, 3, 4])
+

--- a/toqito/perms/tests/test_permute_systems.py
+++ b/toqito/perms/tests/test_permute_systems.py
@@ -166,3 +166,14 @@ def test_permute_systems_invalid_dim_mismatch_perm():
     with np.testing.assert_raises(ValueError):
         test_input_mat = np.array([1, 2, 3, 4])
         permute_systems(test_input_mat, [2, 1, 3, 4])
+
+
+def test_permute_systems_row_vector_with_explicit_dim():
+    assert np.array_equal(
+        permute_systems(
+            np.arange(8).reshape(1, 8),
+            [1, 2, 0],
+            [2, 2, 2],
+        ),
+        np.array([0, 4, 1, 5, 2, 6, 3, 7]),
+    )


### PR DESCRIPTION
Closes #1827

Fixes an inconsistency where `permute_systems` rejected row-vector inputs of shape `(1, D)` when `dim` was explicitly provided.

The fix makes row vectors behave consistently with 1-D arrays and column vectors.

A regression test was added to verify that `(1, D)` inputs are correctly permuted when `dim` is specified.