### PR TITLE
polish: include the offending index in the gell_mann error message

### DIFF
--- a/toqito/matrices/gell_mann.py
+++ b/toqito/matrices/gell_mann.py
@@ -109,7 +109,7 @@ def gell_mann(ind: int, is_sparse: bool = False) -> np.ndarray | csr_array:
     elif ind == 8:
         gm_op = np.array([[1, 0, 0], [0, 1, 0], [0, 0, -2]]) / np.sqrt(3)
     else:
-        raise ValueError("Gell-Mann index values can only be values from 0 to 8 (inclusive).")
+        raise ValueError(f"Gell-Mann index must be an integer in [0, 8]; got {ind}.")
 
     if is_sparse:
         gm_op_out = csr_array(gm_op)

--- a/toqito/matrices/tests/test_gell_mann.py
+++ b/toqito/matrices/tests/test_gell_mann.py
@@ -1,6 +1,9 @@
 """Test gell_mann."""
 
+import re
+
 import numpy as np
+import pytest
 from scipy.sparse import csr_array
 
 from toqito.matrices import gell_mann
@@ -93,7 +96,7 @@ def test_gell_mann_idx_8():
 
 def test_gell_mann_invalid_idx():
     """Invalid Gell-Mann parameters."""
-    with np.testing.assert_raises(ValueError):
+    with pytest.raises(ValueError, match=re.escape("Gell-Mann index must be an integer in [0, 8]; got 9.")):
         gell_mann(9)
 
 


### PR DESCRIPTION
## Description
Closes #1795

The out-of-range Gell-Mann index error now reports the value that was passed: `Gell-Mann index must be an integer in [0, 8]; got 9.` The existing `gell_mann(9)` test was upgraded from a bare `assert_raises` to `pytest.raises(ValueError, match=re.escape(...))` pinning the exact message.

## Changes
  -  [x] Echo the offending `ind` in the `ValueError`
  -  [x] Pin the new message in `test_gell_mann_invalid_idx`

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures.