### PR TITLE
polish: report the bad subsystem index and valid range in partial_trace

### DIFF
--- a/toqito/matrix_ops/partial_trace.py
+++ b/toqito/matrix_ops/partial_trace.py
@@ -167,13 +167,14 @@ def partial_trace(
     # Validate sys indices and compute subsystem product.
     if isinstance(sys, int):
         if sys < 0 or sys >= num_sys:
-            raise ValueError("Subsystem indices in `sys` are out of bounds.")
+            raise ValueError(f"Subsystem index {sys} is out of bounds; must be in [0, {num_sys}).")
         prod_dim_sys = dim[sys]
         sys = np.array([sys])
 
     elif isinstance(sys, (list, tuple, np.ndarray)):
-        if any(s < 0 or s >= num_sys for s in sys):
-            raise ValueError("Subsystem indices in `sys` are out of bounds.")
+        for s in sys:
+            if s < 0 or s >= num_sys:
+                raise ValueError(f"Subsystem index {s} is out of bounds; must be in [0, {num_sys}).")
         prod_dim_sys = int(np.prod([dim[i] for i in sys]))
         sys = np.array(sys)
 

--- a/toqito/matrix_ops/tests/test_partial_trace.py
+++ b/toqito/matrix_ops/tests/test_partial_trace.py
@@ -644,17 +644,18 @@ def test_is_trace_prserving(input_mat, expected_result, sys_arg, dim_arg):
 
 
 @pytest.mark.parametrize(
-    "sys_value",
+    "sys_value, bad_index",
     [
-        2,  # int out-of-bounds
-        [2],  # list out-of-bounds
-        [-1],  # negative index
+        (2, 2),  # int out-of-bounds
+        ([2], 2),  # list out-of-bounds
+        ([-1], -1),  # negative index
     ],
 )
-def test_sys_out_of_bounds(sys_value):
-    """Test that out-of-bounds subsystem indices raise ValueError."""
+def test_sys_out_of_bounds(sys_value, bad_index):
+    """Out-of-bounds subsystem indices raise ValueError naming the offending index."""
     mat = np.eye(4)
-    with pytest.raises(ValueError, match="out of bounds"):
+    expected = f"Subsystem index {bad_index} is out of bounds; must be in [0, 2)."
+    with pytest.raises(ValueError, match=re.escape(expected)):
         partial_trace(mat, sys_value, [2, 2])
 
 


### PR DESCRIPTION
## Description
Closes #1796

Both out-of-bounds branches in `partial_trace` raised the same vague message, `"Subsystem indices in `sys` are out of bounds."`, without saying which index was wrong. Each now reports the offending index and the valid range, e.g. `"Subsystem index 2 is out of bounds; must be in [0, 2)."` The list branch was changed from `any(...)` to an explicit loop so it can name the specific bad index. `test_sys_out_of_bounds` now asserts the specific index for the int, list, and negative cases.

## Changes
  -  [x] Report the offending index + valid range in both branches
  -  [x] Assert the specific message per case in the test

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest` (72/72 in `test_partial_trace.py`).
  -  [x] Check the documentation build does not lead to any failures.
