### PR TITLE
polish: clearer error message for is_totally_positive on an empty matrix

### DIFF
--- a/toqito/matrix_props/is_totally_positive.py
+++ b/toqito/matrix_props/is_totally_positive.py
@@ -108,7 +108,7 @@ def is_totally_positive(
         atol = tol
 
     if mat.size == 0:
-        raise ValueError("Empty matrix to be neither totally positive nor not totally positive.")
+        raise ValueError("Cannot determine total positivity of an empty matrix.")
 
     dims = mat.shape
 

--- a/toqito/matrix_props/tests/test_is_totally_positive.py
+++ b/toqito/matrix_props/tests/test_is_totally_positive.py
@@ -1,5 +1,7 @@
 """Test is_totally_positive."""
 
+import re
+
 import numpy as np
 import pytest
 
@@ -47,7 +49,7 @@ def test_is_totally_positive(mat, tol, sub_sizes, expected_result):
 )
 def test_is_totally_positive_invalid(mat, tol, sub_sizes):
     """Test function works as expected for an invalid input."""
-    with np.testing.assert_raises(ValueError):
+    with pytest.raises(ValueError, match=re.escape("Cannot determine total positivity of an empty matrix.")):
         is_totally_positive(mat, atol=tol, sub_sizes=sub_sizes)
 
 


### PR DESCRIPTION
## Description
Closes #1794

`is_totally_positive` raised the grammatically broken `Empty matrix to be neither totally positive nor not totally positive.` on an empty input. Reworded to `Cannot determine total positivity of an empty matrix.` and upgraded the empty-matrix test to `pytest.raises(ValueError, match=...)` pinning it.

## Changes
  -  [x] Reword the empty-matrix `ValueError`
  -  [x] Pin the new message in `test_is_totally_positive_invalid`

## Checklist
  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures.