### PR TITLE
fix: validate orthonormality in mutually unbiased basis check (#1826)

### DIFF
--- a/toqito/state_props/is_mutually_unbiased_basis.py
+++ b/toqito/state_props/is_mutually_unbiased_basis.py
@@ -95,8 +95,21 @@ def is_mutually_unbiased_basis(vectors: list[np.ndarray | list[float | Any]]) ->
     mat = np.column_stack([np.asarray(vector).reshape(-1) for vector in vectors])
     gram = np.abs(mat.conj().T @ mat) ** 2
 
+    # Check that each consecutive block of `dim` vectors forms an orthonormal basis.
+    identity = np.eye(dim)
+
+    for basis_start in range(0, num_vectors, dim):
+        basis_block = gram[
+            basis_start : basis_start + dim,
+            basis_start : basis_start + dim,
+        ]
+
+        if not np.allclose(basis_block, identity, atol=1e-10):
+            return False
+
     # Mutual unbiasedness requires |<e_i|f_j>|^2 = 1/dim for every pair of vectors drawn
-    # from two *different* bases, i.e. every entry in the off-diagonal `dim x dim` blocks.
+    # from two *different* bases.
     basis_index = np.arange(num_vectors) // dim
     cross_basis = basis_index[:, None] != basis_index[None, :]
-    return bool(np.allclose(gram[cross_basis], 1 / dim))
+
+    return bool(np.allclose(gram[cross_basis], 1 / dim, atol=1e-10))

--- a/toqito/state_props/tests/test_is_mutually_unbiased_basis.py
+++ b/toqito/state_props/tests/test_is_mutually_unbiased_basis.py
@@ -81,3 +81,15 @@ e_0, e_1 = basis(2, 0), basis(2, 1)
 def test_is_mutually_unbiased(states, expected_result):
     """Test function works as expected for a valid input."""
     np.testing.assert_equal(is_mutually_unbiased_basis(states), expected_result)
+
+
+def test_non_orthonormal_basis():
+    """Test that non-orthonormal vector sets are rejected."""
+    e0, e1 = basis(2, 0), basis(2, 1)
+
+    v = 1 / np.sqrt(2) * (e0 + e1)
+
+    np.testing.assert_equal(
+        is_mutually_unbiased_basis([e0, e1, v, v]),
+        False,
+    )


### PR DESCRIPTION
## Problem

`is_mutually_unbiased_basis` verified only the mutual unbiasedness condition between different bases:

$|\langle u, v\rangle|^2 = 1/dim$

However, it did not verify that each group of `dim` vectors was actually an orthonormal basis. This allowed invalid inputs containing repeated or non-orthonormal vectors to incorrectly pass the check.

For example, a set like `{v, v}` could satisfy the cross-basis inner product condition while not forming a valid basis.

## Changes

- Added an orthonormality validation step for each consecutive block of `dim` vectors.
- Reused the existing Gram matrix calculation to check whether each basis block matches the identity matrix.
- Added a numerical tolerance (`atol=1e-10`) for floating-point comparisons.
- Invalid non-orthonormal basis sets now correctly return `False`.

This ensures that the function now validates both requirements of mutually unbiased bases:
1. Each individual set of vectors is an orthonormal basis.
2. Different bases satisfy the mutual unbiasedness condition.