### PR TITLE
Fix swap subsystem count for rectangular dimensions

### DIFF
--- a/toqito/perms/swap.py
+++ b/toqito/perms/swap.py
@@ -141,7 +141,7 @@ def swap(
         if not all(isinstance(d, (int, float, np.integer, np.floating)) for d in np.ravel(dim)):
             raise TypeError("dim entries must be int or float values.")
         dim = np.array(dim, dtype=int)
-        num_sys = len(dim)
+        num_sys = dim.shape[1] if dim.ndim == 2 and dim.shape[0] == 2 else len(dim)
 
     if len(sys) != 2:
         raise ValueError("InvalidSys: sys must be a vector with exactly two elements.")

--- a/toqito/perms/tests/test_swap.py
+++ b/toqito/perms/tests/test_swap.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from toqito.perms import swap
+from toqito.perms import permute_systems, swap
 
 
 @pytest.mark.parametrize(
@@ -502,6 +502,17 @@ from toqito.perms import swap
 def test_swap(input_matrix, sys, dim, row_only, expected_result):
     """Test swap operation."""
     result = swap(input_matrix, sys, dim, row_only)
+    assert np.allclose(result, expected_result)
+
+
+def test_swap_with_rectangular_dim_counts_subsystems_by_columns():
+    """Test swap accepts a two-row dim form with more than two subsystems."""
+    test_matrix = np.arange(96).reshape(12, 8)
+    dim = [[2, 2, 3], [2, 2, 2]]
+    expected_result = permute_systems(test_matrix, [2, 1, 0], dim)
+
+    result = swap(test_matrix, [1, 3], dim)
+
     assert np.allclose(result, expected_result)
 
 


### PR DESCRIPTION
## Description
Fixes #1828.

The documented two-row rectangular `dim` form stores one subsystem per column. `swap` was counting rows instead, so valid subsystem indices beyond 2 were rejected before reaching `permute_systems`.

## Changes
- Count subsystems from the column count when `dim` is a two-row rectangular dimension array.
- Add regression coverage for swapping systems 1 and 3 of a rectangular 3-subsystem operator.

## Checklist
- [x] Use `ruff` for errors related to code style and formatting.
- [x] Verify all previous and newly added unit tests pass in `pytest`.
- [ ] Check the documentation build does not lead to any failures.