### PR TITLE
docs: document natural_representation, hadamard, and horodecki

### DIFF
--- a/toqito/channel_ops/natural_representation.py
+++ b/toqito/channel_ops/natural_representation.py
@@ -10,6 +10,13 @@ def natural_representation(kraus_ops: list[np.ndarray]) -> np.ndarray:
     \(\Phi = \sum_i K_i \otimes K_i^*\)
     where \(K_i^*\) is the complex conjugate of \(K_i\).
 
+    Args:
+        kraus_ops: A list of Kraus operators, or a stacked ndarray whose first
+            axis indexes the Kraus operators.
+
+    Returns:
+        The natural-representation matrix of the quantum channel.
+
     Examples:
         ```python exec="1" source="above" result="text"
         import numpy as np

--- a/toqito/matrices/hadamard.py
+++ b/toqito/matrices/hadamard.py
@@ -26,6 +26,12 @@ def hadamard(n_param: int = 1) -> np.ndarray:
         \left(-1\right)^{i \cdot j}
     \]
 
+    Args:
+        n_param: Number of tensor factors. Must be at least 1.
+
+    Returns:
+        The `2^{n_param}`-dimensional Hadamard matrix.
+
     Examples:
         The standard 1-qubit Hadamard matrix can be generated in `toqito` as
 

--- a/toqito/states/horodecki.py
+++ b/toqito/states/horodecki.py
@@ -62,6 +62,14 @@ def horodecki(a_param: float, dim: list[int] | None = None) -> np.ndarray:
         [@horodecki1997separability] and the 2x4 Horodecki state is defined explicitly in Section 4.2 of
         [@horodecki1997separability].
 
+    Args:
+        a_param: State parameter in the interval [0, 1].
+        dim: Local dimensions of the state. Supported values are [3, 3] and [2, 4];
+            defaults to [3, 3].
+
+    Returns:
+        The Horodecki density matrix for the requested dimensions.
+
     Examples:
         The following code generates a Horodecki state in \(\mathbb{C}^3 \otimes \mathbb{C}^3\)
 


### PR DESCRIPTION
## Summary
- add Args and Returns sections to `natural_representation`
- add Args and Returns sections to `hadamard`
- add Args and Returns sections to `horodecki`

Closes #1789.
Closes #1790.
Closes #1791.

## Validation
- `/Users/quant/.local/bin/uv run ruff check toqito/channel_ops/natural_representation.py toqito/matrices/hadamard.py toqito/states/horodecki.py`
- `/Users/quant/.local/bin/uv run ruff format --check toqito/channel_ops/natural_representation.py toqito/matrices/hadamard.py toqito/states/horodecki.py`
- `/Users/quant/.local/bin/uv run pytest toqito/channel_ops/tests/test_natural_representation.py toqito/matrices/tests/test_hadamard.py toqito/states/tests/test_horodecki.py`
- `git diff --check`