### PR TITLE
docs: add quantum_relative_entropy example

### DIFF
--- a/toqito/state_props/quantum_relative_entropy.py
+++ b/toqito/state_props/quantum_relative_entropy.py
@@ -99,6 +99,20 @@ def quantum_relative_entropy(
     Returns:
         The quantum relative entropy \(D(X||Y)\) as a float.
 
+    Examples:
+        Compute \(D(|0\rangle\langle 0| \parallel I / 2)\), which is
+        \(\ln(2)\) in nats.
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+
+        from toqito.state_props import quantum_relative_entropy
+
+        rho = np.array([[1.0, 0.0], [0.0, 0.0]])
+        sigma = np.identity(2) / 2
+        print(f"{quantum_relative_entropy(rho, sigma):.6f}")
+        ```
+
     """
     if not isinstance(mat_x, (np.ndarray, cvxpy.Expression)):
         raise ValueError("mat_x must be a numpy array or a cvxpy expression")


### PR DESCRIPTION
## Summary
- add a runnable `quantum_relative_entropy` example
- compute `D(|0><0| || I / 2)` and print the natural-log result

Closes #1798.

## Validation
- `/Users/quant/.local/bin/uv run ruff check toqito/state_props/quantum_relative_entropy.py`
- `/Users/quant/.local/bin/uv run ruff format --check toqito/state_props/quantum_relative_entropy.py`
- `/Users/quant/.local/bin/uv run pytest toqito/state_props/tests/test_quantum_relative_entropy.py`
- `git diff --check`