### PR TITLE
test: cover negative pretty_good_measurement probabilities

### DIFF
--- a/toqito/measurements/tests/test_pretty_good_measurement.py
+++ b/toqito/measurements/tests/test_pretty_good_measurement.py
@@ -61,6 +61,12 @@ def test_pgm_invalid_probs(states, probs):
         pretty_good_measurement(states, probs)
 
 
+def test_pgm_negative_probability_raises():
+    """Ensures that probability vectors must be nonnegative."""
+    with pytest.raises(ValueError, match="nonnegative"):
+        pretty_good_measurement(trine(), [-1 / 3, 2 / 3, 2 / 3])
+
+
 @pytest.mark.parametrize(
     "states, probs",
     [


### PR DESCRIPTION
## Summary
- add a regression test for `pretty_good_measurement` probabilities that sum to one but include a negative entry
- assert the nonnegative-probability `ValueError` branch is reached

Closes #1792.

## Validation
- `/Users/quant/.local/bin/uv run pytest toqito/measurements/tests/test_pretty_good_measurement.py -q`
- `/Users/quant/.local/bin/uv run ruff check toqito/measurements/tests/test_pretty_good_measurement.py`
- `/Users/quant/.local/bin/uv run ruff format --check toqito/measurements/tests/test_pretty_good_measurement.py`
- `git diff --check`