### PR TITLE
Fix false positives in is_absolutely_k_incoherent for k = n - 1

### DIFF
--- a/toqito/matrix_props/is_absolutely_k_incoherent.py
+++ b/toqito/matrix_props/is_absolutely_k_incoherent.py
@@ -1,8 +1,5 @@
 """Checks if the matrix is absolutely $k$-incoherent."""
 
-import warnings
-
-import cvxpy as cp
 import numpy as np
 
 from toqito.matrix_props import is_positive_semidefinite, is_square
@@ -15,8 +12,9 @@ def is_absolutely_k_incoherent(mat: np.ndarray, k: int, tol: float = 1e-15) -> b
     if \(U \rho U^* \in \mathbb{I}_{k, n}\) for all unitary matrices \(U \in \text{U}(\mathbb{C}^n)\).
 
     This function checks if the provided density matrix is absolutely k-incoherent based on the criteria introduced in
-    [@johnston2022absolutely] and the corresponding QETLAB functionality [@qetlablink]. When
-    necessary, an SDP is set up via ``cvxpy``.
+    [@johnston2022absolutely] and the corresponding QETLAB functionality [@qetlablink]. For
+    :code:`k = n - 1` the SDP characterization of [@johnston2022absolutely] (Theorem 8) reduces to a
+    closed-form spectral condition, which is used directly.
 
     The notion of absolute k-incoherence is connected to the notion of quantum state antidistinguishability as discussed
     in [@johnston2025tight].
@@ -98,30 +96,12 @@ def is_absolutely_k_incoherent(mat: np.ndarray, k: int, tol: float = 1e-15) -> b
         elif n <= 3:
             return False
     elif k == n - 1:
-        # [1] Corollary 1: Check maximum eigenvalue condition.
-        if lmax > 1 - 1 / n:
-            return False
-        else:
-            # [1] Theorem 8: Solve an SDP to decide absolute (n-1)-incoherence.
-            lam = np.sort(np.real(eigvals))[::-1]
-            n_eig = len(lam)
-            L = cp.Variable((n_eig, n_eig), symmetric=True)
-            constraints = []
-            # Constraint: L[0, 0] == -lam[0] - sum(L[0, 1:]) - sum(L[1:, 0])
-            constraints.append(L[0, 0] == -lam[0] - cp.sum(L[0, 1:]) - cp.sum(L[1:, 0]))
-            # For indices j = 1 to n_eig-1, enforce L[j, j] == lam[j]
-            for j in range(1, n_eig):
-                constraints.append(L[j, j] == lam[j])
-            # L must be positive semidefinite.
-            constraints.append(L >> 0)
-            # Dummy objective function.
-            objective = cp.Minimize(1)
-            prob = cp.Problem(objective, constraints)
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", message="Solution may be inaccurate")
-                opt_val = prob.solve(solver=cp.SCS, eps=1e-8, verbose=False)
-            # Guard against a failed solve (opt_val is None) so np.isclose does not raise; a feasible solution
-            # (optimal value near 1) means absolute (n-1)-incoherence holds.
-            if opt_val is not None and np.isclose(opt_val, 1.0):
-                return True
+        # [1] Theorem 8 gives an SDP characterization of absolute (n-1)-incoherence. That SDP
+        # admits a closed-form solution: factoring the Gram-type matrix in the SDP shows that it
+        # is feasible if and only if
+        #     sqrt(lmax) <= sum of sqrt of the remaining eigenvalues.
+        # This spectral test is exact, so no SDP solve is needed (solving the feasibility SDP
+        # numerically is also unreliable; first-order solvers can report false feasibility).
+        lam = np.sort(np.real(eigvals))[::-1]
+        return bool(np.sqrt(lam[0]) <= np.sum(np.sqrt(np.clip(lam[1:], 0, None))) + np.sqrt(tol))
     return False

--- a/toqito/matrix_props/tests/test_is_absolutely_k_incoherent.py
+++ b/toqito/matrix_props/tests/test_is_absolutely_k_incoherent.py
@@ -1,6 +1,5 @@
 """Test is_absolutely_k_incoherent."""
 
-import cvxpy as cp
 import numpy as np
 import pytest
 
@@ -47,9 +46,10 @@ from toqito.matrix_props import is_absolutely_k_incoherent
         # equal.
         (np.diag([0.5, 0.5, 0, 0]), 3, True),
         # [1] Theorem 4 branch (non-equal nonzero eigenvalues).
-        # For n = 4 and k = 3, a matrix with eigenvalues [0.6, 0.4, 0, 0] has rank 2 but the nonzero eigenvalues differ.
-        # (This will fall through to the SDP branch; see monkeypatched test below.)
-        (np.diag([0.6, 0.4, 0, 0]), 3, True),
+        # For n = 4 and k = 3, a matrix with eigenvalues [0.6, 0.4, 0, 0] has rank 2 but the nonzero
+        # eigenvalues differ; the spectral condition sqrt(0.6) > sqrt(0.4) shows it is not absolutely
+        # 3-incoherent.
+        (np.diag([0.6, 0.4, 0, 0]), 3, False),
         # k == 2 branch (Frobenius norm fails).
         # For n = 3, a pure state with Frobenius norm squared = 1 (which is greater than 1/(3-1)=0.5) returns False.
         (np.diag([1, 0, 0]), 2, False),
@@ -64,15 +64,19 @@ from toqito.matrix_props import is_absolutely_k_incoherent
         # For n = 4 and k = 3 (n - 1), if lmax > 1 - 1/4 (i.e. lmax > 0.75), then it returns False.
         (np.diag([0.8, 0.1, 0.1, 0]), 3, False),
         # [1] Theorem 8 branch.
-        # For n = 4 and k = 3, if lmax is below the cutoff (0.75), then the SDP is executed and (assuming feasibility)
-        # returns True.
-        (np.diag([0.7, 0.15, 0.15, 0]), 3, True),
+        # For n = 4 and k = 3: sqrt(0.7) > 2 sqrt(0.15), so the Theorem 8 condition fails.
+        (np.diag([0.7, 0.15, 0.15, 0]), 3, False),
         # k <= 0 raise ValueError.
         (np.diag([0.8, 0.1, 0.1, 0]), 0, False),
         (np.diag([0.34, 0.22, 0.22, 0.22]), 2, True),
         (np.diag([0.9, 0.05, 0.05]), 2, False),
-        (np.diag([0.7, 0.15, 0.15, 0]), 3, True),
+        (np.diag([0.7, 0.15, 0.15, 0]), 3, False),
+        # sqrt(0.6) < 2 sqrt(0.2), so the Theorem 8 condition holds.
+        (np.diag([0.6, 0.2, 0.2, 0]), 3, True),
         (np.diag([0.8, 0.1, 0.05, 0.05]), 3, False),
+        # Regression: a first-order SDP solver falsely reported this spectrum feasible for the
+        # Theorem 8 SDP; the closed-form condition correctly rejects it.
+        (np.diag([0.75948417, 0.18316435, 0.03951963, 0.01305637, 0.00477548]), 4, False),
     ],
 )
 def test_is_absolutely_k_incoherent(mat, k, expected):
@@ -93,53 +97,19 @@ def test_is_absolutely_k_incoherent_non_square():
         is_absolutely_k_incoherent(mat, 1)
 
 
-def test_sdp_not_optimal(monkeypatch):
-    """Test that if the SDP returns a value not close to 1.0, is_absolutely_k_incoherent returns False."""
-    # Create a 4x4 matrix that triggers the SDP branch.
-    mat = np.diag([0.7, 0.15, 0.15, 0])
-
-    def fake_solve(self, *args, **kwargs):
-        return 0.5
-
-    monkeypatch.setattr(cp.Problem, "solve", fake_solve)
+def test_non_equal_eigenvalues_branch():
+    """Rank n-k+1 with unequal nonzero eigenvalues is not absolutely (n-1)-incoherent."""
+    mat = np.diag([0.6, 0.4, 0, 0])
     assert is_absolutely_k_incoherent(mat, 3) is False
 
 
-def test_non_equal_eigenvalues_branch(monkeypatch):
-    """Test the branch when rankX == n-k+1 but nonzero eigenvalues are not equal."""
-    # Use n = 4, k = 3 with eigenvalues [0.6, 0.4, 0, 0].
-    mat = np.diag([0.6, 0.4, 0, 0])
-
-    # In the unpatched code, this falls to the SDP branch.
-    # Force the SDP branch to return an objective value near 1.
-    def fake_solve(self, *args, **kwargs):
-        return 1.0
-
-    monkeypatch.setattr(cp.Problem, "solve", fake_solve)
-    # Expect True as the final result.
-    assert is_absolutely_k_incoherent(mat, 3) is True
-
-
-def test_k_equals_n_minus_one_true(monkeypatch):
-    """When k = n - 1 and the SDP succeeds, the function returns True."""
+def test_k_equals_n_minus_one_true():
+    """When k = n - 1 and the Theorem 8 spectral condition holds, the function returns True."""
     mat = np.diag([0.6, 0.2, 0.2, 0.0])
-
-    def fake_solve(self, *args, **kwargs):
-        return 1.0
-
-    monkeypatch.setattr(cp.Problem, "solve", fake_solve)
     assert is_absolutely_k_incoherent(mat, 3) is True
 
 
 def test_k_equals_n_minus_one_large_eigenvalue():
     """When k = n - 1 and the largest eigenvalue exceeds the bound, return False immediately."""
     mat = np.diag([0.9, 0.05, 0.05, 0.0])
-    assert is_absolutely_k_incoherent(mat, 3) is False
-
-
-def test_is_absolutely_k_incoherent_solver_returns_none(monkeypatch):
-    """A failed solve (solver returns None) yields False instead of raising a TypeError."""
-    monkeypatch.setattr(cp.Problem, "solve", lambda self, *a, **k: None)
-    # diag([0.6, 0.2, 0.2, 0]) with k = n - 1 reaches the SDP branch; with the guard it must not raise.
-    mat = np.diag([0.6, 0.2, 0.2, 0.0])
     assert is_absolutely_k_incoherent(mat, 3) is False


### PR DESCRIPTION
## Summary

`is_absolutely_k_incoherent` returned true for states that are not absolutely (n-1)-incoherent. The k = n - 1 branch solved the feasibility SDP of Johnston, Moein, Pereira, and Plosker (Theorem 8) with SCS and accepted the `optimal_inaccurate` status as feasible. SCS misreports certain infeasible instances of this SDP; for example the spectrum (0.759, 0.183, 0.040, 0.013, 0.005) is reported feasible by SCS while CLARABEL and CVXOPT both prove it infeasible.

## Fix

Factoring the Gram-type matrix in the Theorem 8 SDP shows it is feasible if and only if

sqrt(lambda_max) <= sum_i sqrt(lambda_i)  (sum over the remaining eigenvalues),

so the SDP solve is replaced with this exact spectral test. No solver is involved, which removes the failure mode entirely, and the module no longer needs cvxpy.

## Tests

- Corrected the expectations that had encoded the solver's false positives. Each corrected case was re-verified against exact solvers; for instance diag(0.6, 0.4, 0, 0) with k = 3 is infeasible by hand (the 2x2 Schur complement bound gives a minimum of -0.4 > -0.6).
- Removed the monkeypatch tests that faked SDP solver return values, since there is no SDP anymore.
- Added a regression test for the SCS-misreported spectrum.
- `matrix_props` suite passes 365/365; ruff check and format are clean.