### PR TITLE
fix(channel_props): submodule import in channel_dim example to pass strict docs build

### DIFF
--- a/toqito/channel_props/channel_dim.py
+++ b/toqito/channel_props/channel_dim.py
@@ -48,7 +48,7 @@ def channel_dim(
 
         ```python exec="1" source="above" result="text"
         import numpy as np
-        from toqito.channel_props import channel_dim
+        from toqito.channel_props.channel_dim import channel_dim
 
         kraus_ops = [
             np.sqrt(0.5) * np.eye(2),


### PR DESCRIPTION
## Problem

The `preview` (strict docs) job fails:

```
TypeError: 'module' object is not callable   (channel_dim(kraus_ops))
Aborted with 1 warnings in strict mode!
```

Under `mkdocs build --strict`, `api-autonav` imports `toqito.channel_props.channel_dim` (the submodule) directly. Because `channel_props` uses a lazy `__getattr__` loader, that real submodule attribute **shadows** the lazily-cached function, so the docstring example's `from toqito.channel_props import channel_dim` resolves to the *module*.

## Fix

Import the function from its defining submodule in the example: `from toqito.channel_props.channel_dim import channel_dim`. That is order-independent and always resolves to the function.

I initially tried making `channel_props` eager (like the other subpackages), but eager loading forces a **pre-existing latent `matrix_props` import cycle** (`matrix_props/__init__` -> `sk_norm` -> deps -> partial `matrix_props` -> `sk_operator_norm`), which broke the full pytest suite. Keeping the lazy loader and fixing the example avoids that entirely.

## Verification

- Reproduced the docs-build condition (submodule imported first): the example's import now resolves to the function and runs.
- `import toqito` clean (no cycle); `ruff` clean.
- Docstring-only, one line.