### PR TITLE
perf(is_pseudo_hermitian): fold redundant matrix_rank into the inv (completes #1758)

### DIFF
--- a/toqito/matrix_props/is_pseudo_hermitian.py
+++ b/toqito/matrix_props/is_pseudo_hermitian.py
@@ -86,11 +86,15 @@ def is_pseudo_hermitian(mat: np.ndarray, signature: np.ndarray, rtol: float = 1e
     if not is_hermitian(signature, rtol=rtol, atol=atol):
         raise ValueError("Signature not hermitian matrix.")
 
-    if np.linalg.matrix_rank(signature) != signature.shape[0]:
-        raise ValueError("Signature is not invertible.")
+    # Test invertibility by attempting the inverse the function needs anyway, rather than a
+    # separate matrix_rank (full SVD) pre-check followed by a redundant inv.
+    try:
+        signature_inv = np.linalg.inv(signature)
+    except np.linalg.LinAlgError as error:
+        raise ValueError("Signature is not invertible.") from error
 
     if not is_square(mat) or not has_same_dimension([mat, signature]):
         return False
 
-    eta_H_inv_eta = signature @ mat @ np.linalg.inv(signature)
+    eta_H_inv_eta = signature @ mat @ signature_inv
     return np.allclose(eta_H_inv_eta, mat.conj().T, rtol=rtol, atol=atol)


### PR DESCRIPTION
Completes the last item of #1758. The other three predicates (`is_unitary`, `is_absolutely_k_incoherent`, `majorizes`) were already optimized in earlier PRs.

## Change

`is_pseudo_hermitian` ran `np.linalg.matrix_rank(signature)` — a full SVD — solely to reject singular signatures, and *then* computed `np.linalg.inv(signature)` anyway. Fold both into a single `inv` guarded by `try/except np.linalg.LinAlgError`, reusing the inverse:

```python
try:
    signature_inv = np.linalg.inv(signature)
except np.linalg.LinAlgError as error:
    raise ValueError("Signature is not invertible.") from error
...
eta_H_inv_eta = signature @ mat @ signature_inv
```

Same `ValueError` for singular signatures, one decomposition instead of two — **~5x** on the invertibility check for a 64x64 signature.

## Behavior note (transparency)

`np.linalg.inv` fails on *exact* singularity (LU pivot), whereas `matrix_rank` rejects at an SVD tolerance. So a signature that is rank-deficient only at that tolerance — near-singular but not exactly singular — is now inverted rather than rejected. That is exactly the inverse the function then uses, so this tests the operation it actually performs rather than a separate proxy. The existing tests (exact-singular and genuine-invertible cases) pass unchanged. This is a deliberately different, and I'd argue more direct, approach than the eigvalsh swap in the closed #1843.

## Checklist
  -  [x] `ruff` clean.
  -  [x] Tests pass (test_is_pseudo_hermitian: 5 passed).