### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "toqito"
-version = "1.2.0"
+version = "1.3.0"
 description = "Python tools for the study of quantum information."
 readme = "README.md"
 requires-python = ">=3.12,<4"


### PR DESCRIPTION
Version bump for the 1.3.0 release.

Since 1.2.0 this includes new functionality (Tsallis/quadrature relative entropy), package reorganization (`channel_opt`; `cones` dispersed), and correctness fixes — plus breaking import-path removals from `toqito.cones` and `toqito.channel_metrics`, hence a minor bump rather than a patch.