### PR TITLE
refactor: remove deprecated input_mat and tol parameters

### DIFF
--- a/toqito/channels/amplitude_damping.py
+++ b/toqito/channels/amplitude_damping.py
@@ -1,14 +1,11 @@
 """Generates the (generalized) amplitude damping channel."""
 
-import warnings
-
 import numpy as np
 
 from toqito.channel_ops.kraus_to_choi import kraus_to_choi
 
 
 def amplitude_damping(
-    input_mat: np.ndarray | None = None,
     gamma: float = 0,
     prob: float = 1,
     return_kraus_ops: bool = False,
@@ -39,17 +36,13 @@ def amplitude_damping(
     damping process.
 
     Args:
-        input_mat: Deprecated. Passing a matrix here applies the channel to that matrix; this
-            convenience path will be removed in a future release. Prefer
-            `apply_channel(input_mat, amplitude_damping(gamma=..., prob=...))`.
         gamma: The damping rate, a float between 0 and 1. Represents the probability of energy dissipation.
         prob: The probability of energy loss, a float between 0 and 1.
         return_kraus_ops: If `True`, return the list of Kraus operators instead of the Choi matrix.
 
     Returns:
         The Choi matrix of the channel, or its list of Kraus operators when `return_kraus_ops` is
-        `True`. When the deprecated `input_mat` argument is provided, the channel applied to that
-        input is returned instead.
+        `True`.
 
     Examples:
         Apply the channel (returned as a Choi matrix) to a state via `apply_channel`:
@@ -77,25 +70,5 @@ def amplitude_damping(
     k2 = np.sqrt(1 - prob) * np.array([[np.sqrt(1 - gamma), 0], [0, 1]])
     k3 = np.sqrt(1 - prob) * np.sqrt(gamma) * np.array([[0, 0], [1, 0]])
 
-    if input_mat is None:
-        kraus_ops = [k0, k1, k2, k3]
-        return kraus_ops if return_kraus_ops else kraus_to_choi(kraus_ops)
-
-    if input_mat.shape != (2, 2):
-        raise ValueError("Input matrix must be 2x2 for the generalized amplitude damping channel.")
-
-    warnings.warn(
-        "Passing `input_mat` to `amplitude_damping` is deprecated; "
-        "use `apply_channel(input_mat, amplitude_damping(...))` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    input_mat = np.asarray(input_mat, dtype=complex)
-
-    return (
-        k0 @ input_mat @ k0.conj().T
-        + k1 @ input_mat @ k1.conj().T
-        + k2 @ input_mat @ k2.conj().T
-        + k3 @ input_mat @ k3.conj().T
-    )
+    kraus_ops = [k0, k1, k2, k3]
+    return kraus_ops if return_kraus_ops else kraus_to_choi(kraus_ops)

--- a/toqito/channels/bitflip.py
+++ b/toqito/channels/bitflip.py
@@ -1,14 +1,11 @@
 """Implements the bitflip quantum gate channel."""
 
-import warnings
-
 import numpy as np
 
 from toqito.channel_ops.kraus_to_choi import kraus_to_choi
 
 
 def bitflip(
-    input_mat: np.ndarray | None = None,
     prob: float = 0,
     return_kraus_ops: bool = False,
 ) -> np.ndarray | list[np.ndarray]:
@@ -36,16 +33,12 @@ def bitflip(
     \]
 
     Args:
-        input_mat: Deprecated. Passing a matrix here applies the channel to that matrix; this
-            convenience path will be removed in a future release. Prefer
-            `apply_channel(input_mat, bitflip(prob=...))`.
         prob: The probability of a bitflip occurring.
         return_kraus_ops: If `True`, return the list of Kraus operators instead of the Choi matrix.
 
     Returns:
         The Choi matrix of the channel, or its list of Kraus operators when `return_kraus_ops` is
-        `True`. When the deprecated `input_mat` argument is provided, the channel applied to that
-        input is returned instead.
+        `True`.
 
     Examples:
         Obtain the Kraus operators for the bitflip channel with probability 0.3:
@@ -75,19 +68,5 @@ def bitflip(
     k0 = np.sqrt(1 - prob) * np.eye(2)
     k1 = np.sqrt(prob) * np.array([[0, 1], [1, 0]])
 
-    if input_mat is None:
-        kraus_ops = [k0, k1]
-        return kraus_ops if return_kraus_ops else kraus_to_choi(kraus_ops)
-
-    if input_mat.shape != (2, 2):
-        raise ValueError("Input matrix must be 2x2 for the bitflip channel.")
-
-    warnings.warn(
-        "Passing `input_mat` to `bitflip` is deprecated; use `apply_channel(input_mat, bitflip(...))` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    input_mat = np.asarray(input_mat, dtype=complex)
-
-    return k0 @ input_mat @ k0.conj().T + k1 @ input_mat @ k1.conj().T
+    kraus_ops = [k0, k1]
+    return kraus_ops if return_kraus_ops else kraus_to_choi(kraus_ops)

--- a/toqito/channels/pauli_channel.py
+++ b/toqito/channels/pauli_channel.py
@@ -1,7 +1,6 @@
 """Generates the Choi matrix of a Pauli channel."""
 
 import itertools
-import warnings
 
 import numpy as np
 
@@ -9,9 +8,7 @@ from toqito.channel_ops.kraus_to_choi import kraus_to_choi
 from toqito.matrices.pauli import pauli
 
 
-def pauli_channel(
-    prob: int | np.ndarray, return_kraus_ops: bool = False, input_mat: np.ndarray | None = None
-) -> np.ndarray | tuple:
+def pauli_channel(prob: int | np.ndarray, return_kraus_ops: bool = False) -> np.ndarray | tuple:
     r"""Return the Choi matrix of a Pauli channel.
 
     The Pauli channel is defined by a set of Pauli operators weighted by a probability vector.
@@ -38,14 +35,10 @@ def pauli_channel(
             qubits. The probabilities correspond to Pauli operators in lexicographical order of length strictly equal to
             \(q\), when `prob` is a vector.
         return_kraus_ops: If `True`, return the list of Kraus operators instead of the Choi matrix.
-        input_mat: Deprecated. When provided, the channel is also applied to this matrix and
-            returned in a tuple alongside the Choi matrix. Prefer
-            `apply_channel(input_mat, pauli_channel(...))` instead.
 
     Returns:
         The Choi matrix of the Pauli channel, or its list of Kraus operators when
-        `return_kraus_ops` is `True`. When the deprecated ``input_mat`` argument is used, a tuple
-        including the output matrix is returned for backward compatibility.
+        `return_kraus_ops` is `True`.
 
     Raises:
         ValueError: If probabilities are negative or don't sum to 1.
@@ -94,19 +87,7 @@ def pauli_channel(
     ]
     Phi = kraus_to_choi(kraus_operators)
 
-    if input_mat is not None:
-        warnings.warn(
-            "Passing `input_mat` to `pauli_channel` is deprecated; "
-            "use `apply_channel(input_mat, pauli_channel(...))` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-    output_mat = None
-    if input_mat is not None:
-        output_mat = sum(k @ input_mat @ k.conj().T for k in kraus_operators)
-
     if return_kraus_ops:
-        return (kraus_operators, output_mat) if input_mat is not None else kraus_operators
+        return kraus_operators
 
-    return (Phi, output_mat) if input_mat is not None else Phi
+    return Phi

--- a/toqito/channels/phase_damping.py
+++ b/toqito/channels/phase_damping.py
@@ -1,14 +1,11 @@
 """phase damping channel."""
 
-import warnings
-
 import numpy as np
 
 from toqito.channel_ops.kraus_to_choi import kraus_to_choi
 
 
 def phase_damping(
-    input_mat: np.ndarray | None = None,
     gamma: float = 0,
     return_kraus_ops: bool = False,
 ) -> np.ndarray | list[np.ndarray]:
@@ -25,16 +22,12 @@ def phase_damping(
     \]
 
     Args:
-        input_mat: Deprecated. Passing a matrix here applies the channel to that matrix; this
-            convenience path will be removed in a future release. Prefer
-            `apply_channel(input_mat, phase_damping(gamma=...))`.
         gamma: The dephasing rate (between 0 and 1), representing the probability of phase decoherence.
         return_kraus_ops: If `True`, return the list of Kraus operators instead of the Choi matrix.
 
     Returns:
         The Choi matrix of the channel, or its list of Kraus operators when `return_kraus_ops` is
-        `True`. When the deprecated `input_mat` argument is provided, the channel applied to that
-        input is returned instead.
+        `True`.
 
     Examples:
         Apply the channel (returned as a Choi matrix) to a state via `apply_channel`:
@@ -57,20 +50,5 @@ def phase_damping(
     k0 = np.diag([1, np.sqrt(1 - gamma)])
     k1 = np.diag([0, np.sqrt(gamma)])
 
-    if input_mat is None:
-        kraus_ops = [k0, k1]
-        return kraus_ops if return_kraus_ops else kraus_to_choi(kraus_ops)
-
-    if input_mat.shape != (2, 2):
-        raise ValueError("Input matrix must be 2x2 for the phase damping channel.")
-
-    warnings.warn(
-        "Passing `input_mat` to `phase_damping` is deprecated; "
-        "use `apply_channel(input_mat, phase_damping(...))` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    input_mat = np.asarray(input_mat, dtype=complex)
-
-    return k0 @ input_mat @ k0.conj().T + k1 @ input_mat @ k1.conj().T
+    kraus_ops = [k0, k1]
+    return kraus_ops if return_kraus_ops else kraus_to_choi(kraus_ops)

--- a/toqito/channels/tests/test_amplitude_damping.py
+++ b/toqito/channels/tests/test_amplitude_damping.py
@@ -75,25 +75,6 @@ def test_invalid_parameters(param, value, error_message):
         amplitude_damping(**kwargs)
 
 
-@pytest.mark.parametrize(
-    "rho",
-    [
-        # 3x3 matrix.
-        np.eye(3),
-        # 2x3 matrix.
-        np.array([[1, 0, 0], [0, 1, 0]]),
-        # 1D array.
-        np.array([1, 0]),
-        # 2x4 matrix.
-        np.array([[1, 0, 0, 0], [0, 1, 0, 0]]),
-    ],
-)
-def test_invalid_dimension(rho):
-    """Test that invalid matrix dimensions raise an error."""
-    with pytest.raises(ValueError, match="Input matrix must be 2x2 for the generalized amplitude damping channel."):
-        amplitude_damping(rho, prob=0.3, gamma=0.5)
-
-
 def test_input_and_return_type():
     """Test for input handling and return types."""
     choi = amplitude_damping(prob=0.3, gamma=0.4)
@@ -102,12 +83,3 @@ def test_input_and_return_type():
     assert len(kraus_ops) == 4
     for op in kraus_ops:
         assert op.shape == (2, 2)
-
-
-def test_input_mat_is_deprecated():
-    """Passing `input_mat` still works but emits a DeprecationWarning."""
-    rho = np.array([[1.0, 0.0], [0.0, 0.0]])
-    with pytest.warns(DeprecationWarning, match="apply_channel"):
-        legacy = amplitude_damping(rho, prob=0.3, gamma=0.4)
-    modern = apply_channel(rho, amplitude_damping(prob=0.3, gamma=0.4))
-    np.testing.assert_almost_equal(legacy, modern)

--- a/toqito/channels/tests/test_bitflip.py
+++ b/toqito/channels/tests/test_bitflip.py
@@ -60,20 +60,6 @@ def test_invalid_probability(prob, error_message):
         bitflip(prob=prob)
 
 
-@pytest.mark.parametrize(
-    "rho",
-    [
-        np.eye(3),  # 3x3 matrix
-        np.array([[1, 0, 0], [0, 1, 0]]),  # 2x3 matrix
-        np.array([[1, 0, 0, 0], [0, 1, 0, 0]]),  # 2x4 matrix
-    ],
-)
-def test_invalid_dimension(rho):
-    """Test that invalid matrix dimensions raise an error."""
-    with pytest.raises(ValueError, match="Input matrix must be 2x2 for the bitflip channel."):
-        bitflip(rho, prob=0.3)
-
-
 def test_apply_to_mixed_state():
     """Test bitflip channel on a mixed state."""
     prob = 0.4
@@ -82,12 +68,3 @@ def test_apply_to_mixed_state():
     result = apply_channel(rho, bitflip(prob=prob))
 
     np.testing.assert_almost_equal(result, expected_output)
-
-
-def test_input_mat_is_deprecated():
-    """Passing `input_mat` still works but emits a DeprecationWarning."""
-    rho = np.array([[1.0, 0.0], [0.0, 0.0]])
-    with pytest.warns(DeprecationWarning, match="apply_channel"):
-        legacy = bitflip(rho, prob=0.4)
-    modern = apply_channel(rho, bitflip(prob=0.4))
-    np.testing.assert_almost_equal(legacy, modern)

--- a/toqito/channels/tests/test_pauli_channel.py
+++ b/toqito/channels/tests/test_pauli_channel.py
@@ -138,16 +138,6 @@ def test_pauli_channel_zero_probability(prob):
             np.testing.assert_almost_equal(k, np.zeros_like(k))
 
 
-def test_pauli_channel_input_mat_is_deprecated():
-    """Passing `input_mat` still works but emits a DeprecationWarning."""
-    prob = np.array([0.1, 0.2, 0.3, 0.4])
-    input_mat = np.eye(2)
-    with pytest.warns(DeprecationWarning, match="apply_channel"):
-        _, legacy = pauli_channel(prob=prob, input_mat=input_mat)
-    modern = apply_channel(input_mat, pauli_channel(prob=prob))
-    np.testing.assert_almost_equal(legacy, np.asarray(modern))
-
-
 def test_pauli_channel_return_kraus_ops():
     """`return_kraus_ops=True` returns the flat list of Kraus operators (one per probability)."""
     prob = np.array([0.25, 0.25, 0.25, 0.25])

--- a/toqito/channels/tests/test_phase_damping.py
+++ b/toqito/channels/tests/test_phase_damping.py
@@ -70,25 +70,6 @@ def test_invalid_gamma(gamma, error_message):
         phase_damping(gamma=gamma)
 
 
-@pytest.mark.parametrize(
-    "rho",
-    [
-        # 3x3 matrix.
-        np.eye(3),
-        # 2x3 matrix.
-        np.array([[1, 0, 0], [0, 1, 0]]),
-        # 1D array.
-        np.array([1, 0]),
-        # 2x4 matrix.
-        np.array([[1, 0, 0, 0], [0, 1, 0, 0]]),
-    ],
-)
-def test_invalid_dimension(rho):
-    """Test that invalid matrix dimensions raise an error."""
-    with pytest.raises(ValueError, match="Input matrix must be 2x2 for the phase damping channel."):
-        phase_damping(rho, gamma=0.5)
-
-
 def test_input_and_return_type():
     """Test for input handling and return types."""
     choi = phase_damping(gamma=0.4)
@@ -97,12 +78,3 @@ def test_input_and_return_type():
     assert len(kraus_ops) == 2
     for op in kraus_ops:
         assert op.shape == (2, 2)
-
-
-def test_input_mat_is_deprecated():
-    """Passing `input_mat` still works but emits a DeprecationWarning."""
-    rho = np.array([[1.0, 0.0], [0.0, 0.0]])
-    with pytest.warns(DeprecationWarning, match="apply_channel"):
-        legacy = phase_damping(rho, gamma=0.4)
-    modern = apply_channel(rho, phase_damping(gamma=0.4))
-    np.testing.assert_almost_equal(legacy, modern)

--- a/toqito/matrix_props/is_k_incoherent.py
+++ b/toqito/matrix_props/is_k_incoherent.py
@@ -1,6 +1,5 @@
 """Checks if the matrix is $k$-incoherent."""
 
-import warnings
 from itertools import combinations
 
 import cvxpy as cp
@@ -10,9 +9,7 @@ from toqito.matrices import comparison
 from toqito.matrix_props import is_positive_semidefinite, is_square
 
 
-def is_k_incoherent(
-    mat: np.ndarray, k: int, rtol: float = 1e-05, atol: float = 1e-15, *, tol: float | None = None
-) -> bool:
+def is_k_incoherent(mat: np.ndarray, k: int, rtol: float = 1e-05, atol: float = 1e-15) -> bool:
     r"""Determine whether a quantum state is k-incoherent [@johnston2022absolutely].
 
     For a positive integers, \(k\) and \(n\), the matrix \(X \in \text{Pos}(\mathbb{C}^n)\) is called
@@ -37,7 +34,6 @@ def is_k_incoherent(
         k: The positive integer coherence level.
         rtol: Relative tolerance for the diagonal comparison (default 1e-05).
         atol: Absolute tolerance for the diagonal comparison (default 1e-15).
-        tol: Deprecated alias retained for backward compatibility; if given it sets ``atol``.
 
     Returns:
         True if `mat` is k-incoherent, False otherwise.
@@ -62,14 +58,6 @@ def is_k_incoherent(
             [is_absolutely_k_incoherent()][toqito.matrix_props.is_absolutely_k_incoherent.is_absolutely_k_incoherent]
 
     """
-    if tol is not None:
-        warnings.warn(
-            "`tol` is deprecated; use `rtol` and `atol` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        atol = tol
-
     if k <= 0:
         raise ValueError("k must be a positive integer.")
     if not is_square(mat):

--- a/toqito/matrix_props/is_rank_one.py
+++ b/toqito/matrix_props/is_rank_one.py
@@ -1,11 +1,9 @@
 """Checks if a matrix has rank one."""
 
-import warnings
-
 import numpy as np
 
 
-def is_rank_one(mat: np.ndarray, rtol: float = 1e-08, atol: float = 1e-08, *, tol: float | None = None) -> bool:
+def is_rank_one(mat: np.ndarray, rtol: float = 1e-08, atol: float = 1e-08) -> bool:
     r"""Determine whether the given matrix has rank one [@wikipediarank].
 
     The function evaluates the singular values (equivalently, eigenvalues for Hermitian matrices)
@@ -17,8 +15,6 @@ def is_rank_one(mat: np.ndarray, rtol: float = 1e-08, atol: float = 1e-08, *, to
         rtol: Relative tolerance, applied to the largest singular value (default 1e-08).
         atol: Absolute tolerance, used as the threshold when there are no singular values
             (default 1e-08).
-        tol: Deprecated alias retained for backward compatibility; if given it sets both ``rtol``
-            and ``atol``.
 
     Returns:
         `True` if the matrix has rank at most one, `False` otherwise.
@@ -46,14 +42,6 @@ def is_rank_one(mat: np.ndarray, rtol: float = 1e-08, atol: float = 1e-08, *, to
         ```
 
     """
-    if tol is not None:
-        warnings.warn(
-            "`tol` is deprecated; use `rtol` and `atol` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        rtol = atol = tol
-
     singular_values = np.linalg.svd(mat, compute_uv=False)
     # Threshold relative to the largest singular value so the result is independent of the matrix scale.
     threshold = rtol * singular_values.max() if singular_values.size else atol

--- a/toqito/matrix_props/is_totally_positive.py
+++ b/toqito/matrix_props/is_totally_positive.py
@@ -1,6 +1,5 @@
 """Checks if the matrix is totally positive."""
 
-import warnings
 from itertools import combinations
 
 import numpy as np
@@ -11,8 +10,6 @@ def is_totally_positive(
     rtol: float = 0.0,
     atol: float = 1e-6,
     sub_sizes: list | None = None,
-    *,
-    tol: float | None = None,
 ) -> bool:
     r"""Determine whether a matrix is totally positive [@wikipediatotallypositive].
 
@@ -25,7 +22,6 @@ def is_totally_positive(
             for negativity. Defaults to ``0.0``, so by default only ``atol`` is used.
         atol: Absolute tolerance parameter (default 1e-06).
         sub_sizes: List of sizes of submatrices to consider. Default is all sizes up to `min(mat.shape)`.
-        tol: Deprecated alias retained for backward compatibility; if given it sets ``atol``.
 
     Returns:
         Return `True` if matrix is totally positive, and `False` otherwise.
@@ -99,14 +95,6 @@ def is_totally_positive(
         ```
 
     """
-    if tol is not None:
-        warnings.warn(
-            "`tol` is deprecated; use `atol` (and optionally `rtol`) instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        atol = tol
-
     if mat.size == 0:
         raise ValueError("Cannot determine total positivity of an empty matrix.")
 

--- a/toqito/matrix_props/tests/test_is_k_incoherent.py
+++ b/toqito/matrix_props/tests/test_is_k_incoherent.py
@@ -175,13 +175,6 @@ def test_sdp_branch(mat, k, expected):
     assert is_k_incoherent(mat, k) is True
 
 
-def test_is_k_incoherent_deprecated_tol_alias_warns():
-    """The deprecated `tol` keyword still works but emits a DeprecationWarning."""
-    diag = np.diag([0.5, 0.5])
-    with pytest.warns(DeprecationWarning, match="tol"):
-        assert is_k_incoherent(diag, 1, tol=1e-15) is True
-
-
 def test_non_square():
     """Ensure non-square input is flagged."""
     # Construct a non-square matrix.
@@ -204,7 +197,7 @@ def test_hierarchical_recursion(monkeypatch):
     orig_is_k_incoherent = is_k_incoherent
 
     # Monkey-patch is_k_incoherent so that when called with k == 2 it returns True.
-    def fake_is_k_incoherent(mat, k, rtol=1e-05, atol=1e-15, *, tol=None):
+    def fake_is_k_incoherent(mat, k, rtol=1e-05, atol=1e-15):
         if k == 2:
             return True
         else:
@@ -231,7 +224,7 @@ def test_hierarchical_recursion_branch():
     orig_is_k_incoherent = is_k_incoherent.__globals__["is_k_incoherent"]
 
     # Override is_k_incoherent so that when called with k==2 it returns True.
-    def fake_is_k_incoherent(mat, k, rtol=1e-05, atol=1e-15, *, tol=None):
+    def fake_is_k_incoherent(mat, k, rtol=1e-05, atol=1e-15):
         if k == 2:
             return True
         else:

--- a/toqito/matrix_props/tests/test_is_rank_one.py
+++ b/toqito/matrix_props/tests/test_is_rank_one.py
@@ -33,13 +33,6 @@ def test_small_singular_values_respected_by_tolerance():
     np.testing.assert_equal(is_rank_one(singular_values, rtol=1e-8), True)
 
 
-def test_deprecated_tol_alias_warns():
-    """The deprecated `tol` keyword still works but emits a DeprecationWarning."""
-    singular_values = np.diag([1.0, 1e-9])
-    with pytest.warns(DeprecationWarning, match="tol"):
-        np.testing.assert_equal(is_rank_one(singular_values, tol=1e-8), True)
-
-
 def test_is_rank_one_scale_invariant():
     """Rank detection does not depend on the overall scale of the matrix."""
     # A small scalar multiple of a rank-2 matrix is still rank 2 (the old absolute tolerance reported rank <= 1).

--- a/toqito/matrix_props/tests/test_is_totally_positive.py
+++ b/toqito/matrix_props/tests/test_is_totally_positive.py
@@ -51,9 +51,3 @@ def test_is_totally_positive_invalid(mat, tol, sub_sizes):
     """Test function works as expected for an invalid input."""
     with pytest.raises(ValueError, match=re.escape("Cannot determine total positivity of an empty matrix.")):
         is_totally_positive(mat, atol=tol, sub_sizes=sub_sizes)
-
-
-def test_is_totally_positive_deprecated_tol_alias_warns():
-    """The deprecated `tol` keyword still works but emits a DeprecationWarning."""
-    with pytest.warns(DeprecationWarning, match="tol"):
-        np.testing.assert_equal(is_totally_positive(np.array([[1, 2], [2, 5]]), tol=1e-6), True)


### PR DESCRIPTION
Scrubs the project's deprecation shims in favor of hard removal — no `DeprecationWarning`s or backward-compat cruft anywhere.

## Removed

**Channels** — drop the legacy `input_mat` parameter (`amplitude_damping`, `bitflip`, `phase_damping`, `pauli_channel`). They now always return the channel (Choi matrix, or Kraus operators with `return_kraus_ops=True`). To apply a channel to a state, use `apply_channel(state, channel(...))`.

**Predicates** — drop the deprecated `tol` alias (`is_rank_one`, `is_k_incoherent`, `is_totally_positive`); use `rtol` / `atol`.

Also removes the deprecation tests, the now-obsolete `test_invalid_dimension` tests (which only existed to check the `input_mat` shape guard), and the unused `warnings` imports.

**Left in place:** `docs/content/gallery_conf.py` — that note is about a *Python 3.12* deprecation (`ast.Str`/`.s`) it works around, not a toqito deprecation.

## Breaking change (no shims)

External code passing `input_mat=` to these channels or `tol=` to these predicates will now raise `TypeError` instead of emitting a warning. No production code in toqito used the deprecated arguments (only the deprecation tests, now removed).

## Verification

- `import toqito` clean; channels return operators; affected test files pass (102).
- `ruff check` / `format` clean.
- Full suite run pending in CI.

## Checklist
  -  [x] `ruff` clean.
  -  [x] Tests pass (affected files; full suite in CI).