### PR TITLE
test(channels): 100% coverage for dephasing and depolarizing

### DIFF
--- a/toqito/channels/tests/test_dephasing.py
+++ b/toqito/channels/tests/test_dephasing.py
@@ -38,3 +38,29 @@ def test_dephasing_invalid_param_p(param_p):
     """An out-of-range dephasing parameter raises a clear ValueError."""
     with pytest.raises(ValueError, match=re.escape("The dephasing parameter must be between 0 and 1.")):
         dephasing(2, param_p)
+
+
+@pytest.mark.parametrize("param_p", [0.0, 0.5, 1.0])
+def test_dephasing_kraus_ops_match_choi(param_p):
+    """`return_kraus_ops=True` gives a Kraus decomposition equivalent to the Choi form."""
+    dim = 3
+    rho = np.arange(1, 10, dtype=complex).reshape(3, 3) + 1j * np.arange(9, 0, -1).reshape(3, 3)
+
+    kraus_ops = dephasing(dim, param_p, return_kraus_ops=True)
+    assert isinstance(kraus_ops, list)
+    assert all(k.shape == (dim, dim) for k in kraus_ops)
+
+    via_kraus = sum(k @ rho @ k.conj().T for k in kraus_ops)
+    via_choi = apply_channel(rho, dephasing(dim, param_p))
+    np.testing.assert_allclose(via_kraus, via_choi, atol=1e-12)
+
+
+def test_dephasing_kraus_ops_endpoints():
+    """At `p = 1` the only Kraus operator is the identity; at `p = 0` there are `dim` projectors."""
+    dim = 3
+    kraus_identity = dephasing(dim, 1.0, return_kraus_ops=True)
+    assert len(kraus_identity) == 1
+    np.testing.assert_allclose(kraus_identity[0], np.eye(dim))
+
+    kraus_complete = dephasing(dim, 0.0, return_kraus_ops=True)
+    assert len(kraus_complete) == dim

--- a/toqito/channels/tests/test_depolarizing.py
+++ b/toqito/channels/tests/test_depolarizing.py
@@ -38,3 +38,29 @@ def test_depolarizing_invalid_param_p(param_p):
     """Test invalid input to param_p."""
     with pytest.raises(ValueError, match=re.escape("The depolarizing probability must be between 0 and 1.")):
         depolarizing(2, param_p)
+
+
+@pytest.mark.parametrize("param_p", [0.0, 0.5, 1.0])
+def test_depolarizing_kraus_ops_match_choi(param_p):
+    """`return_kraus_ops=True` gives a Kraus decomposition equivalent to the Choi form."""
+    dim = 3
+    rho = np.arange(1, 10, dtype=complex).reshape(3, 3) + 1j * np.arange(9, 0, -1).reshape(3, 3)
+
+    kraus_ops = depolarizing(dim, param_p, return_kraus_ops=True)
+    assert isinstance(kraus_ops, list)
+    assert all(k.shape == (dim, dim) for k in kraus_ops)
+
+    via_kraus = sum(k @ rho @ k.conj().T for k in kraus_ops)
+    via_choi = apply_channel(rho, depolarizing(dim, param_p))
+    np.testing.assert_allclose(via_kraus, via_choi, atol=1e-12)
+
+
+def test_depolarizing_kraus_ops_endpoints():
+    """At `p = 1` the only Kraus operator is the identity; at `p = 0` there are `dim**2` operators."""
+    dim = 3
+    kraus_identity = depolarizing(dim, 1.0, return_kraus_ops=True)
+    assert len(kraus_identity) == 1
+    np.testing.assert_allclose(kraus_identity[0], np.eye(dim))
+
+    kraus_complete = depolarizing(dim, 0.0, return_kraus_ops=True)
+    assert len(kraus_complete) == dim**2


### PR DESCRIPTION
The `return_kraus_ops=True` branch of `dephasing` and `depolarizing` was never exercised by any test, leaving both modules well under full coverage (dephasing 41%, depolarizing 44% from their own test files).

Adds tests that:
- reconstruct the channel from its returned Kraus operators and check it equals the Choi form, across `p` in {0, 0.5, 1} (covering the identity-append, the loop, and the zero-weight skip branches);
- check the operator set at the endpoints (`p = 1` gives a single identity operator; `p = 0` gives `dim` projectors for dephasing and `dim**2` operators for depolarizing).

Both modules are now at 100% coverage. No source changes.