### PR TITLE
test: cover untested branches in permutation_operator, is_positive, tensor_unravel, partial_transpose

### DIFF
--- a/toqito/channel_props/tests/test_is_positive.py
+++ b/toqito/channel_props/tests/test_is_positive.py
@@ -25,3 +25,9 @@ def test_is_positive_transpose_not_completely_positive():
     transpose_choi = swap_operator(2)
     np.testing.assert_equal(is_positive(transpose_choi), True)
     np.testing.assert_equal(is_completely_positive(transpose_choi), False)
+
+
+def test_is_positive_non_hermitian_choi_false():
+    """A non-Hermitian Choi matrix cannot come from a positive (Hermiticity-preserving) map."""
+    non_hermitian = np.array([[1, 2, 3, 4], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]], dtype=complex)
+    np.testing.assert_equal(is_positive(non_hermitian), False)

--- a/toqito/matrix_ops/tests/test_partial_transpose.py
+++ b/toqito/matrix_ops/tests/test_partial_transpose.py
@@ -2,6 +2,7 @@
 
 import cvxpy
 import numpy as np
+import pytest
 from cvxpy.atoms.affine.vstack import Vstack
 
 from toqito.matrix_ops import partial_transpose
@@ -738,3 +739,16 @@ def test_partial_transpose_three_subsystems():
 
     expected = np.kron(np.eye(2, 2), mat.T)
     np.testing.assert_equal(np.allclose(res, expected), True)
+
+
+def test_partial_transpose_scalar_float_dim():
+    """A scalar float `dim` is accepted (covers the float-to-array branch)."""
+    rho = np.arange(16).reshape(4, 4)
+    np.testing.assert_allclose(partial_transpose(rho, dim=2.0), partial_transpose(rho, dim=[2, 2]))
+
+
+def test_partial_transpose_scalar_dim_not_divisor():
+    """A scalar `dim` that does not evenly divide the matrix raises a ValueError."""
+    rho = np.arange(16).reshape(4, 4)
+    with pytest.raises(ValueError, match="InvalidDim"):
+        partial_transpose(rho, dim=3.0)

--- a/toqito/matrix_ops/tests/test_tensor_unravel.py
+++ b/toqito/matrix_ops/tests/test_tensor_unravel.py
@@ -33,3 +33,9 @@ def test_tensor_unravel(tensor_input, expected_output, expected_exception):
     else:
         result = tensor_unravel(tensor)
         assert np.array_equal(result, expected_output)
+
+
+def test_tensor_unravel_unique_is_smaller_value():
+    """The unique element can be the smaller of the two values (covers the counts[0] branch)."""
+    tensor = np.array([[1, 1], [1, -1]])
+    np.testing.assert_array_equal(tensor_unravel(tensor), np.array([1, 1, -1]))

--- a/toqito/perms/tests/test_permutation_operator.py
+++ b/toqito/perms/tests/test_permutation_operator.py
@@ -89,3 +89,10 @@ def test_permutation_operator_dim_2_2_perm_1_0():
     expected_res = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
     bool_mat = np.isclose(res, expected_res)
     np.testing.assert_equal(np.all(bool_mat), True)
+
+
+def test_permutation_operator_dim_as_array():
+    """`dim` provided as a numpy array is accepted (covers the ndarray branch)."""
+    res = permutation_operator(np.array([2, 2]), [1, 0])
+    expected_res = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+    np.testing.assert_allclose(res, expected_res)


### PR DESCRIPTION
Follow-up to the dephasing/depolarizing coverage work. Adds direct unit tests for branches that each module's own test suite left uncovered:

- `perms/permutation_operator`: `dim` passed as a numpy array (the non-int, non-list branch).
- `channel_props/is_positive`: a non-Hermitian Choi matrix returns `False` (a positive map is Hermiticity-preserving).
- `matrix_ops/tensor_unravel`: the unique element is the smaller of the two values (the `counts[0] == 1` branch).
- `matrix_ops/partial_transpose`: a scalar float `dim`, and a scalar `dim` that does not evenly divide the matrix (the `InvalidDim` error path).

Each of the four modules is now at 100% coverage. No source changes.