### PR TITLE
test(channel_ops): cover kraus_to_choi general sys branch and partial_channel non-CP path

### DIFF
--- a/toqito/channel_ops/tests/test_kraus_to_choi.py
+++ b/toqito/channel_ops/tests/test_kraus_to_choi.py
@@ -156,3 +156,13 @@ def test_kraus_to_choi_accepts_stacked_ndarray():
     kraus_list = [np.array([[1, 0], [0, 0]], dtype=complex), np.array([[0, 0], [0, 1]], dtype=complex)]
     stacked = np.stack(kraus_list)
     np.testing.assert_allclose(kraus_to_choi(stacked), kraus_to_choi(kraus_list))
+
+
+def test_kraus_to_choi_general_sys_branch():
+    """The general (non-fast-path) `sys` branch yields a valid Choi matrix for a CP map."""
+    pauli_x = np.array([[0, 1], [1, 0]], dtype=complex)
+    choi = kraus_to_choi([pauli_x], sys=1)
+    assert choi.shape == (4, 4)
+    herm = (choi + choi.conj().T) / 2
+    np.testing.assert_allclose(choi, herm)
+    assert np.linalg.eigvalsh(herm).min() > -1e-10

--- a/toqito/channel_ops/tests/test_partial_channel.py
+++ b/toqito/channel_ops/tests/test_partial_channel.py
@@ -164,3 +164,13 @@ def test_partial_channel_error(test_input, map_arg, sys_arg, dim_arg):
 
     with pytest.raises(ValueError):
         partial_channel(test_input, map_arg)
+
+
+def test_partial_channel_non_cp_map_explicit_dim():
+    """A non-CP map given as [left, right] operator pairs, applied with an explicit 2D `dim`."""
+    rho = np.arange(16, dtype=complex).reshape(4, 4)
+    a = np.array([[1, 2], [3, 4]], dtype=complex)
+    b = np.array([[0, 1], [1, 1]], dtype=complex)
+    res = partial_channel(rho, [[a, b]], sys=2, dim=np.array([[2, 2], [2, 2]]))
+    expected = np.kron(np.eye(2), a) @ rho @ np.kron(np.eye(2), b).conj().T
+    np.testing.assert_allclose(res, expected)


### PR DESCRIPTION
Continuing the coverage sweep, both in `channel_ops`:

- `kraus_to_choi`: the general (non-fast-path) `sys` branch (lines 80-90) was never exercised. Adds a test that it returns a valid Choi matrix (correct shape, Hermitian, PSD) for a CP map.
- `partial_channel`: the non-completely-positive branch (a map given as `[left, right]` operator pairs) and the explicit 2D `dim` path were untested. Adds a test that checks the output against a direct `(I (x) A) rho (I (x) B)^dagger` computation.

Both modules reach 100% coverage. No source changes.