### PR TITLE
test(rand): cover redraw loop and Wishart valid-scale branches

### DIFF
--- a/toqito/rand/tests/test_random_linearly_independent_vectors.py
+++ b/toqito/rand/tests/test_random_linearly_independent_vectors.py
@@ -72,3 +72,18 @@ def test_square_case():
     mat = random_linearly_independent_vectors(5, 5, seed=0)
     assert mat.shape == (5, 5)
     assert np.linalg.matrix_rank(mat) == 5
+
+
+def test_random_linearly_independent_vectors_redraws_on_rank_deficiency(monkeypatch):
+    """A rank-deficient draw triggers a redraw (covers the loop-back branch)."""
+    real_rank = np.linalg.matrix_rank
+    calls = {"n": 0}
+
+    def fake_rank(mat):
+        calls["n"] += 1
+        return 0 if calls["n"] == 1 else real_rank(mat)
+
+    monkeypatch.setattr(np.linalg, "matrix_rank", fake_rank)
+    res = random_linearly_independent_vectors(2, 3, seed=0)
+    assert res.shape == (3, 2)
+    assert calls["n"] >= 2

--- a/toqito/rand/tests/test_random_psd_operator.py
+++ b/toqito/rand/tests/test_random_psd_operator.py
@@ -185,3 +185,12 @@ def test_random_psd_operator_wishart_rank_deficient_warning():
     """Test that num_degrees < dim raises a UserWarning about rank deficiency."""
     with pytest.warns(UserWarning, match="rank-deficient"):
         random_psd_operator(4, distribution="wishart", num_degrees=2)
+
+
+def test_random_psd_operator_wishart_valid_scale():
+    """A valid PSD `scale` under the Wishart distribution is accepted (covers the valid-scale branch)."""
+    dim = 3
+    op = random_psd_operator(dim, distribution="wishart", scale=2 * np.eye(dim), num_degrees=5, seed=1)
+    assert op.shape == (dim, dim)
+    assert_allclose(op, op.conj().T)
+    assert is_positive_semidefinite(op)


### PR DESCRIPTION
Two more branch gaps in `rand`:

- `random_linearly_independent_vectors`: the rank-deficient redraw loop (the function redraws until it gets a full-rank matrix) was never exercised, since random Gaussian draws are full-rank almost surely. Covered by monkeypatching the rank check to force one retry.
- `random_psd_operator`: the branch where a valid PSD `scale` is supplied under `distribution="wishart"` was untested (existing tests only hit the invalid-scale error path).

Both modules reach 100% coverage. No source changes.