### PR TITLE
test(state_props): cover untested branches in is_product, schmidt_rank, tsallis_relative_entropy

### DIFF
--- a/toqito/state_props/tests/test_is_product.py
+++ b/toqito/state_props/tests/test_is_product.py
@@ -38,3 +38,11 @@ def test_is_product(rho, dim, expected_result):
     """Test function works as expected for a valid input."""
     ipv, _ = is_product(rho=rho, dim=dim)
     np.testing.assert_equal(ipv, expected_result)
+
+
+def test_is_product_multipartite_entangled_subfactor():
+    """A tripartite state that is product across (12|3) but entangled in (1|2) is not a product state."""
+    bell_12 = np.array([1, 0, 0, 1]) / np.sqrt(2)
+    state = np.kron(bell_12, np.array([1, 0]))
+    ipv, _ = is_product(state, [2, 2, 2])
+    assert not np.all(ipv)

--- a/toqito/state_props/tests/test_schmidt_rank.py
+++ b/toqito/state_props/tests/test_schmidt_rank.py
@@ -62,3 +62,9 @@ def test_schmidt_rank_singlet_state():
     """Computing the Schmidt rank of the entangled singlet state should yield a value greater than 1."""
     rho = 1 / np.sqrt(2) * (np.kron(e_0, e_1) - np.kron(e_1, e_0))
     np.testing.assert_equal(schmidt_rank(rho) > 1, True)
+
+
+def test_schmidt_rank_one_dimensional_vector():
+    """A 1D (non-column) vector input is handled (covers the vector branch)."""
+    bell_1d = np.array([1, 0, 0, 1]) / np.sqrt(2)
+    assert schmidt_rank(bell_1d) == 2

--- a/toqito/state_props/tests/test_tsallis_relative_entropy.py
+++ b/toqito/state_props/tests/test_tsallis_relative_entropy.py
@@ -194,3 +194,10 @@ def test_tsallis_relative_entropy_rejects_nonconstant_quadratic() -> None:
     y_c = cvxpy.Constant(np.eye(2) / 2)
     with pytest.raises(ValueError, match=_NOT_SUPPORTED):
         tsallis_relative_entropy(cvxpy.square(x_var), y_c, 0.5)
+
+
+def test_tsallis_relative_entropy_constant_y_no_value():
+    """A constant CVXPY `mat_y` with no numeric value raises a clear ValueError."""
+    mat_y = cvxpy.Parameter((2, 2))
+    with pytest.raises(ValueError, match=re.escape("Constant CVXPY expression has no numeric value")):
+        tsallis_relative_entropy(np.eye(2) / 2, mat_y, 0.5)


### PR DESCRIPTION
Three more branch gaps in `state_props`:

- `is_product`: the branch where a multipartite state is product across the top cut but a sub-factor is entangled (so the overall state is not a product). Covered with a tripartite state that is product across (12|3) but entangled across (1|2).
- `schmidt_rank`: a 1D (non-column) vector input, which skips the operator-Schmidt-rank path.
- `tsallis_relative_entropy`: a constant CVXPY `mat_y` whose `.value` is `None` raises a clear `ValueError`.

All three modules reach 100% coverage. No source changes.