### PR TITLE
refactor: remove dead branches in tensor and swap (100% coverage)

### DIFF
--- a/toqito/matrix_ops/tensor.py
+++ b/toqito/matrix_ops/tensor.py
@@ -130,10 +130,9 @@ def tensor(*args: np.ndarray | int | list[np.ndarray]) -> np.ndarray:
             return args[0][0]
         if len(args[0]) == 2:
             return np.kron(args[0][0], args[0][1])
-        if len(args[0]) >= 3:
-            result = args[0][0]
-            for i in range(1, len(args[0])):
-                result = np.kron(result, args[0][i])
+        result = args[0][0]
+        for i in range(1, len(args[0])):
+            result = np.kron(result, args[0][i])
         return result
 
     # Tensor product one matrix `n` times with itself.

--- a/toqito/perms/swap.py
+++ b/toqito/perms/swap.py
@@ -137,7 +137,8 @@ def swap(
             raise ValueError("InvalidDim: The value of dim must evenly divide the number of rows and columns of rho.")
         dim = np.array([[dim, rho_dims[0] // dim], [dim, rho_dims[1] // dim]], dtype=int)
         num_sys = 2
-    elif isinstance(dim, (list, np.ndarray)):
+    else:
+        # `dim` is a list or ndarray here; other types are rejected by the check above.
         if not all(isinstance(d, (int, float, np.integer, np.floating)) for d in np.ravel(dim)):
             raise TypeError("dim entries must be int or float values.")
         dim = np.array(dim, dtype=int)


### PR DESCRIPTION
Two functions had a branch that coverage flags as never taken because it is unreachable:

- `matrix_ops/tensor`: the length 0, 1, and 2 cases all return above, so `if len(args[0]) >= 3` is always true. Drop the guard and run the Kronecker loop directly.
- `perms/swap`: an upstream check already rejects any `dim` that is not `None`/`int`/`list`/`ndarray`, so by the time the third branch is reached `dim` is always a list or ndarray. Change the `elif isinstance(dim, (list, np.ndarray))` to a plain `else`.

No behavior change; both modules reach 100% coverage. Existing tests cover the retained paths.