### PR TITLE
test: cover branches in _is_power_of_two, is_absolutely_k_incoherent, nonnegative_rank

### DIFF
--- a/toqito/cones/tests/test_utils.py
+++ b/toqito/cones/tests/test_utils.py
@@ -1,0 +1,13 @@
+"""Tests for cones._utils helpers."""
+
+from toqito.cones._utils import _is_power_of_two
+
+
+def test_is_power_of_two():
+    """Powers of two are detected; non-positive and non-powers are rejected."""
+    assert _is_power_of_two(1) is True
+    assert _is_power_of_two(2) is True
+    assert _is_power_of_two(8) is True
+    assert _is_power_of_two(6) is False
+    assert _is_power_of_two(0) is False
+    assert _is_power_of_two(-4) is False

--- a/toqito/matrix_props/tests/test_is_absolutely_k_incoherent.py
+++ b/toqito/matrix_props/tests/test_is_absolutely_k_incoherent.py
@@ -113,3 +113,9 @@ def test_k_equals_n_minus_one_large_eigenvalue():
     """When k = n - 1 and the largest eigenvalue exceeds the bound, return False immediately."""
     mat = np.diag([0.9, 0.05, 0.05, 0.0])
     assert is_absolutely_k_incoherent(mat, 3) is False
+
+
+def test_is_absolutely_k_incoherent_k_outside_two_and_n_minus_one():
+    """A peaked spectrum with k outside {2, n-1} falls through to the final `return False`."""
+    rho = np.diag([0.9, 0.05, 0.03, 0.01, 0.01])
+    assert is_absolutely_k_incoherent(rho, 3) is False

--- a/toqito/matrix_props/tests/test_nonnegative_rank.py
+++ b/toqito/matrix_props/tests/test_nonnegative_rank.py
@@ -79,3 +79,10 @@ def test_known_nonneg_rank_exceeds_standard_rank():
 def test_check_nn_rank_anls_returns_false_when_k_too_small():
     """Directly exercise the non-convergent branch: no rank-1 nonneg factorization of I_3."""
     assert not _check_nn_rank_anls(np.eye(3), k=1, tol=1e-6)
+
+
+def test_nonnegative_rank_exceeds_matrix_rank():
+    """A matrix whose nonnegative rank exceeds its rank forces the search past the first candidate."""
+    mat = np.array([[1, 1, 0, 0], [0, 1, 1, 0], [0, 0, 1, 1], [1, 0, 0, 1]], dtype=float)
+    assert np.linalg.matrix_rank(mat) == 3
+    assert nonnegative_rank(mat) == 4


### PR DESCRIPTION
Gaps identified from the full-suite codecov report (not reachable via the fast local runs):

- `cones/_utils._is_power_of_two`: the non-positive-input branch (`n <= 0`).
- `matrix_props/is_absolutely_k_incoherent`: a peaked spectrum with `k` outside `{2, n-1}`, which falls through to the final `return False`.
- `matrix_props/nonnegative_rank`: a matrix whose nonnegative rank (4) exceeds its rank (3), forcing the search loop past its first candidate.

All fast and deterministic. No source changes.