### PR TITLE
ci: make codecov upload non-blocking

### DIFF
--- a/.github/workflows/build-test-actions.yml
+++ b/.github/workflows/build-test-actions.yml
@@ -80,7 +80,9 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           use_oidc: true
-          fail_ci_if_error: true
+          # Coverage upload is informational; a transient codecov CLI/CDN or
+          # signature-verification failure should not red an otherwise-green build.
+          fail_ci_if_error: false
           files: ./coverage.xml
           verbose: true
       - name: Build artifacts


### PR DESCRIPTION
A recent master build failed even though every test job was green: the `codecov/codecov-action` step could not verify the signature of the codecov CLI it downloaded (a transient issue on codecov's CDN/signing side), and `fail_ci_if_error: true` turned that into a job failure.

Coverage upload is informational, so a codecov infrastructure hiccup should not red an otherwise-green build. This sets `fail_ci_if_error: false`. Codecov still uploads normally when healthy; when its tooling flakes, CI stays green and you notice via the coverage report not updating rather than a spurious red build.