### PR TITLE
docs: use lowercase parameter names in channel_dim error messages

### DIFF
--- a/toqito/channel_metrics/tests/test_completely_bounded_trace_norm.py
+++ b/toqito/channel_metrics/tests/test_completely_bounded_trace_norm.py
@@ -70,7 +70,7 @@ def test_cb_trace_norm_rectangular(test_input, expected):
 def test_cb_trace_norm_rectangular_requires_dim():
     """A Choi matrix with unequal input/output dimensions requires the `dim` argument."""
     choi = kraus_to_choi([[isometry_1, isometry_1]])
-    with pytest.raises(ValueError, match="the optional argument DIM must be specified"):
+    with pytest.raises(ValueError, match="the optional argument dim must be specified"):
         completely_bounded_trace_norm(choi)
 
 

--- a/toqito/channel_props/channel_dim.py
+++ b/toqito/channel_props/channel_dim.py
@@ -82,10 +82,10 @@ def channel_dim(
 
         # Now do some error checking.
         if (dim_in[0] != dim_in[1] or dim_out[0] != dim_out[1]) and not allow_rect:
-            raise ValueError("The input and output spaces of PHI must be square.")
+            raise ValueError("The input and output spaces of phi must be square.")
 
         if np.any(dim != np.vstack([dim_in, dim_out]).T):
-            raise ValueError("The dimensions of PHI do not match those provided in the DIM argument.")
+            raise ValueError("The dimensions of phi do not match those provided in the dim argument.")
 
         if (is_cpt and any(k_mat.shape != (dim[0, 1], dim[0, 0]) for k_mat in left_ops)) or (
             not is_cpt
@@ -94,7 +94,7 @@ def channel_dim(
                 for left, right in zip(left_ops, right_ops)
             )
         ):
-            raise ValueError("The Kraus operators of PHI do not all have the same size.")
+            raise ValueError("The Kraus operators of phi do not all have the same size.")
 
     # If Phi is a Choi matrix, the dimensions are a bit more of a pain: we have
     # to guess a bit if the input and output dimensions are different.
@@ -110,13 +110,13 @@ def channel_dim(
 
         if dim[0, 0] * dim[0, 1] != rows or dim[1, 0] * dim[1, 1] != cols:
             raise ValueError(
-                "If the input and output dimensions are unequal and PHI is provided "
-                "as a Choi matrix, the optional argument DIM must be specified "
-                "(and its dimensions must agree with PHI)."
+                "If the input and output dimensions are unequal and phi is provided "
+                "as a Choi matrix, the optional argument dim must be specified "
+                "(and its dimensions must agree with phi)."
             )
 
         if (dim[0, 0] != dim[1, 0] or dim[0, 1] != dim[1, 1]) and not allow_rect:
-            raise ValueError("The input and output spaces of PHI must be square.")
+            raise ValueError("The input and output spaces of phi must be square.")
 
         # environment dimension is the rank of the Choi matrix
         dim_e = None


### PR DESCRIPTION
## Summary

Fixes 6 user-facing `ValueError` messages in `channel_dim.py` that referenced parameters by their MATLAB/QETLAB-style uppercase names (`PHI`, `DIM`) instead of the actual Python parameter names (`phi`, `dim`).

## Problem

When a user hit one of these errors, they could not map `PHI` or `DIM` to any argument they had passed, since the function signature uses lowercase `phi` and `dim`.

## Changes

| Before | After |
|--------|-------|
| `"The input and output spaces of PHI must be square."` | `"The input and output spaces of phi must be square."` |
| `"The dimensions of PHI do not match those provided in the DIM argument."` | `"The dimensions of phi do not match those provided in the dim argument."` |
| `"The Kraus operators of PHI do not all have the same size."` | `"The Kraus operators of phi do not all have the same size."` |
| `"If ... PHI is provided ... DIM must be specified ... agree with PHI"` | `"If ... phi is provided ... dim must be specified ... agree with phi"` |

Developer-facing comments are unchanged.

Fixes #1885