### PR TITLE
perf: vectorize standard basis construction

### DIFF
--- a/toqito/matrices/standard_basis.py
+++ b/toqito/matrices/standard_basis.py
@@ -35,9 +35,7 @@ def standard_basis(dim: int, flatten: bool = False) -> list[np.ndarray]:
         ```
 
     """
-    first_basis_vector = np.zeros(dim) if flatten else np.zeros((dim, 1))
-    first_basis_vector[0] = 1.0
-
-    # The standard_basis is obtained by cyclic permutations of the first basis
-    # vector
-    return [np.array([first_basis_vector[i - j] for i in range(dim)]) for j in range(dim)]
+    basis = np.eye(dim)
+    if not flatten:
+        basis = basis[..., np.newaxis]
+    return list(basis)

--- a/toqito/matrices/tests/test_standard_basis.py
+++ b/toqito/matrices/tests/test_standard_basis.py
@@ -1,23 +1,24 @@
 """Test standard_basis."""
 
 import numpy as np
+import pytest
 
 from toqito.matrices import standard_basis
 
 
-def test_standard_basis_2_d():
-    """Return the standard basis in 2 dimensions."""
-    basis = standard_basis(2)
-    expected_basis = [np.array([1, 0]).reshape(-1, 1), np.array([0, 1]).reshape(-1, 1)]
+@pytest.mark.parametrize("dim", [1, 2, 5])
+def test_standard_basis(dim):
+    """Return the standard basis in the requested dimension."""
+    basis = standard_basis(dim)
+    expected_basis = [vector.reshape(-1, 1) for vector in np.eye(dim)]
 
-    assert np.allclose(basis[0], expected_basis[0])
-    assert np.allclose(basis[1], expected_basis[1])
+    assert all(np.array_equal(actual, expected) for actual, expected in zip(basis, expected_basis))
 
 
-def test_standard_basis_2_d_flatten():
-    """Return the standard basis in 2 dimensions flattened."""
-    basis = standard_basis(2, flatten=True)
-    expected_basis = [np.array([1, 0]), np.array([0, 1])]
+@pytest.mark.parametrize("dim", [1, 2, 5])
+def test_standard_basis_flatten(dim):
+    """Return the flattened standard basis in the requested dimension."""
+    basis = standard_basis(dim, flatten=True)
+    expected_basis = list(np.eye(dim))
 
-    assert np.allclose(basis[0], expected_basis[0])
-    assert np.allclose(basis[1], expected_basis[1])
+    assert all(np.array_equal(actual, expected) for actual, expected in zip(basis, expected_basis))


### PR DESCRIPTION
﻿## Summary

- replace the Python-level standard-basis construction loop with `numpy.eye`
- preserve flattened and column-vector output shapes
- broaden exact-output coverage across dimensions 1, 2, and 5

## Performance

Measured locally with Python 3.13 and NumPy through the project `uv` environment:

| Dimension | Previous | Vectorized | Speedup |
| --- | ---: | ---: | ---: |
| 32 | 1313.3 us/call | 16.8 us/call | 78.0x |
| 128 | 18848.0 us/call | 58.8 us/call | 320.4x |

The benchmark also asserted `np.array_equal` between the previous and new outputs.

## Validation

- `uv run pytest toqito/matrices/tests -q` (143 passed)
- `uv run ruff check toqito/matrices/standard_basis.py toqito/matrices/tests/test_standard_basis.py`
- `uv run ruff format --check toqito/matrices/standard_basis.py toqito/matrices/tests/test_standard_basis.py`
- `git diff --check`

Closes #1887
