### PR TITLE
docs: convert reStructuredText docstring roles to MkDocs syntax (#1884)

### DIFF
--- a/toqito/channel_opt/channel_distinguishability.py
+++ b/toqito/channel_opt/channel_distinguishability.py
@@ -96,7 +96,7 @@ def channel_distinguishability(
     Returns:
         A tuple ``(value, operators)``. ``value`` is the optimal probability of discriminating the
         channels. ``operators`` holds the optimal strategy operators for the SDP branches (the
-        measurement operators :math:`P_i` for ``primal_dual="primal"`` and the dual operator for
+        measurement operators \(P_i\) for ``primal_dual="primal"`` and the dual operator for
         ``primal_dual="dual"``) and is an empty list for the closed-form two-channel Bayesian
         branch and for degenerate priors.
 

--- a/toqito/matrix_props/trace_matrix_log.py
+++ b/toqito/matrix_props/trace_matrix_log.py
@@ -25,7 +25,7 @@ def trace_matrix_log(
     This function evaluates the formula numerically. Constant CVXPY expressions
     with a concrete ``.value`` are routed through the numeric path. Affine or
     variable CVXPY inputs are not supported; use
-    :func:`~toqito.cones.trace_matrix_log_hypo_cone` for composition in a
+    [trace_matrix_log_hypo_cone][toqito.cones.trace_matrix_log_hypo_cone] for composition in a
     parent SDP (with quadrature parameters ``m``, ``k``, ``apx``).
 
     Args:

--- a/toqito/nonlocal_games/extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/extended_nonlocal_game.py
@@ -559,11 +559,11 @@ class ExtendedNonlocalGame:
         y: int,
         referee_dim: int,
     ) -> cvxpy.Expression:
-        r"""Return the commuting-measurement answer probability :math:`p(a, b \mid x, y)`.
+        r"""Return the commuting-measurement answer probability \(p(a, b \mid x, y)\).
 
         At NPA level 1 and above, the block
-        :math:`K_{xy}(a,b) = \mathrm{Tr}_{AB}(I_R \otimes A_a^x B_b^y \, \sigma)`
-        in the assemblage satisfies :math:`p(a,b \mid x,y) = \mathrm{Tr}\, K_{xy}(a,b)`.
+        \(K_{xy}(a,b) = \mathrm{Tr}_{AB}(I_R \otimes A_a^x B_b^y \, \sigma)\)
+        in the assemblage satisfies \(p(a,b \mid x,y) = \mathrm{Tr}\, K_{xy}(a,b)\).
         """
         block = assemblage[x, y][
             a * referee_dim : (a + 1) * referee_dim,
@@ -647,10 +647,11 @@ class ExtendedNonlocalGame:
         ``(num_alice_out, num_bob_out, num_alice_in, num_bob_in)``, ``op`` is one of
         ``"=="``, ``"<="``, or ``">="``, and ``rhs`` is a float. The constraint is
 
-        .. math::
+        \[
             \sum_{a,b,x,y} c_{abxy}\, p(a,b \mid x,y) \;\operatorname{op}\; d,
+        \]
 
-        with :math:`p(a,b \mid x,y) = \mathrm{Tr}\, K_{xy}(a,b)` at the NPA level used
+        with \(p(a,b \mid x,y) = \mathrm{Tr}\, K_{xy}(a,b)\) at the NPA level used
         (level 1 and above expose these marginals on the assemblage blocks).
 
         Args:

--- a/toqito/nonlocal_games/tests/_constrained_games_fixtures.py
+++ b/toqito/nonlocal_games/tests/_constrained_games_fixtures.py
@@ -63,7 +63,7 @@ def constrained_bb84_monogamy_answer_constraints() -> list[AnswerEventConstraint
 
 
 def constrained_bb84_monogamy_answer_constraints_dense() -> list[AnswerEventConstraint]:
-    """Dense-array form of [constrained_bb84_monogamy_answer_constraints][toqito.nonlocal_games.tests._constrained_games_fixtures]."""
+    """Dense-array form of constrained_bb84_monogamy_answer_constraints."""
     c_x0 = np.zeros((2, 2, 2, 2), dtype=float)
     c_x0[0, 1, 0, 0] = 1.0
     c_x0[1, 0, 0, 0] = 1.0

--- a/toqito/nonlocal_games/tests/_constrained_games_fixtures.py
+++ b/toqito/nonlocal_games/tests/_constrained_games_fixtures.py
@@ -49,11 +49,12 @@ def constrained_bb84_monogamy_answer_constraints() -> list[AnswerEventConstraint
     :meth:`~toqito.nonlocal_games.extended_nonlocal_game.ExtendedNonlocalGame.commuting_measurement_value_upper_bound`,
     this is
 
-    .. math::
+    \[
         \sum_{a \neq b} p(a, b \mid x, x) = 0 \quad \forall x,
+    \]
 
-    returned as one equality constraint per question :math:`x` (for the standard
-    BB84 game, :math:`x \in \{0, 1\}`).
+    returned as one equality constraint per question \(x\) (for the standard
+    BB84 game, \(x \in \{0, 1\}\)).
     """
     return [
         ({(0, 1, 0, 0): 1.0, (1, 0, 0, 0): 1.0}, "==", 0.0),
@@ -62,7 +63,7 @@ def constrained_bb84_monogamy_answer_constraints() -> list[AnswerEventConstraint
 
 
 def constrained_bb84_monogamy_answer_constraints_dense() -> list[AnswerEventConstraint]:
-    """Dense-array form of :func:`constrained_bb84_monogamy_answer_constraints`."""
+    """Dense-array form of [constrained_bb84_monogamy_answer_constraints][toqito.nonlocal_games.tests._constrained_games_fixtures]."""
     c_x0 = np.zeros((2, 2, 2, 2), dtype=float)
     c_x0[0, 1, 0, 0] = 1.0
     c_x0[1, 0, 0, 0] = 1.0
@@ -73,10 +74,10 @@ def constrained_bb84_monogamy_answer_constraints_dense() -> list[AnswerEventCons
 
 
 def forbid_bb84_diagonal_answers_at(x: int, y: int) -> list[AnswerEventConstraint]:
-    r"""Forbid both diagonal answer pairs :math:`p(0,0\mid x,y)=p(1,1\mid x,y)=0`.
+    r"""Forbid both diagonal answer pairs \(p(0,0\mid x,y)=p(1,1\mid x,y)=0\).
 
-    At NPA level 1 for the BB84 game, forbidding only :math:`p(0,0\mid 0,0)=0` does not
-    lower the commuting upper bound (the optimum can use :math:`p(1,1\mid 0,0)` instead).
+    At NPA level 1 for the BB84 game, forbidding only \(p(0,0\mid 0,0)=0\) does not
+    lower the commuting upper bound (the optimum can use \(p(1,1\mid 0,0)\) instead).
     Zeroing both diagonal events at a question pair is binding.
     """
     return [({(0, 0, x, y): 1.0, (1, 1, x, y): 1.0}, "==", 0.0)]

--- a/toqito/state_metrics/tests/test_trace_distance.py
+++ b/toqito/state_metrics/tests/test_trace_distance.py
@@ -7,7 +7,7 @@ from toqito.states import basis
 
 
 def test_trace_distance_same_state():
-    r"""Test that: :math:`T(\rho, \sigma) = 0` iff `\rho = \sigma`."""
+    r"""Test that: \(T(\rho, \sigma) = 0\) iff `\rho = \sigma`."""
     e_0, e_1 = basis(2, 0), basis(2, 1)
     e_00 = np.kron(e_0, e_0)
     e_11 = np.kron(e_1, e_1)

--- a/toqito/state_opt/bell_inequality_max.py
+++ b/toqito/state_opt/bell_inequality_max.py
@@ -787,8 +787,9 @@ def _cg_to_fp(cg_mat: np.ndarray, desc: list[int], behavior: bool = False) -> np
     r"""Convert a Bell functional or behavior from Collins-Gisin (CG) to Full Probability (FP) notation.
 
     The Collins-Gisin (CG) notation for a Bell functional or behavior is represented by a matrix
-    (see [cg_to_fc][toqito.state_opt.bell_inequality_max]). The Full Probability (FP) notation represents the full probability
-    distribution \(V(a, b, x, y) = P(a, b | x, y)\), the probability of Alice getting outcome
+    (see [cg_to_fc][toqito.state_opt.bell_inequality_max]).
+    The Full Probability (FP) notation represents the full probability distribution
+    \(V(a, b, x, y) = P(a, b | x, y)\), the probability of Alice getting outcome
     \(a\) (0 to oa-1) and Bob getting outcome \(b\) (0 to ob-1) given inputs \(x\)
     (0 to ia-1) and \(y\) (0 to ib-1). This is stored as a 4D numpy array with indices
     `V[a, b, x, y]`.

--- a/toqito/state_opt/bell_inequality_max.py
+++ b/toqito/state_opt/bell_inequality_max.py
@@ -787,7 +787,7 @@ def _cg_to_fp(cg_mat: np.ndarray, desc: list[int], behavior: bool = False) -> np
     r"""Convert a Bell functional or behavior from Collins-Gisin (CG) to Full Probability (FP) notation.
 
     The Collins-Gisin (CG) notation for a Bell functional or behavior is represented by a matrix
-    (see :func:`cg_to_fc`). The Full Probability (FP) notation represents the full probability
+    (see [cg_to_fc][toqito.state_opt.bell_inequality_max]). The Full Probability (FP) notation represents the full probability
     distribution \(V(a, b, x, y) = P(a, b | x, y)\), the probability of Alice getting outcome
     \(a\) (0 to oa-1) and Bob getting outcome \(b\) (0 to ob-1) given inputs \(x\)
     (0 to ia-1) and \(y\) (0 to ib-1). This is stored as a 4D numpy array with indices
@@ -942,7 +942,7 @@ def _fc_to_fp(fc_mat: np.ndarray, behavior: bool = False) -> np.ndarray:
     Assumes binary outcomes (\(oa=2\), \(ob=2\)) corresponding to physical values +1 and -1.
     The FP tensor indices \(a, b = 0, 1\) correspond to outcomes \(+1, -1\) respectively.
 
-    The Full Correlator (FC) notation is represented by a matrix (see :func:`.fc_to_cg`).
+    The Full Correlator (FC) notation is represented by a matrix (see [fc_to_cg][toqito.state_opt.bell_inequality_max]).
     The Full Probability (FP) notation represents the full probability distribution
     \(V(a, b, x, y) = P(\text{out}_A=a', \text{out}_B=b' | x, y)\),
     where \(a=0 \rightarrow a'=+1\), \(a=1 \rightarrow a'=-1\) (similarly for \(b\)),
@@ -1212,7 +1212,7 @@ def _fp_to_fc(v_mat: np.ndarray, behavior: bool = False) -> np.ndarray:
 
     Args:
         v_mat: The probability tensor \(V[a, b, x, y]\)
-                          in Full Probability notation (:math:`oa=2`, :math:`ob=2`).
+                          in Full Probability notation (\(oa=2\), \(ob=2\)).
         behavior: If True, assume input is a behavior (default: False, assume functional).
 
     Returns:

--- a/toqito/state_opt/tests/test_ppt_distinguishability.py
+++ b/toqito/state_opt/tests/test_ppt_distinguishability.py
@@ -220,16 +220,18 @@ def test_ppt_distinguishability_four_bell_states():
 
     The resource state is defined by
 
-    .. math::
+    \[
         |\tau_{\epsilon} \rangle = \sqrt{\frac{1+\epsilon}{2}} +
         |0\rangle | 0\rangle +
         \sqrt{\frac{1-\epsilon}{2}} |1 \rangle |1 \rangle
+    \]
 
     The closed form probability with which Alice and Bob can distinguish via
     PPT measurements is given as follows
 
-    .. math::
+    \[
         \frac{1}{2} \left(1 + \sqrt{1 - \epsilon^2} \right).
+    \]
 
     This formula happens to be equal to LOCC and SEP as well for this case.
     Refer to Theorem 5 in  :footcite:`Bandyopadhyay_2015_Limitations` for more details.

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -642,20 +642,20 @@ def is_separable(
 
 
 def _choi_1975_choi_matrix() -> np.ndarray:
-    r"""Return the Choi matrix of Choi's 1975 indecomposable positive map on :math:`M_3`.
+    r"""Return the Choi matrix of Choi's 1975 indecomposable positive map on \(M_3\).
 
-    The map :math:`\Phi: M_3 \to M_3` is defined by
+    The map \(\Phi: M_3 \to M_3\) is defined by
 
-    .. math::
-
+    \[
         \Phi(A)_{00} = A_{00} + A_{22}, \quad
         \Phi(A)_{11} = A_{00} + A_{11}, \quad
         \Phi(A)_{22} = A_{11} + A_{22}, \quad
         \Phi(A)_{ij} = -A_{ij} \text{ for } i \neq j.
+    \]
 
     It is a standard example from [@choi1975] of a positive but not
     completely positive map — its Choi matrix has a negative eigenvalue — and
-    is used in :func:`is_separable` as an entanglement witness.
+    is used in [is_separable][toqito.state_props.is_separable] as an entanglement witness.
     """
     # Diagonal blocks carry Phi(E_ii) along the block diagonal.
     diag_action = [
@@ -679,36 +679,36 @@ def _terhal_2000_tile_witness() -> np.ndarray:
     r"""Terhal 2000 indecomposable positive-map witness built on the 3x3 tile UPB.
 
     Implements Theorem 3 of [@terhal2000family]: given the five tile UPB
-    product vectors :math:`\{|\alpha_i\rangle \otimes |\beta_i\rangle\}_{i=0}^4`
-    spanning a 5-dimensional subspace of :math:`\mathbb{C}^3 \otimes
-    \mathbb{C}^3`, the Hermitian operator
+    product vectors \(\{|\alpha_i\rangle \otimes |\beta_i\rangle\}_{i=0}^4\)
+    spanning a 5-dimensional subspace of \(\mathbb{C}^3 \otimes
+    \mathbb{C}^3\), the Hermitian operator
 
-    .. math::
-
+    \[
         H = \sum_{i=0}^{4} |\alpha_i\rangle\langle\alpha_i| \otimes
             |\beta_i\rangle\langle\beta_i|
             - d \varepsilon |\Psi\rangle\langle\Psi|
+    \]
 
-    is an indecomposable entanglement witness, where :math:`d = 3`,
+    is an indecomposable entanglement witness, where \(d = 3\),
 
-    .. math::
-
+    \[
         \varepsilon = \min_{|\phi_A\rangle, |\phi_B\rangle}
             \sum_{i=0}^{4} |\langle\phi_A|\alpha_i\rangle|^2
                            |\langle\phi_B|\beta_i\rangle|^2,
+    \]
 
-    and :math:`|\Psi\rangle` is a maximally entangled state with
-    :math:`\langle\Psi|\rho_{\text{tile}}|\Psi\rangle > 0` (the ``standard''
-    max-ent state :math:`(|00\rangle+|11\rangle+|22\rangle)/\sqrt{3}` fails
-    this condition for the tile UPB because :math:`|\Psi\rangle` happens to
-    lie in the UPB span; we use :math:`(|10\rangle+|21\rangle+|02\rangle)/\sqrt{3}`
+    and \(|\Psi\rangle\) is a maximally entangled state with
+    \(\langle\Psi|\rho_{\text{tile}}|\Psi\rangle > 0\) (the ``standard''
+    max-ent state \((|00\rangle+|11\rangle+|22\rangle)/\sqrt{3}\) fails
+    this condition for the tile UPB because \(|\Psi\rangle\) happens to
+    lie in the UPB span; we use \((|10\rangle+|21\rangle+|02\rangle)/\sqrt{3}\)
     instead, which satisfies it).
 
-    A state :math:`\rho` is detected as entangled iff
-    :math:`\mathrm{tr}(H\rho) < 0`. Positivity on product states follows from
-    :math:`|\langle\Psi|\phi_A\otimes\phi_B\rangle|^2 \le 1/d` for maximally
-    entangled :math:`|\Psi\rangle` (Lemma 1 of the paper) combined with the
-    definition of :math:`\varepsilon`.
+    A state \(\rho\) is detected as entangled iff
+    \(\mathrm{tr}(H\rho) < 0\). Positivity on product states follows from
+    \(|\langle\Psi|\phi_A\otimes\phi_B\rangle|^2 \le 1/d\) for maximally
+    entangled \(|\Psi\rangle\) (Lemma 1 of the paper) combined with the
+    definition of \(\varepsilon\).
     """
     # Factor each tile(i) vector into its A and B factors via SVD.
     alpha_vecs = []
@@ -778,11 +778,11 @@ def _range_projector_product_overlap_3x3_rank4(
 ) -> float | None:
     r"""Estimate the best product overlap with the range projector of a 3x3 rank-4 state.
 
-    For the projector :math:`P` onto :math:`\operatorname{range}(\rho)`, compute
+    For the projector \(P\) onto \(\operatorname{range}(\rho)\), compute
 
-    .. math::
-
+    \[
         \max_{\|a\|=\|b\|=1} \langle a \otimes b | P | a \otimes b \rangle
+    \]
 
     by alternating maximization with deterministic random restarts.
 
@@ -853,19 +853,19 @@ def _filter_normal_form(
 
     Implements the iterative algorithm of Verstraete, Dehaene, and De Moor
     (PRA 64, 010101 (2001)) used in Gittsovich et al. [@gittsovich2008unifying]
-    Section IV.D: alternate applying :math:`T_A = (d_A \rho_A)^{-1/2}` on
-    subsystem A and :math:`T_B = (d_B \rho_B)^{-1/2}` on subsystem B until both
+    Section IV.D: alternate applying \(T_A = (d_A \rho_A)^{-1/2}\) on
+    subsystem A and \(T_B = (d_B \rho_B)^{-1/2}\) on subsystem B until both
     marginals become proportional to the identity. In normal form
-    :math:`\tilde\rho_A = I/d_A` and :math:`\tilde\rho_B = I/d_B`, so the
+    \(\tilde\rho_A = I/d_A\) and \(\tilde\rho_B = I/d_B\), so the
     reduced states carry no separability information and the correlations
     live entirely in the off-diagonal block of the covariance matrix.
 
     Each filter step preserves the trace exactly:
 
-    .. math::
-
+    \[
         \mathrm{tr}\big[(T_A \otimes I) \rho (T_A^\dagger \otimes I)\big]
         = \mathrm{tr}\big[(d_A \rho_A)^{-1} \rho_A\big] = 1/d_A \cdot d_A = 1,
+    \]
 
     so no renormalization is needed.
 
@@ -918,16 +918,16 @@ def _filter_normal_form(
 
 
 def _filter_cmc_xi_sum(rho_normal: np.ndarray, dims: list[int]) -> float:
-    r"""Compute :math:`\sum_i \xi_i` for a state already in filter normal form.
+    r"""Compute \(\sum_i \xi_i\) for a state already in filter normal form.
 
-    The :math:`\xi_i` are the coefficients in the operator-basis expansion
+    The \(\xi_i\) are the coefficients in the operator-basis expansion
 
-    .. math::
-
+    \[
         \tilde\rho = \frac{1}{d_A d_B} \left(I + \sum_k \xi_k G^A_k \otimes G^B_k\right),
+    \]
 
-    equal to :math:`d_A d_B` times the operator Schmidt coefficients of
-    :math:`\tilde\rho - I/(d_A d_B)` (which in turn are the singular values
+    equal to \(d_A d_B\) times the operator Schmidt coefficients of
+    \(\tilde\rho - I/(d_A d_B)\) (which in turn are the singular values
     of the realignment of that trace-zero operator). See Gittsovich et al.
     2008, Eq. (66).
     """
@@ -939,16 +939,16 @@ def _filter_cmc_xi_sum(rho_normal: np.ndarray, dims: list[int]) -> float:
 
 
 def _filter_cmc_bound(dA: int, dB: int) -> float:
-    r"""Return the Filter CMC separability bound for a :math:`d_A \times d_B` system.
+    r"""Return the Filter CMC separability bound for a \(d_A \times d_B\) system.
 
     From Gittsovich et al. 2008, Proposition IV.15, Eq. (72):
 
-    .. math::
-
+    \[
         \sum_k \xi_k \le \sqrt{d_A d_B (d_A - 1)(d_B - 1)}.
+    \]
 
-    This generalizes Proposition IV.13 (:math:`d^2 - d` for the symmetric
-    :math:`d_A = d_B = d` case) and, in practice, is tighter than Eq. (71)
+    This generalizes Proposition IV.13 (\(d^2 - d\) for the symmetric
+    \(d_A = d_B = d\) case) and, in practice, is tighter than Eq. (71)
     across the dimensions of interest here.
     """
     return float(np.sqrt(dA * dB * (dA - 1) * (dB - 1)))
@@ -968,9 +968,9 @@ def _iterative_product_state_subtraction(
     Loosely modelled on QETLAB's ``sk_iterate`` (with ``s = 1``) and the
     Gühne method [@guhne2009entanglement]. At each outer iteration, run
     alternating rank-1 maximization (with a handful of random restarts) to
-    find a product state :math:`|\psi\rangle|\phi\rangle` with high overlap
+    find a product state \(|\psi\rangle|\phi\rangle\) with high overlap
     on the residual state, then subtract as much of
-    :math:`|\psi\rangle\langle\psi| \otimes |\phi\rangle\langle\phi|` as
+    \(|\psi\rangle\langle\psi| \otimes |\phi\rangle\langle\phi|\) as
     positivity allows (via a geometric backoff search). Returns ``True`` if
     the residual eventually enters the Gurvits-Barnum separable ball or
     shrinks to numerical zero. Returns ``False`` if the loop stalls

--- a/toqito/state_props/ln_quantum_entropy.py
+++ b/toqito/state_props/ln_quantum_entropy.py
@@ -19,7 +19,7 @@ def ln_quantum_entropy(mat_x: np.ndarray | cvxpy.Expression) -> float:
     This function evaluates the formula numerically. Constant CVXPY expressions
     with a concrete ``.value`` are routed through the numeric path. Affine or
     variable CVXPY inputs are not supported; use
-    :func:`~toqito.cones.ln_quantum_entropy_hypo_cone` for composition in a
+    [ln_quantum_entropy_hypo_cone][toqito.cones.ln_quantum_entropy_hypo_cone] for composition in a
     parent SDP (with quadrature parameters ``m``, ``k``, ``apx``).
 
     Args:

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -1234,8 +1234,8 @@ def test_choi_1975_map_detects_npt_isotropic_3x3_via_partial_channel():
     """Applying Choi's map to an NPT 3x3 isotropic state gives a non-PSD image.
 
     This is the entanglement-witness signature used in section 12 of
-    :func:`is_separable`. We exercise the same `partial_channel` path directly
-    rather than routing through :func:`is_separable`, because the PPT criterion
+    [is_separable][toqito.state_props.is_separable]. We exercise the same `partial_channel` path directly
+    rather than routing through [is_separable][toqito.state_props.is_separable], because the PPT criterion
     would catch this state earlier.
     """
     me_vec = max_entangled(3, False, False)

--- a/toqito/state_props/tests/test_quantum_conditional_entropy.py
+++ b/toqito/state_props/tests/test_quantum_conditional_entropy.py
@@ -51,7 +51,7 @@ def _rand_density(dim: int, seed: int) -> np.ndarray:
 
 
 def _reference_conditional_entropy(rho: np.ndarray, dim: list[int], sys: int) -> float:
-    r"""Build :math:`-D(\rho \| I \otimes \rho_{\text{marginal}})` directly."""
+    r"""Build \(-D(\rho \| I \otimes \rho_{\text{marginal}})\) directly."""
     if sys == 0:
         sigma = np.kron(np.eye(dim[0]), partial_trace(rho, 0, dim))
     else:


### PR DESCRIPTION
Fixes #1884

Convert Sphinx/reStructuredText docstring roles to MkDocs-compatible syntax across 11 files (55 occurrences):

- **Inline math**: \:math:\\\X\\\\ → \\\\\(X\\\\)\
- **Display math**: \.. math::\ blocks → \\\\\[ ... \\\\]\
- **Cross-references**: \:func:\\\~toqito.pkg.mod.name\\\\ → \[name][toqito.pkg.mod.name]\

Files changed: channel_distinguishability, trace_matrix_log, extended_nonlocal_game, _constrained_games_fixtures, test_trace_distance, bell_inequality_max, test_ppt_distinguishability, is_separable, ln_quantum_entropy, test_is_separable, test_quantum_conditional_entropy.