### PR TITLE
perf: vectorize generalized Pauli-Z construction

### DIFF
--- a/toqito/matrices/gen_pauli_z.py
+++ b/toqito/matrices/gen_pauli_z.py
@@ -1,6 +1,6 @@
 """Produces a generalized Pauli-Z operator matrix."""
 
-from cmath import exp, pi
+from math import pi
 
 import numpy as np
 
@@ -51,5 +51,5 @@ def gen_pauli_z(dim: int) -> np.ndarray:
 
     """
     c_var = 2j * pi / dim
-    omega = (exp(k * c_var) for k in range(dim))
-    return np.diag(list(omega))
+    omega = np.exp(np.arange(dim) * c_var)
+    return np.diag(omega)


### PR DESCRIPTION
## Description

Vectorizes the roots-of-unity construction in `gen_pauli_z` with NumPy operations while preserving the function's signature and bit-for-bit output. Addresses #1887.

## Changes

- [x] Replace the Python generator loop with `np.exp(np.arange(dim) * c_var)`.
- [x] Preserve existing behavior and exact output.

## Benchmark

Measured on Windows, Python 3.12, NumPy 2.5.1:

| Dimension | Iterations | Before | After | Speedup |
| --- | ---: | ---: | ---: | ---: |
| 64 | 10,000 | 23.26 us | 13.34 us | 1.74x |
| 256 | 3,000 | 311.78 us | 243.97 us | 1.28x |
| 1024 | 300 | 2391.03 us | 2233.95 us | 1.07x |

## Validation

- `python -m pytest toqito/matrices/tests/test_gen_pauli_z.py -q` (19 passed)
- `python -m ruff check toqito/matrices/gen_pauli_z.py`
- `python -m ruff format --check toqito/matrices/gen_pauli_z.py`
- exact equality against the previous implementation for dimensions 1, 2, 3, 4, 5, 8, 16, 31, 64, and 256

## Checklist

- [x] Use `ruff` for errors related to code style and formatting.
- [x] Verify all relevant previous unit tests pass in `pytest`.
- [ ] Check the documentation build does not lead to failures (not run; this code-only change does not affect documentation).
