### PR TITLE
perf(states): vectorize ghz and w_state constructors

### DIFF
--- a/toqito/states/ghz.py
+++ b/toqito/states/ghz.py
@@ -66,7 +66,8 @@ def ghz(dim: int, num_qubits: int, coeff: list[int] | None = None) -> np.ndarray
     if coeff is None:
         coeff = np.ones(dim)
     else:
-        coeff = np.array(coeff)
+        # Flatten so column-vector input keeps working with the vectorized fill below.
+        coeff = np.array(coeff).ravel()
     if len(coeff) != dim:
         raise ValueError("InvalidCoeff: The variable `coeff` must be a vector of length equal to `dim`.")
 
@@ -79,10 +80,9 @@ def ghz(dim: int, num_qubits: int, coeff: list[int] | None = None) -> np.ndarray
 
     # Initialize the GHZ state vector, matching the coefficient dtype so complex coefficients are preserved.
     ghz_state = np.zeros((dim**num_qubits, 1), dtype=coeff.dtype)
-    # Fill the state vector with the corresponding coefficients.
-    for i in range(dim):
-        # Calculate the index for the tensor product state |i, i, ..., i>.
-        index = sum(i * (dim**k) for k in range(num_qubits))
-        ghz_state[index] = coeff[i]
+    # Fill the state vector with the corresponding coefficients. The tensor product state
+    # |i, i, ..., i> lives at index i * (1 + dim + dim^2 + ... + dim^(num_qubits - 1)).
+    step = sum(dim**k for k in range(num_qubits))
+    ghz_state[np.arange(dim) * step, 0] = coeff
 
     return ghz_state

--- a/toqito/states/tests/test_ghz.py
+++ b/toqito/states/tests/test_ghz.py
@@ -15,6 +15,12 @@ ghz_2_3 = 1 / np.sqrt(2) * (tensor(e_0, e_0, e_0) + tensor(e_1, e_1, e_1))
     [
         # Produces the 3-qubit GHZ state: `1/sqrt(2) * (|000> + |111>)`.
         (2, 3, None, ghz_2_3),
+        # Boundary: local dimension 1 collapses to the single state |00>.
+        (1, 2, None, np.array([[1.0]])),
+        # Boundary: a single party gives the plus state on one qudit.
+        (2, 1, None, 1 / np.sqrt(2) * np.array([[1.0], [1.0]])),
+        # A column-shaped coefficient vector behaves the same as a flat one.
+        (2, 3, np.array([[1.0], [1.0]]) / np.sqrt(2), ghz_2_3),
     ],
 )
 def test_ghz(dim, num_qubits, coeff, expected_res):
@@ -127,3 +133,15 @@ def test_ghz_non_normalized_coeff_4_7():
 
     result = ghz(dim, num_qubits, non_normalized_coeff)
     np.testing.assert_allclose(result, expected_state)
+
+
+def test_ghz_exact_values_and_dtype():
+    """The state is filled exactly (no rounding) and the coefficient dtype is preserved."""
+    # Coefficients [3, 4] normalize to exactly [0.6, 0.8] in float64.
+    res = ghz(2, 2, [3, 4])
+    assert np.array_equal(res, np.array([[0.6], [0.0], [0.0], [0.8]]))
+
+    # A unit-norm integer coefficient vector is not renormalized, so its dtype survives.
+    res = ghz(2, 3, [1, 0])
+    assert res.dtype == np.array([1, 0]).dtype
+    assert np.array_equal(res, np.array([[1], [0], [0], [0], [0], [0], [0], [0]]))

--- a/toqito/states/tests/test_w_state.py
+++ b/toqito/states/tests/test_w_state.py
@@ -48,6 +48,28 @@ def test_w_state_complex_coefficients():
     np.testing.assert_allclose(res[1, 0], coeffs[3])
 
 
+def test_w_state_column_coefficients():
+    """A column-shaped coefficient vector behaves the same as a flat one."""
+    flat = w_state(3, np.ones(3) / np.sqrt(3))
+    column = w_state(3, np.ones((3, 1)) / np.sqrt(3))
+    assert np.array_equal(column, flat)
+
+
+def test_w_state_exact_values_and_dtype():
+    """The state is filled exactly (no rounding) and the coefficient dtype is preserved."""
+    # Coefficients [0, 3, 4] normalize to exactly [0.0, 0.6, 0.8] in float64.
+    res = w_state(3, [0, 3, 4])
+    expected = np.zeros((8, 1))
+    expected[1, 0] = 0.8  # excitation on qubit 2 (index 2**0) carries coeff[2].
+    expected[2, 0] = 0.6  # excitation on qubit 1 (index 2**1) carries coeff[1].
+    assert np.array_equal(res, expected)
+
+    # A unit-norm integer coefficient vector is not renormalized, so its dtype survives.
+    res = w_state(2, [1, 0])
+    assert res.dtype == np.array([1, 0]).dtype
+    assert np.array_equal(res, np.array([[0], [0], [1], [0]]))
+
+
 @pytest.mark.parametrize(
     "idx, coeff",
     [

--- a/toqito/states/w_state.py
+++ b/toqito/states/w_state.py
@@ -62,7 +62,8 @@ def w_state(num_qubits: int, coeff: list[int] | None = None) -> np.ndarray:
     if coeff is None:
         coeff_arr = np.ones(num_qubits)
     else:
-        coeff_arr = np.array(coeff)
+        # Flatten so column-vector input keeps working with the vectorized fill below.
+        coeff_arr = np.array(coeff).ravel()
     if len(coeff_arr) != num_qubits:
         raise ValueError("InvalidCoeff: The variable `coeff` must be a vector of length equal to `num_qubits`.")
 
@@ -75,9 +76,7 @@ def w_state(num_qubits: int, coeff: list[int] | None = None) -> np.ndarray:
     # preserved.
     ret_w_state = np.zeros((2**num_qubits, 1), dtype=coeff_arr.dtype)
     # Fill the vector so that the state has the single excitation distributed according to coeff.
-    # Note: The ordering assumes that the binary representation corresponds to qubits in little-endian order.
-    for i in range(num_qubits):
-        # The position for an excitation on qubit i is at index 2**i.
-        # We assign the coefficient to the position corresponding to an excitation in that qubit.
-        ret_w_state[2**i] = coeff_arr[num_qubits - i - 1]
+    # Index 2**j carries the coefficient of qubit (num_qubits - 1 - j) in the docstring's labeling,
+    # hence the reversal.
+    ret_w_state[2 ** np.arange(num_qubits), 0] = coeff_arr[::-1]
     return ret_w_state


### PR DESCRIPTION
## Description

Closes #1895. Replaces the small per-coefficient Python loops in the `ghz` and `w_state` constructors with single vectorized index assignments, as proposed in the issue. Output is bit-for-bit identical to the loop versions and no signatures change.

## Changes

  -  [x] `toqito/states/ghz.py`: the fill loop becomes `ghz_state[np.arange(dim) * step, 0] = coeff` with `step = sum(dim**k for k in range(num_qubits))`.
  -  [x] `toqito/states/w_state.py`: the fill loop becomes `ret_w_state[2 ** np.arange(num_qubits), 0] = coeff_arr[::-1]`.
  -  [x] Both functions flatten the coefficient array after coercion (`np.array(coeff).ravel()`) so column-shaped input keeps working exactly as it did with the old element-wise assignment.
  -  [x] Tests: added `dim=1` and `num_qubits=1` boundary cases and a column-coefficient case for `ghz`, a column-coefficient test for `w_state`, and exact-equality tests for both (using coefficients like `[3, 4]` that normalize to exactly `[0.6, 0.8]` in float64, plus unit-norm integer coefficients that pin dtype preservation).

Equivalence was verified against the old loop implementations with `np.array_equal` over `dim` 1-7 x `num_qubits` 1-5 and `w_state` sizes 2-13, with default, integer, complex, unnormalized, and column-shaped coefficients: zero mismatches in value, shape, or dtype, and all error paths unchanged.

Performance: the fill step is a wash at tiny sizes (microsecond scale) and wins grow with size: about 5.8x at `dim=16`, 29.7x at `dim=100`, 142x at `dim=1000` for `ghz`, and 2-4x for `w_state` at 10-20 qubits.

One note for reviewers: flattening makes the coefficient length check size-based rather than shape-based, so a malformed matrix input such as `ghz(4, 2, np.eye(2))` is now accepted (flattened to length 4) where it previously raised. Row-vector input `(1, dim)`, which is what the docstrings literally describe, now works as documented. Happy to add a stricter shape guard if preferred.

## Checklist

  -  [x] Use `ruff` for errors related to code style and formatting. (`uv run ruff check`: all checks passed; `uv run ruff format --check`: 502 files already formatted)
  -  [x] Verify all previous and newly added unit tests pass in `pytest`. (full suite: 3660 passed, 63 skipped, 3 xfailed in 15:55; targeted: 45 passed)
  -  [x] Check the documentation build does not lead to any failures. (`mkdocs build` from `docs/`: built in 325.63 seconds with no errors)
