### PR TITLE
perf: vectorize entangled subspace construction

### DIFF
--- a/toqito/matrices/entangled_subspace.py
+++ b/toqito/matrices/entangled_subspace.py
@@ -79,37 +79,38 @@ def entangled_subspace(
     # Vandermonde matrix: V[i, k] = (i+1)^k
     V = np.fliplr(np.vander(np.arange(1, m + 1)))
 
-    E = np.zeros((prod_dim, dim))
+    k_grid, j_grid = np.meshgrid(
+        np.arange(m - r),
+        np.arange(r + 1 - d_b, d_a - r),
+        indexing="ij",
+    )
+    k_values = k_grid.ravel()
+    j_values = j_grid.ravel()
 
-    ct = 0
-    for k in range(m - r):
-        for j in range(r + 1 - d_b, d_a - r):
-            # Length of the j-th diagonal of a (d_b x d_a) matrix.
-            if j >= 0:
-                diag_len = min(d_b, d_a - j)
-            else:
-                diag_len = min(d_b + j, d_a)
+    diag_lens = np.where(
+        j_values >= 0,
+        np.minimum(d_b, d_a - j_values),
+        np.minimum(d_b + j_values, d_a),
+    )
+    valid = k_values < diag_lens - r
+    k_values = k_values[valid][:dim]
+    j_values = j_values[valid][:dim]
+    diag_lens = diag_lens[valid][:dim]
 
-            if k < diag_len - r:
-                D = V[:diag_len, k]
+    diag_positions = np.arange(m)
+    position_grid = np.broadcast_to(diag_positions, (len(k_values), m))
+    entry_mask = position_grid < diag_lens[:, np.newaxis]
+    row_offsets = np.where(j_values >= 0, j_values, -j_values * d_a)
+    row_indices = position_grid * (d_a + 1) + row_offsets[:, np.newaxis]
+    column_indices = np.broadcast_to(
+        np.arange(len(k_values))[:, np.newaxis],
+        row_indices.shape,
+    )
+    values = V[position_grid, k_values[:, np.newaxis]]
 
-                # Place D on the j-th diagonal of a (d_b x d_a) matrix.
-                T = np.zeros((d_b, d_a))
-                if j >= 0:
-                    for i in range(diag_len):
-                        T[i, i + j] = D[i]
-                else:
-                    for i in range(diag_len):
-                        T[i - j, i] = D[i]
-
-                E[:, ct] = T.reshape(prod_dim)
-
-                ct += 1
-                if ct >= dim:
-                    # Orthonormalize via QR.
-                    Q, _ = qr(E, mode="economic")
-                    return Q
+    E = np.zeros((prod_dim, len(k_values)))
+    E[row_indices[entry_mask], column_indices[entry_mask]] = values[entry_mask]
 
     # Orthonormalize via QR.
-    Q, _ = qr(E[:, :ct], mode="economic")
+    Q, _ = qr(E, mode="economic")
     return Q


### PR DESCRIPTION
## Description

Vectorizes the diagonal/Vandermonde basis construction in `entangled_subspace` while preserving the original column order, QR call, signature, and output. Addresses #1894.

## Changes

- build every valid `(k, diagonal)` combination with a NumPy mesh grid
- compute diagonal lengths and flattened row indices with broadcasting
- fill the full basis matrix with one advanced-index assignment
- remove the nested Python loops and per-column temporary matrices

## Benchmark

Measured on Windows, Python 3.12, NumPy 2.5.1, including QR:

| Local dimensions | Subspace dimension | Before | After | Speedup |
| --- | ---: | ---: | ---: | ---: |
| 8 x 8 | 49 | 0.333 ms | 0.246 ms | 1.36x |
| 12 x 12 | 121 | 2.898 ms | 2.367 ms | 1.22x |
| 12 x 16 | 165 | 4.785 ms | 3.827 ms | 1.25x |

## Validation

- `python -m pytest toqito/matrices/tests/test_entangled_subspace.py -q` (22 passed)
- `python -m ruff check toqito/matrices/entangled_subspace.py`
- `python -m ruff format --check toqito/matrices/entangled_subspace.py`
- `git diff --check`
- exact equality against the previous implementation across 384 representative combinations of rectangular local dimensions, `r`, and requested subspace dimensions

## Checklist

- [x] Use `ruff` for errors related to code style and formatting.
- [x] Verify all relevant previous unit tests pass in `pytest`.
- [ ] Check the documentation build does not lead to failures (not run; this code-only change does not affect documentation).
