### PR TITLE
Use lowercase parameter names in error messages

### DIFF
--- a/toqito/channel_metrics/tests/test_completely_bounded_trace_norm.py
+++ b/toqito/channel_metrics/tests/test_completely_bounded_trace_norm.py
@@ -70,7 +70,7 @@ def test_cb_trace_norm_rectangular(test_input, expected):
 def test_cb_trace_norm_rectangular_requires_dim():
     """A Choi matrix with unequal input/output dimensions requires the `dim` argument."""
     choi = kraus_to_choi([[isometry_1, isometry_1]])
-    with pytest.raises(ValueError, match="the optional argument DIM must be specified"):
+    with pytest.raises(ValueError, match="the optional argument `dim` must be specified"):
         completely_bounded_trace_norm(choi)
 
 

--- a/toqito/channel_props/channel_dim.py
+++ b/toqito/channel_props/channel_dim.py
@@ -82,10 +82,10 @@ def channel_dim(
 
         # Now do some error checking.
         if (dim_in[0] != dim_in[1] or dim_out[0] != dim_out[1]) and not allow_rect:
-            raise ValueError("The input and output spaces of PHI must be square.")
+            raise ValueError("The input and output spaces of `phi` must be square.")
 
         if np.any(dim != np.vstack([dim_in, dim_out]).T):
-            raise ValueError("The dimensions of PHI do not match those provided in the DIM argument.")
+            raise ValueError("The dimensions of `phi` do not match those provided in the `dim` argument.")
 
         if (is_cpt and any(k_mat.shape != (dim[0, 1], dim[0, 0]) for k_mat in left_ops)) or (
             not is_cpt
@@ -94,7 +94,7 @@ def channel_dim(
                 for left, right in zip(left_ops, right_ops)
             )
         ):
-            raise ValueError("The Kraus operators of PHI do not all have the same size.")
+            raise ValueError("The Kraus operators of `phi` do not all have the same size.")
 
     # If Phi is a Choi matrix, the dimensions are a bit more of a pain: we have
     # to guess a bit if the input and output dimensions are different.
@@ -110,13 +110,13 @@ def channel_dim(
 
         if dim[0, 0] * dim[0, 1] != rows or dim[1, 0] * dim[1, 1] != cols:
             raise ValueError(
-                "If the input and output dimensions are unequal and PHI is provided "
-                "as a Choi matrix, the optional argument DIM must be specified "
-                "(and its dimensions must agree with PHI)."
+                "If the input and output dimensions are unequal and `phi` is provided "
+                "as a Choi matrix, the optional argument `dim` must be specified "
+                "(and its dimensions must agree with `phi`)."
             )
 
         if (dim[0, 0] != dim[1, 0] or dim[0, 1] != dim[1, 1]) and not allow_rect:
-            raise ValueError("The input and output spaces of PHI must be square.")
+            raise ValueError("The input and output spaces of `phi` must be square.")
 
         # environment dimension is the rank of the Choi matrix
         dim_e = None

--- a/toqito/perms/permute_systems.py
+++ b/toqito/perms/permute_systems.py
@@ -177,7 +177,7 @@ def permute_systems(
     if sorted(perm) != list(range(num_sys)):
         raise ValueError("InvalidPerm: `perm` must be a permutation vector.")
     if input_mat_dims[0] != prod_dim_r or (not row_only and input_mat_dims[1] != prod_dim_c):
-        raise ValueError("InvalidDim: The dimensions specified in DIM do not agree with the size of X.")
+        raise ValueError("InvalidDim: The dimensions specified in `dim` do not agree with the size of `input_mat`.")
     if is_vec:
         # If `input_mat` is a 1-by-X row vector, ensure we "flatten it" appropriately:
         if input_mat.shape[0] == 1:

--- a/toqito/states/horodecki.py
+++ b/toqito/states/horodecki.py
@@ -131,4 +131,4 @@ def horodecki(a_param: float, dim: list[int] | None = None) -> np.ndarray:
             ]
         )
         return horo_state
-    raise ValueError("InvalidDim: DIM must be one of [3, 3], or [2, 4].")
+    raise ValueError("InvalidDim: `dim` must be one of [3, 3], or [2, 4].")


### PR DESCRIPTION
## Description

  Updates user-facing error messages to use the actual lowercase Python parameter names instead of uppercase MATLAB/QETLAB-style names.

  Closes #1885

  ## Changes

  - [x] Replace `PHI` and `DIM` with `phi` and `dim`.
  - [x] Replace `X` with the actual `input_mat` parameter name.
  - [x] Update the affected exact-string test assertion.

  ## Checklist

  - [x] Use `ruff` for errors related to code style and formatting.
  - [ ] Verify all previous and newly added unit tests pass in `pytest`.
  - [ ] Check the documentation build does not lead to any failures.

  ### Testing performed

  - 113 affected tests passed.
  - `ruff check` passed.
  - `ruff format --check` passed.
  - `git diff --check` passed.
