### PR TITLE
docs: fix leftover reStructuredText roles missed by #1892

### DIFF
--- a/toqito/nonlocal_games/tests/_constrained_games_fixtures.py
+++ b/toqito/nonlocal_games/tests/_constrained_games_fixtures.py
@@ -46,7 +46,7 @@ def constrained_bb84_monogamy_answer_constraints() -> list[AnswerEventConstraint
     Implements Eq. (60) in arXiv:2405.13717, Section 4.1 ("Constrained BB84
     monogamy-of-entanglement game"): Alice and Bob never answer differently when
     they receive the same question. In the answer-event form used by
-    :meth:`~toqito.nonlocal_games.extended_nonlocal_game.ExtendedNonlocalGame.commuting_measurement_value_upper_bound`,
+    `ExtendedNonlocalGame.commuting_measurement_value_upper_bound`,
     this is
 
     \[

--- a/toqito/state_opt/bell_inequality_max.py
+++ b/toqito/state_opt/bell_inequality_max.py
@@ -787,7 +787,7 @@ def _cg_to_fp(cg_mat: np.ndarray, desc: list[int], behavior: bool = False) -> np
     r"""Convert a Bell functional or behavior from Collins-Gisin (CG) to Full Probability (FP) notation.
 
     The Collins-Gisin (CG) notation for a Bell functional or behavior is represented by a matrix
-    (see [cg_to_fc][toqito.state_opt.bell_inequality_max]).
+    (see `_cg_to_fc`).
     The Full Probability (FP) notation represents the full probability distribution
     \(V(a, b, x, y) = P(a, b | x, y)\), the probability of Alice getting outcome
     \(a\) (0 to oa-1) and Bob getting outcome \(b\) (0 to ob-1) given inputs \(x\)
@@ -943,7 +943,7 @@ def _fc_to_fp(fc_mat: np.ndarray, behavior: bool = False) -> np.ndarray:
     Assumes binary outcomes (\(oa=2\), \(ob=2\)) corresponding to physical values +1 and -1.
     The FP tensor indices \(a, b = 0, 1\) correspond to outcomes \(+1, -1\) respectively.
 
-    The Full Correlator (FC) notation is represented by a matrix (see [fc_to_cg][toqito.state_opt.bell_inequality_max]).
+    The Full Correlator (FC) notation is represented by a matrix (see `_fc_to_cg`).
     The Full Probability (FP) notation represents the full probability distribution
     \(V(a, b, x, y) = P(\text{out}_A=a', \text{out}_B=b' | x, y)\),
     where \(a=0 \rightarrow a'=+1\), \(a=1 \rightarrow a'=-1\) (similarly for \(b\)),

--- a/toqito/state_props/learnability.py
+++ b/toqito/state_props/learnability.py
@@ -47,7 +47,7 @@ def learnability(
         states: Sequence of state vectors or density matrices acting on the same space.
         k: Subset size for the POVM outcomes; must satisfy `1 <= k <= len(states)`.
         solver: Optional CVXPY solver name. Defaults to `"SCS"`.
-        solver_kwargs: Extra keyword arguments forwarded to :meth:`cvxpy.Problem.solve`.
+        solver_kwargs: Extra keyword arguments forwarded to `cvxpy.Problem.solve`.
         verify_reduced: If `True` and the states are pure, also solve the reduced SDP.
         verify_tolerance: Absolute tolerance used when comparing the two optimal values.
         tol: Numerical tolerance used when validating positivity and rank-one states.


### PR DESCRIPTION
Follow-up to #1892 (#1884). A handful of reStructuredText roles were left unconverted:

- `bell_inequality_max.py`: the two cross-references #1892 created (`[cg_to_fc][toqito.state_opt.bell_inequality_max]`) point at the module path rather than the object, and drop the leading underscore of the real private helpers (`_cg_to_fc`, `_fc_to_cg`). Since both the target and the containing docstrings are private (excluded from the rendered docs), a cross-reference can't resolve, so these use inline code with the corrected names.
- `learnability.py`: a `:meth:` role referencing the external `cvxpy.Problem.solve` in the public `learnability()` docstring rendered literally; converted to inline code (external symbols aren't cross-linkable).
- A leftover `:meth:` in a non-rendered test fixture, converted to inline code.

The only `.. math::` still present is inside a `#` code comment, which is not a docstring and correctly left as-is. No behavior change.