### PR TITLE
Fix sandwich bug for integral relative entropy

### DIFF
--- a/toqito/channel_metrics/channel_relative_entropy.py
+++ b/toqito/channel_metrics/channel_relative_entropy.py
@@ -126,7 +126,7 @@ def channel_relative_entropy(
     choi_2 = channel_2
     solve_kwargs = {"eps": 1e-8, "verbose": False, **kwargs}
 
-    mu, lam = _sandwich_parameters(choi_1, choi_2)
+    mu, lam = _sandwich_parameters(choi_1, choi_2, epsilon_dec)
     if mu <= 0 or lam <= mu:
         raise ValueError(
             "The integral representation requires 0 < mu < lambda. "

--- a/toqito/channel_metrics/tests/test_channel_relative_entropy.py
+++ b/toqito/channel_metrics/tests/test_channel_relative_entropy.py
@@ -191,7 +191,7 @@ def test_raises_degenerate_integral_bounds(monkeypatch):
     monkeypatch.setattr(
         _CHANNEL_RELATIVE_ENTROPY_MOD,
         "_sandwich_parameters",
-        lambda rho, sigma: (0.0, 1.0),
+        lambda rho, sigma, epsilon_dec=1e-2: (0.0, 1.0),
     )
     with pytest.raises(ValueError, match="0 < mu < lambda"):
         channel_relative_entropy(channel_1, channel_2, in_dim=2, epsilon_dec=0.2)
@@ -199,7 +199,7 @@ def test_raises_degenerate_integral_bounds(monkeypatch):
     monkeypatch.setattr(
         _CHANNEL_RELATIVE_ENTROPY_MOD,
         "_sandwich_parameters",
-        lambda rho, sigma: (2.0, 1.0),
+        lambda rho, sigma, epsilon_dec=1e-2: (2.0, 1.0),
     )
     with pytest.raises(ValueError, match="0 < mu < lambda"):
         channel_relative_entropy(channel_1, channel_2, in_dim=2, epsilon_dec=0.2)
@@ -230,7 +230,7 @@ def test_raises_when_lower_sdp_fails(monkeypatch):
     monkeypatch.setattr(
         _CHANNEL_RELATIVE_ENTROPY_MOD,
         "_sandwich_parameters",
-        lambda rho, sigma: (0.1, 2.0),
+        lambda rho, sigma, epsilon_dec=1e-2: (0.1, 2.0),
     )
 
     class FakeProblem:
@@ -256,7 +256,7 @@ def test_raises_when_upper_sdp_fails(monkeypatch):
     monkeypatch.setattr(
         _CHANNEL_RELATIVE_ENTROPY_MOD,
         "_sandwich_parameters",
-        lambda rho, sigma: (0.1, 2.0),
+        lambda rho, sigma, epsilon_dec=1e-2: (0.1, 2.0),
     )
 
     class FakeProblem:
@@ -282,7 +282,7 @@ def test_warns_on_optimal_inaccurate_lower(monkeypatch):
     monkeypatch.setattr(
         _CHANNEL_RELATIVE_ENTROPY_MOD,
         "_sandwich_parameters",
-        lambda rho, sigma: (0.1, 2.0),
+        lambda rho, sigma, epsilon_dec=1e-2: (0.1, 2.0),
     )
 
     class FakeProblem:
@@ -308,7 +308,7 @@ def test_warns_on_optimal_inaccurate_upper(monkeypatch):
     monkeypatch.setattr(
         _CHANNEL_RELATIVE_ENTROPY_MOD,
         "_sandwich_parameters",
-        lambda rho, sigma: (0.1, 2.0),
+        lambda rho, sigma, epsilon_dec=1e-2: (0.1, 2.0),
     )
 
     class FakeProblem:

--- a/toqito/cones/_integral_relative_entropy_helpers.py
+++ b/toqito/cones/_integral_relative_entropy_helpers.py
@@ -13,19 +13,29 @@ def _generalized_eigenvalues(a: np.ndarray, b: np.ndarray) -> np.ndarray:
         return np.real(eig(a, b, left=False, right=False)[0])
 
 
-def _sandwich_parameters(rho: np.ndarray, sigma: np.ndarray) -> tuple[float, float]:
-    r"""Return sandwich bounds \(\mu\) and \(\lambda\) for PSD matrices \(X\) and \(Y\)."""
+def _sandwich_parameters(
+    rho: np.ndarray,
+    sigma: np.ndarray,
+    epsilon_dec: float = 1e-2,
+) -> tuple[float, float]:
+    r"""Return sandwich bounds \(\mu\) and \(\lambda\) for PSD matrices \(X\) and \(Y\).
+
+    A singular \(X\) gives the exact endpoint \(\mu = 0\), which Corollary 1 of
+    [@kossmann2024optimisingrelativeentropy] excludes. The remark following that
+    corollary instead applies the method on \([\varepsilon, \lambda]\), leaving an
+    error of at most \(\varepsilon\) on the omitted \([0, \varepsilon]\).
+    """
     try:
         w_xy = _generalized_eigenvalues(rho, sigma)
-        w_yx = _generalized_eigenvalues(sigma, rho)
     except LinAlgError as exc:
         raise ValueError("Failed to compute sandwich parameters from generalized eigenvalues.") from exc
     finite_xy = w_xy[np.isfinite(w_xy)]
-    finite_yx = w_yx[np.isfinite(w_yx)]
-    if finite_xy.size == 0 or finite_yx.size == 0:
+    if finite_xy.size == 0:
         raise ValueError("Failed to compute sandwich parameters from generalized eigenvalues.")
     lam = float(np.max(finite_xy))
-    mu = float(np.min(finite_yx))
+    mu = float(np.min(finite_xy))
+    if mu <= 0:
+        mu = float(epsilon_dec)
     return mu, lam
 
 

--- a/toqito/cones/integral_relative_entropy_lower_cone.py
+++ b/toqito/cones/integral_relative_entropy_lower_cone.py
@@ -65,7 +65,7 @@ def integral_relative_entropy_lower_cone(
         if mu is not None or lam is not None:
             raise ValueError("mu and lam must both be provided or both omitted")
         x_val, y_val = _numeric_pair_for_sandwich(mat_x, mat_y)
-        mu, lam = _sandwich_parameters(x_val, y_val)
+        mu, lam = _sandwich_parameters(x_val, y_val, epsilon_dec)
     _require_valid_sandwich(mu, lam)
 
     grid = _make_grid(mu, lam, epsilon_dec)

--- a/toqito/cones/integral_relative_entropy_upper_cone.py
+++ b/toqito/cones/integral_relative_entropy_upper_cone.py
@@ -66,7 +66,7 @@ def integral_relative_entropy_upper_cone(
         if mu is not None or lam is not None:
             raise ValueError("mu and lam must both be provided or both omitted")
         x_val, y_val = _numeric_pair_for_sandwich(mat_x, mat_y)
-        mu, lam = _sandwich_parameters(x_val, y_val)
+        mu, lam = _sandwich_parameters(x_val, y_val, epsilon_dec)
     _require_valid_sandwich(mu, lam)
 
     grid = _make_grid(mu, lam, epsilon_dec)

--- a/toqito/state_props/integral_relative_entropy.py
+++ b/toqito/state_props/integral_relative_entropy.py
@@ -100,7 +100,7 @@ def evaluate_relative_entropy_integral(
     default_kwargs = {"eps": 1e-8, "verbose": False}
     default_kwargs.update(solve_kwargs)
 
-    mu, lam = _sandwich_parameters(mat_x_eval, mat_y_eval)
+    mu, lam = _sandwich_parameters(mat_x_eval, mat_y_eval, epsilon_dec)
 
     x_c = cvxpy.Constant(mat_x_eval)
     y_c = cvxpy.Constant(mat_y_eval)

--- a/toqito/state_props/tests/test_integral_relative_entropy.py
+++ b/toqito/state_props/tests/test_integral_relative_entropy.py
@@ -21,6 +21,14 @@ from toqito.state_props.integral_relative_entropy import (
 _NOT_SUPPORTED = re.escape(_AFFINE_VARIABLE_USE_CONE)
 
 
+def _commuting_relative_entropy(diag_x: list[float], diag_y: list[float]) -> float:
+    r"""Return the closed-form (D(X|Y)) in nats for commuting diagonal states."""
+    dx = np.array(diag_x, dtype=float)
+    dy = np.array(diag_y, dtype=float)
+    support = dx > 0
+    return float(np.sum(dx[support] * np.log(dx[support] / dy[support])))
+
+
 def test_generalized_eigenvalues_eig_fallback():
     """``eigh`` may fail when the right factor is singular; ``eig`` is used instead."""
     choi_1 = np.asarray(depolarizing(2, 1))
@@ -42,7 +50,9 @@ def test_sandwich_parameters_no_finite_eigenvalues(monkeypatch):
 
     with pytest.raises(
         ValueError,
-        match=re.escape("Failed to compute sandwich parameters from generalized eigenvalues."),
+        match=re.escape(
+            "Failed to compute sandwich parameters from generalized eigenvalues."
+        ),
     ):
         _sandwich_parameters(np.eye(2), np.eye(2) / 2)
 
@@ -74,14 +84,18 @@ def test_evaluate_relative_entropy_integral_shape_mismatch():
 def test_evaluate_relative_entropy_integral_mat_x_not_psd():
     """Non-PSD ``mat_x`` should raise ``ValueError``."""
     mat_x = np.array([[1.0, 2.0], [2.0, 1.0]])
-    with pytest.raises(ValueError, match="mat_x must be a positive semidefinite matrix"):
+    with pytest.raises(
+        ValueError, match="mat_x must be a positive semidefinite matrix"
+    ):
         evaluate_relative_entropy_integral(mat_x, np.eye(2))
 
 
 def test_evaluate_relative_entropy_integral_mat_y_not_psd():
     """Non-PSD ``mat_y`` should raise ``ValueError``."""
     mat_y = np.array([[1.0, 2.0], [2.0, 1.0]])
-    with pytest.raises(ValueError, match="mat_y must be a positive semidefinite matrix"):
+    with pytest.raises(
+        ValueError, match="mat_y must be a positive semidefinite matrix"
+    ):
         evaluate_relative_entropy_integral(np.eye(2), mat_y)
 
 
@@ -96,7 +110,7 @@ def test_evaluate_relative_entropy_integral_degenerate_sandwich(monkeypatch):
     """Degenerate ``mu``/``lambda`` should raise ``ValueError``."""
     monkeypatch.setattr(
         "toqito.state_props.integral_relative_entropy._sandwich_parameters",
-        lambda mat_x, mat_y: (1.0, 1.0),
+        lambda mat_x, mat_y, epsilon_dec=1e-2: (1.0, 1.0),
     )
     with pytest.raises(ValueError, match="0 < mu < lambda"):
         evaluate_relative_entropy_integral(np.eye(2) / 2, np.eye(2) / 4)
@@ -121,6 +135,60 @@ def test_evaluate_relative_entropy_integral_complex_hermitian():
     assert result >= 0.0
 
 
+@pytest.mark.parametrize(
+    ("diag_x", "diag_y"),
+    [
+        ([0.75, 0.25], [0.5, 0.5]),
+        ([0.7, 0.3], [0.4, 0.6]),
+        ([0.9, 0.1], [0.5, 0.5]),
+    ],
+)
+def test_evaluate_relative_entropy_integral_matches_closed_form(diag_x, diag_y):
+    """For a qubit pair both sandwich endpoints are grid points, so the bounds are exact.
+
+    This pins the endpoints themselves: an inexact ``mu`` shrinks the integration
+    range and silently biases the estimate downwards.
+    """
+    expected = _commuting_relative_entropy(diag_x, diag_y)
+    result = evaluate_relative_entropy_integral(np.diag(diag_x), np.diag(diag_y))
+    assert result == pytest.approx(expected, abs=1e-6)
+
+
+@pytest.mark.parametrize("epsilon_dec", [1e-1, 1e-2, 1e-3])
+def test_evaluate_relative_entropy_integral_obeys_discretization_bound(epsilon_dec):
+    """Corollary 1 of [@kossmann2024optimisingrelativeentropy] caps the error at ``epsilon_dec``.
+
+    The third eigenvalue puts a kink strictly inside the grid, so unlike the qubit
+    case the estimate is not exact and has to converge as the grid is refined.
+    """
+    diag_x, diag_y = [0.5, 0.3, 0.2], [1 / 3, 1 / 3, 1 / 3]
+    expected = _commuting_relative_entropy(diag_x, diag_y)
+    result = evaluate_relative_entropy_integral(
+        np.diag(diag_x),
+        np.diag(diag_y),
+        epsilon_dec=epsilon_dec,
+    )
+    assert abs(result - expected) <= epsilon_dec
+
+
+def test_evaluate_relative_entropy_integral_singular_mat_x_converges():
+    """A singular ``mat_x`` truncates the integral at ``epsilon_dec``, costing at most that much."""
+    diag_x, diag_y = [0.6, 0.4, 0.0], [1 / 3, 1 / 3, 1 / 3]
+    expected = _commuting_relative_entropy(diag_x, diag_y)
+
+    errors = []
+    for epsilon_dec in (1e-1, 1e-2, 1e-3):
+        result = evaluate_relative_entropy_integral(
+            np.diag(diag_x),
+            np.diag(diag_y),
+            epsilon_dec=epsilon_dec,
+        )
+        errors.append(abs(result - expected))
+        assert errors[-1] <= epsilon_dec
+
+    assert errors[0] > errors[1] > errors[2]
+
+
 def test_evaluate_relative_entropy_integral_lower_sdp_failure(monkeypatch):
     """A failed lower-bound solve should raise ``RuntimeError``."""
 
@@ -130,7 +198,9 @@ def test_evaluate_relative_entropy_integral_lower_sdp_failure(monkeypatch):
         def __init__(self, objective, constraints):
             self.value = 1.0
             FakeProblem.created += 1
-            self.status = cvxpy.INFEASIBLE if FakeProblem.created == 1 else cvxpy.OPTIMAL
+            self.status = (
+                cvxpy.INFEASIBLE if FakeProblem.created == 1 else cvxpy.OPTIMAL
+            )
 
         def solve(self, **kwargs):
             pass
@@ -175,7 +245,9 @@ def test_evaluate_relative_entropy_integral_warns_on_inaccurate_lower(monkeypatc
         def __init__(self, objective, constraints):
             self.value = 0.1
             FakeProblem.created += 1
-            self.status = cvxpy.OPTIMAL_INACCURATE if FakeProblem.created == 1 else cvxpy.OPTIMAL
+            self.status = (
+                cvxpy.OPTIMAL_INACCURATE if FakeProblem.created == 1 else cvxpy.OPTIMAL
+            )
 
         def solve(self, **kwargs):
             pass
@@ -196,7 +268,9 @@ def test_evaluate_relative_entropy_integral_warns_on_inaccurate_upper(monkeypatc
         def __init__(self, objective, constraints):
             self.value = 0.1
             FakeProblem.created += 1
-            self.status = cvxpy.OPTIMAL if FakeProblem.created == 1 else cvxpy.OPTIMAL_INACCURATE
+            self.status = (
+                cvxpy.OPTIMAL if FakeProblem.created == 1 else cvxpy.OPTIMAL_INACCURATE
+            )
 
         def solve(self, **kwargs):
             pass
@@ -221,7 +295,9 @@ def test_sandwich_parameters_raises_on_lin_alg_error(monkeypatch):
 
     with pytest.raises(
         ValueError,
-        match=re.escape("Failed to compute sandwich parameters from generalized eigenvalues."),
+        match=re.escape(
+            "Failed to compute sandwich parameters from generalized eigenvalues."
+        ),
     ):
         _sandwich_parameters(np.eye(2), np.eye(2) / 2)
 

--- a/toqito/state_props/tests/test_integral_relative_entropy.py
+++ b/toqito/state_props/tests/test_integral_relative_entropy.py
@@ -50,9 +50,7 @@ def test_sandwich_parameters_no_finite_eigenvalues(monkeypatch):
 
     with pytest.raises(
         ValueError,
-        match=re.escape(
-            "Failed to compute sandwich parameters from generalized eigenvalues."
-        ),
+        match=re.escape("Failed to compute sandwich parameters from generalized eigenvalues."),
     ):
         _sandwich_parameters(np.eye(2), np.eye(2) / 2)
 
@@ -84,18 +82,14 @@ def test_evaluate_relative_entropy_integral_shape_mismatch():
 def test_evaluate_relative_entropy_integral_mat_x_not_psd():
     """Non-PSD ``mat_x`` should raise ``ValueError``."""
     mat_x = np.array([[1.0, 2.0], [2.0, 1.0]])
-    with pytest.raises(
-        ValueError, match="mat_x must be a positive semidefinite matrix"
-    ):
+    with pytest.raises(ValueError, match="mat_x must be a positive semidefinite matrix"):
         evaluate_relative_entropy_integral(mat_x, np.eye(2))
 
 
 def test_evaluate_relative_entropy_integral_mat_y_not_psd():
     """Non-PSD ``mat_y`` should raise ``ValueError``."""
     mat_y = np.array([[1.0, 2.0], [2.0, 1.0]])
-    with pytest.raises(
-        ValueError, match="mat_y must be a positive semidefinite matrix"
-    ):
+    with pytest.raises(ValueError, match="mat_y must be a positive semidefinite matrix"):
         evaluate_relative_entropy_integral(np.eye(2), mat_y)
 
 
@@ -198,9 +192,7 @@ def test_evaluate_relative_entropy_integral_lower_sdp_failure(monkeypatch):
         def __init__(self, objective, constraints):
             self.value = 1.0
             FakeProblem.created += 1
-            self.status = (
-                cvxpy.INFEASIBLE if FakeProblem.created == 1 else cvxpy.OPTIMAL
-            )
+            self.status = cvxpy.INFEASIBLE if FakeProblem.created == 1 else cvxpy.OPTIMAL
 
         def solve(self, **kwargs):
             pass
@@ -245,9 +237,7 @@ def test_evaluate_relative_entropy_integral_warns_on_inaccurate_lower(monkeypatc
         def __init__(self, objective, constraints):
             self.value = 0.1
             FakeProblem.created += 1
-            self.status = (
-                cvxpy.OPTIMAL_INACCURATE if FakeProblem.created == 1 else cvxpy.OPTIMAL
-            )
+            self.status = cvxpy.OPTIMAL_INACCURATE if FakeProblem.created == 1 else cvxpy.OPTIMAL
 
         def solve(self, **kwargs):
             pass
@@ -268,9 +258,7 @@ def test_evaluate_relative_entropy_integral_warns_on_inaccurate_upper(monkeypatc
         def __init__(self, objective, constraints):
             self.value = 0.1
             FakeProblem.created += 1
-            self.status = (
-                cvxpy.OPTIMAL if FakeProblem.created == 1 else cvxpy.OPTIMAL_INACCURATE
-            )
+            self.status = cvxpy.OPTIMAL if FakeProblem.created == 1 else cvxpy.OPTIMAL_INACCURATE
 
         def solve(self, **kwargs):
             pass
@@ -295,9 +283,7 @@ def test_sandwich_parameters_raises_on_lin_alg_error(monkeypatch):
 
     with pytest.raises(
         ValueError,
-        match=re.escape(
-            "Failed to compute sandwich parameters from generalized eigenvalues."
-        ),
+        match=re.escape("Failed to compute sandwich parameters from generalized eigenvalues."),
     ):
         _sandwich_parameters(np.eye(2), np.eye(2) / 2)
 


### PR DESCRIPTION
the previous sandwich function for finding mu was buggy and set mu to 1/lam. fix the function and all a fallback for negative mu. add tests to catch original bug.

## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [ ] Change 1

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://vprusso.github.io/toqito/contributing-guide/).

  -  [ ] Use `ruff` for errors related to code style and formatting.
  -  [ ] Verify all previous and newly added unit tests pass in `pytest`.
  -  [ ] Check the documentation build does not lead to any failures.
