### PR TITLE
docs: document explicit input errors

### DIFF
--- a/toqito/channels/amplitude_damping.py
+++ b/toqito/channels/amplitude_damping.py
@@ -44,6 +44,9 @@ def amplitude_damping(
         The Choi matrix of the channel, or its list of Kraus operators when `return_kraus_ops` is
         `True`.
 
+    Raises:
+        ValueError: If `prob` or `gamma` is outside the interval \([0, 1]\).
+
     Examples:
         Apply the channel (returned as a Choi matrix) to a state via `apply_channel`:
 

--- a/toqito/channels/bitflip.py
+++ b/toqito/channels/bitflip.py
@@ -40,6 +40,9 @@ def bitflip(
         The Choi matrix of the channel, or its list of Kraus operators when `return_kraus_ops` is
         `True`.
 
+    Raises:
+        ValueError: If `prob` is outside the interval \([0, 1]\).
+
     Examples:
         Obtain the Kraus operators for the bitflip channel with probability 0.3:
 

--- a/toqito/channels/ldot_channel.py
+++ b/toqito/channels/ldot_channel.py
@@ -39,6 +39,9 @@ def ldot_channel(mat: np.ndarray, efficient: bool = True) -> np.ndarray:
     Returns:
         The LDOI projection of the input matrix.
 
+    Raises:
+        ValueError: If `mat` is not square or its dimension is not a perfect square.
+
     Examples:
         Apply LDOT channel to project an arbitrary matrix onto LDOI subspace:
 

--- a/toqito/channels/phase_damping.py
+++ b/toqito/channels/phase_damping.py
@@ -29,6 +29,9 @@ def phase_damping(
         The Choi matrix of the channel, or its list of Kraus operators when `return_kraus_ops` is
         `True`.
 
+    Raises:
+        ValueError: If `gamma` is outside the interval \([0, 1]\).
+
     Examples:
         Apply the channel (returned as a Choi matrix) to a state via `apply_channel`:
 

--- a/toqito/matrices/cyclic_permutation.py
+++ b/toqito/matrices/cyclic_permutation.py
@@ -18,6 +18,10 @@ def cyclic_permutation(n: int, k: int = 1) -> np.ndarray:
          one position to the right in a cyclic manner, creating a circular permutation pattern. If `k` is specified, the
          function raises the matrix to the power of `k`, representing successive applications of the cyclic permutation.
 
+    Raises:
+        TypeError: If `n` or `k` is not an integer.
+        ValueError: If `n` is not a positive integer.
+
     Examples:
         Generate fixed point.
 


### PR DESCRIPTION
## Description

Documents explicit input-validation exceptions in five public APIs as part of #1888.

## Changes

- [x] Add Google-style `Raises` sections to `cyclic_permutation`, `amplitude_damping`, `bitflip`, `phase_damping`, and `ldot_channel`.
- [x] Cover invalid types, invalid probability/damping ranges, non-positive dimensions, and invalid LDOT matrix dimensions.

## Validation

- [x] `ruff check` on all five modified modules
- [x] `ruff format --check` on all five modified modules
- [x] Targeted tests for all five APIs (56 passed)
- [x] Imported `cyclic_permutation` and verified the rendered docstring contains `Raises:`
- [x] `git diff --check`
- [x] GitHub Actions test and style checks passed

A full local MkDocs build was not run because `mkdocs` is unavailable in the local environment. The repository's Docs Preview check was skipped by its workflow configuration.