### PR TITLE
docs: add runnable dicke and measure examples

### DIFF
--- a/toqito/measurement_ops/measure.py
+++ b/toqito/measurement_ops/measure.py
@@ -42,17 +42,20 @@ def measure(
 
     and, if \(p_i > tol\), the post‐measurement state is updated via
 
-    \[
-        u = \frac{1}{\sqrt{3}} e_0 + \sqrt{\frac{2}{3}} e_1
-    \]
+    Examples:
+        Consider the state
 
-    where we define \(u u^* = \rho \in \text{D}(\mathcal{X})\).
+        \[
+            u = \frac{1}{\sqrt{3}} e_0 + \sqrt{\frac{2}{3}} e_1
+        \]
 
-    Define measurement operators
+        where we define \(u u^* = \rho \in \text{D}(\mathcal{X})\).
 
-    \[
-        P_0 = e_0 e_0^* \quad \text{and} \quad P_1 = e_1 e_1^*.
-    \]
+        Define measurement operators
+
+        \[
+            P_0 = e_0 e_0^* \quad \text{and} \quad P_1 = e_1 e_1^*.
+        \]
 
         ```python exec="1" source="above" result="text"
         import numpy as np
@@ -66,21 +69,21 @@ def measure(
 
         proj_0 = e_0 @ e_0.conj().T
         proj_1 = e_1 @ e_1.conj().T
-        print(measure(proj_0, rho))
+        print(measure(rho, proj_0))
         ```
 
-    Then the probability of obtaining outcome \(0\) is given by
+        Then the probability of obtaining outcome \(0\) is given by
 
-    \[
-        \langle P_0, \rho \rangle = \frac{1}{3}.
-    \]
+        \[
+            \langle P_0, \rho \rangle = \frac{1}{3}.
+        \]
 
 
-    Similarly, the probability of obtaining outcome \(1\) is given by
+        Similarly, the probability of obtaining outcome \(1\) is given by
 
-    \[
-        \langle P_1, \rho \rangle = \frac{2}{3}.
-    \]
+        \[
+            \langle P_1, \rho \rangle = \frac{2}{3}.
+        \]
 
         ```python exec="1" source="above" result="text"
         import numpy as np

--- a/toqito/states/dicke.py
+++ b/toqito/states/dicke.py
@@ -13,15 +13,15 @@ def dicke(num_qubit: int, num_excited: int, return_dm: bool = False) -> np.ndarr
     distributed across the given number of qubits (i.e., `num_qubit`). It is symmetric and represents
     an equal superposition of all possible states with the specified number of excited qubits.
 
-    Example
-    Consider generating a Dicke state with 3 qubits and 1 excitation:
+    Examples:
+        Consider generating a Dicke state with 3 qubits and 1 excitation:
 
         ```python exec="1" source="above" result="text"
         from toqito.states import dicke
         print(dicke(3, 1))
         ```
 
-    If we request the density matrix for this state, the return value is:
+        If we request the density matrix for this state, the return value is:
 
         ```python exec="1" source="above" result="text"
         from toqito.states import dicke


### PR DESCRIPTION
## Description

Adds proper runnable `Examples` sections to `dicke` and `measure` as part of #1886.

## Changes

- [x] Promote the existing Dicke state snippets into a rendered `Examples` section.
- [x] Add a rendered `Examples` section to `measure` and correct the state/operator argument order in its projector example.

## Validation

- [x] Ran every documented snippet directly against this branch and verified the printed results
- [x] Targeted tests (22 passed)
- [x] `ruff check`
- [x] `ruff format --check`
- [x] `git diff --check`
- [x] GitHub Actions test and style checks passed

A full local MkDocs build was not run because `mkdocs` is unavailable in the local environment. The repository's Docs Preview check was skipped by its workflow configuration.