### PR TITLE
docs: add geometric mean cone examples

### DIFF
--- a/toqito/cones/geometric_mean_epi_cone.py
+++ b/toqito/cones/geometric_mean_epi_cone.py
@@ -43,6 +43,24 @@ def geometric_mean_epi_cone(
     Returns:
         A list of CVX constraints.
 
+    Examples:
+        Minimize a scalar upper bound for the geometric mean with weight (t = 2).
+
+        ```python exec="1" source="above" result="text"
+        import cvxpy
+        import numpy as np
+
+        from toqito.cones import geometric_mean_epi_cone
+
+        mat_a = cvxpy.Constant(np.array([[4.0]]))
+        mat_b = cvxpy.Constant(np.array([[1.0]]))
+        mat_t = cvxpy.Variable((1, 1), symmetric=True)
+        constraints = geometric_mean_epi_cone(mat_a, mat_b, mat_t, t=2)
+        problem = cvxpy.Problem(cvxpy.Minimize(mat_t[0, 0]), constraints)
+        problem.solve(solver="SCS")
+        print(f"{mat_t.value.item():.2f}")
+        ```
+
     """
     if t < -1 or (t > 0 and t < 1) or t > 2:
         raise ValueError("The weight must be in the range [-1, 0] or [1, 2].")

--- a/toqito/cones/geometric_mean_hypo_cone.py
+++ b/toqito/cones/geometric_mean_hypo_cone.py
@@ -50,6 +50,24 @@ def geometric_mean_hypo_cone(
     Returns:
         A list of CVX constraints.
 
+    Examples:
+        Maximize a scalar lower bound for the geometric mean with weight (t = 1/2).
+
+        ```python exec="1" source="above" result="text"
+        import cvxpy
+        import numpy as np
+
+        from toqito.cones import geometric_mean_hypo_cone
+
+        mat_a = cvxpy.Constant(np.array([[4.0]]))
+        mat_b = cvxpy.Constant(np.array([[1.0]]))
+        mat_t = cvxpy.Variable((1, 1), symmetric=True)
+        constraints = geometric_mean_hypo_cone(mat_a, mat_b, mat_t, t=0.5)
+        problem = cvxpy.Problem(cvxpy.Maximize(mat_t[0, 0]), constraints)
+        problem.solve(solver="SCS")
+        print(f"{mat_t.value.item():.2f}")
+        ```
+
     """
     if t < 0 or t > 1:
         raise ValueError("The weight must be in the range [0, 1].")


### PR DESCRIPTION
## Description

Adds runnable `Examples` sections to the matrix geometric-mean epigraph and hypograph cone builders as part of #1886.

## Changes

- [x] Demonstrate minimizing a scalar epigraph bound at `t=2`.
- [x] Demonstrate maximizing a scalar hypograph bound at `t=0.5`.
- [x] Keep both executable snippets small and deterministic (`0.25` and `2.00`).

## Checklist

- [x] Use `ruff` for errors related to code style and formatting.
- [x] Verify all previous and newly added unit tests pass in `pytest`.
- [x] Check the documentation examples execute successfully.

## Validation

- Direct execution of both examples (`epi=0.25`, `hypo=2.00`)
- Targeted cone tests (`102 passed`)
- `ruff check`
- `ruff format --check`
- `git diff --check`

The targeted suite reports two existing SCS accuracy warnings while passing.