### PR TITLE
docs: document channel input errors

### DIFF
--- a/toqito/channel_ops/kraus_to_choi.py
+++ b/toqito/channel_ops/kraus_to_choi.py
@@ -28,6 +28,9 @@ def kraus_to_choi(kraus_ops: list[np.ndarray] | list[list[np.ndarray]], sys: int
     Returns:
         The corresponding Choi matrix of the provided Kraus operators.
 
+    Raises:
+        ValueError: If ``sys`` is negative or ``kraus_ops`` is empty.
+
     Examples:
         The transpose map:
 

--- a/toqito/channel_props/channel_dim.py
+++ b/toqito/channel_props/channel_dim.py
@@ -42,6 +42,12 @@ def channel_dim(
     Returns:
         The input, output, and environment dimensions of a channel.
 
+    Raises:
+        ValueError: If rectangular spaces are disallowed but the channel is
+            rectangular, the supplied dimensions do not match the channel,
+            Kraus operators have inconsistent sizes, or ``dim`` is not a
+            scalar, length-two vector, or \(2 \times 2\) matrix.
+
     Examples:
         The dimensions of a channel can be computed from a list of Kraus operators.
         For example, the following Kraus operators describe a qubit bit-flip


### PR DESCRIPTION
## Description

Documents explicit input-validation exceptions in two channel APIs as part of #1888.

## Changes

- [x] Document the invalid `sys` and empty Kraus-list cases in `kraus_to_choi`.
- [x] Document rectangular-space, dimension-mismatch, inconsistent Kraus-size, and invalid `dim` cases in `channel_dim`.

## Checklist

- [x] Use `ruff` for errors related to code style and formatting.
- [x] Verify all previous and newly added unit tests pass in `pytest`.
- [ ] Check the documentation build does not lead to any failures.

## Validation

- Targeted tests: 28 passed
- `ruff check`
- `ruff format --check`
- `git diff --check`

A full local MkDocs build was not run because the documentation dependency group is not installed in this worktree.

## AI assistance

Implemented and reviewed with OpenAI Codex; all listed validation commands were run locally.