### PR TITLE
Make the is_ppt failure test check what it says it checks

### DIFF
--- a/toqito/state_props/tests/test_is_ppt.py
+++ b/toqito/state_props/tests/test_is_ppt.py
@@ -27,9 +27,9 @@ def test_is_ppt(mat, sys, dim, tol, expected_result):
     np.testing.assert_equal(is_ppt(mat=mat, sys=sys, dim=dim, tol=tol), expected_result)
 
 
-def test_is_ppt_non_hermitian_matrix():
-    """Non-Hermitian matrices with invalid dimensions should raise an error."""
-    mat = np.array([[1, 2], [0, 1]])  # Not Hermitian, not valid bipartite dims
+def test_is_ppt_dimension_not_a_perfect_square():
+    """A matrix whose dimension is not a perfect square cannot be split into two subsystems."""
+    mat = np.array([[1, 2], [0, 1]])  # 2 is not a perfect square, so dim becomes [[1, 1], [1, 1]]
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError, match="cannot reshape"):
         is_ppt(mat)


### PR DESCRIPTION
## Description

`test_is_ppt_non_hermitian_matrix` does not test what its name and docstring say. It catches an error that has nothing to do with Hermiticity, and it uses a bare `pytest.raises(Exception)` which would pass on almost anything, including a typo in the function name.

`is_ppt` derives the subsystem dimensions from the square root of the matrix shape:

```python
sqrt_rho_dims = np.round(np.sqrt(list(mat.shape))).astype(int)
```

For a 2x2 input that gives `[[1, 1], [1, 1]]`, and `partial_transpose` then fails while reshaping. Nothing in `is_ppt` inspects Hermiticity at all.

Two probes make it concrete:

```python
>>> is_ppt(np.array([[1, 0], [0, 1]], dtype=float))   # Hermitian, same 2x2 shape
ValueError: cannot reshape array of size 4 into shape (1,1,1,1)

>>> m = np.zeros((4, 4)); m[0, 1] = 5.0               # not Hermitian, valid shape
>>> is_ppt(m)
False
```

So the test passes for a Hermitian matrix of that shape, and a non-Hermitian matrix of a valid shape sails through without any error. The test guards the shape rule, not Hermiticity.

## Changes

  -  [x] Renamed to `test_is_ppt_dimension_not_a_perfect_square`, which is what the case actually covers
  -  [x] Narrowed `pytest.raises(Exception)` to `pytest.raises(ValueError, match="cannot reshape")`, matching how the rest of the suite writes these (`test_entanglement_of_formation.py`, `test_has_symmetric_inner_extension.py`)
  -  [x] Comment now explains why 2x2 fails, so the next reader does not have to rediscover it

Test only. No change to `is_ppt`.

## Checklist

  -  [x] `ruff check` with your configuration - clean on the changed file
  -  [x] `pytest toqito/state_props` - 598 passed, 13 skipped, 2 xfailed
  -  [x] Documentation build not affected, no docs touched

## One open question

Should `is_ppt` reject a non-Hermitian matrix outright? Right now it happily returns a boolean for one, and PPT is only meaningful for Hermitian operators. I did not add that check, since it changes behaviour rather than fixing a test, and you may well prefer it stays permissive. Happy to send it separately if you want it.
