### PR TITLE
docs: add missing Raises sections to public function docstrings

### DIFF
--- a/toqito/channel_ops/natural_representation.py
+++ b/toqito/channel_ops/natural_representation.py
@@ -17,6 +17,9 @@ def natural_representation(kraus_ops: list[np.ndarray]) -> np.ndarray:
     Returns:
         The natural-representation matrix of the quantum channel.
 
+    Raises:
+        ValueError: If `kraus_ops` is empty, or the Kraus operators do not all have the same dimensions.
+
     Examples:
         ```python exec="1" source="above" result="text"
         import numpy as np

--- a/toqito/channel_props/is_quantum_channel.py
+++ b/toqito/channel_props/is_quantum_channel.py
@@ -31,6 +31,9 @@ def is_quantum_channel(
     Returns:
         `True` if the channel is a quantum channel, and `False` otherwise.
 
+    Raises:
+        TypeError: If `phi` is not a numpy array, a list of Kraus operators, or a list of Kraus operator pairs.
+
     Examples:
         We can specify the input as a list of Kraus operators. Consider the map \(\Phi\) defined as
 

--- a/toqito/channel_props/is_trace_preserving.py
+++ b/toqito/channel_props/is_trace_preserving.py
@@ -53,6 +53,9 @@ def is_trace_preserving(
     Returns:
         True if the channel is trace-preserving, and False otherwise.
 
+    Raises:
+        ValueError: If `dim` is not given and equal subsystem dimensions cannot be inferred from the shape of `phi`.
+
     Examples:
         The map \(\Phi\) defined as
 

--- a/toqito/matrices/hadamard.py
+++ b/toqito/matrices/hadamard.py
@@ -32,6 +32,9 @@ def hadamard(n_param: int = 1) -> np.ndarray:
     Returns:
         The `2^{n_param}`-dimensional Hadamard matrix.
 
+    Raises:
+        ValueError: If `n_param` is less than 1.
+
     Examples:
         The standard 1-qubit Hadamard matrix can be generated in `toqito` as
 

--- a/toqito/matrices/pauli.py
+++ b/toqito/matrices/pauli.py
@@ -55,6 +55,9 @@ def pauli(ind: int | str | list[int] | list[str], is_sparse: bool = False) -> np
         tensor product of the indicated Pauli matrices when `ind` is a list. Returned as a
         `scipy.sparse.csr_array` if `is_sparse` is True and as a `np.ndarray` otherwise.
 
+    Raises:
+        ValueError: If `ind` is not one of the recognized Pauli indices.
+
     Examples:
         Example for identity Pauli matrix.
 

--- a/toqito/matrix_ops/null_space.py
+++ b/toqito/matrix_ops/null_space.py
@@ -17,6 +17,9 @@ def null_space(mat: np.ndarray, tol: float = 1e-08) -> np.ndarray:
     Returns:
         A matrix whose columns form an orthonormal basis for the null space.
 
+    Raises:
+        ValueError: If `mat` is not a two-dimensional array.
+
     Examples:
         Consider the matrix
 

--- a/toqito/matrix_ops/tensor_unravel.py
+++ b/toqito/matrix_ops/tensor_unravel.py
@@ -35,6 +35,10 @@ def tensor_unravel(constraint_tensor: np.ndarray) -> np.ndarray:
         A 1D `numpy` array of length \(n+1\) where the first \(n\) elements are the coordinates (indices), and the last
         element is the unique constant (rhs).
 
+    Raises:
+        ValueError: If `constraint_tensor` does not have exactly two distinct values, has no value occurring
+            exactly once, or that value occurs more than once.
+
     Examples:
         ```python exec="1" source="above" result="text"
         import numpy as np

--- a/toqito/matrix_props/factor_width.py
+++ b/toqito/matrix_props/factor_width.py
@@ -41,6 +41,10 @@ def factor_width(
         ``factors`` (list of PSD matrices whose sum equals ``mat`` when feasible), and
         ``subspaces`` (orthonormal bases spanning the subspaces used in the decomposition).
 
+    Raises:
+        ValueError: If `mat` is not square, `k` does not satisfy 1 <= k <= d, or `mat` is not positive
+            semidefinite.
+
     Examples:
         The matrix \(\operatorname{diag}(1, 1, 0)\) has factor width at most \(1\).
         ```python exec="1" source="above" result="text"

--- a/toqito/matrix_props/is_equiangular_tight_frame.py
+++ b/toqito/matrix_props/is_equiangular_tight_frame.py
@@ -32,6 +32,9 @@ def is_equiangular_tight_frame(mat: np.ndarray, tol: float = 1e-8) -> bool:
     Returns:
         `True` if the columns of `mat` form an equiangular tight frame; `False` otherwise.
 
+    Raises:
+        ValueError: If `mat` is not a 2D matrix.
+
     Examples:
         The columns of a Hadamard matrix (rescaled) form an ETF.
 

--- a/toqito/matrix_props/is_totally_positive.py
+++ b/toqito/matrix_props/is_totally_positive.py
@@ -26,6 +26,9 @@ def is_totally_positive(
     Returns:
         Return `True` if matrix is totally positive, and `False` otherwise.
 
+    Raises:
+        ValueError: If `mat` is empty.
+
     Examples:
         Consider the matrix
 

--- a/toqito/matrix_props/positive_semidefinite_rank.py
+++ b/toqito/matrix_props/positive_semidefinite_rank.py
@@ -19,6 +19,9 @@ def positive_semidefinite_rank(mat: np.ndarray, max_rank: int = 10) -> int | Non
     Returns:
         The positive semidefinite rank if found within `max_rank`, or `None` otherwise.
 
+    Raises:
+        ValueError: If `mat` is not nonnegative, or is not square.
+
     Examples:
         As an example (Equation 21 from [@heinosaari2024can]), the PSD rank of the following matrix
 

--- a/toqito/measurement_props/is_povm.py
+++ b/toqito/measurement_props/is_povm.py
@@ -28,6 +28,9 @@ def is_povm(mat_list: list[np.ndarray], rtol: float = 1e-05, atol: float = 1e-08
     Returns:
         Return `True` if set of matrices constitutes a set of measurements, and `False` otherwise.
 
+    Raises:
+        ValueError: If `mat_list` is empty, or its elements are not square matrices of the same dimension.
+
     Examples:
         Consider the following matrices:
 

--- a/toqito/perms/symmetric_projection.py
+++ b/toqito/perms/symmetric_projection.py
@@ -34,6 +34,9 @@ def symmetric_projection(dim: int, p_val: int = 2, partial: bool = False) -> np.
     Returns:
         Projection onto the symmetric subspace.
 
+    Raises:
+        ValueError: If `dim` is less than 1, or `p_val` is less than 1.
+
     Examples:
         The \(2\)-dimensional symmetric projection with \(p=1\) is given as \(2\)-by-\(2\) identity matrix
 

--- a/toqito/rand/random_state_vector.py
+++ b/toqito/rand/random_state_vector.py
@@ -38,6 +38,11 @@ def random_state_vector(
         A normalized column vector of shape ``(total_dim, 1)`` where ``total_dim`` equals `dim` if ``dim`` is an integer
         and equals the product of entries in ``dim`` otherwise.
 
+    Raises:
+        ValueError: If `k_param` is negative, `dim` is given as an empty sequence, the entries of `dim` are
+            not positive integers, or `dim` is not an integer or a length-two sequence when `k_param` is
+            positive.
+
     Examples:
         We may generate a random state vector. For instance, here is an example where we can generate a
         \(2\)-dimensional random state vector.

--- a/toqito/rand/random_unitary.py
+++ b/toqito/rand/random_unitary.py
@@ -17,6 +17,9 @@ def random_unitary(dim: list[int] | int, is_real: bool = False, seed: int | None
     Returns:
         A `dim`-by-`dim` random unitary matrix.
 
+    Raises:
+        ValueError: If `dim` specifies a non-square matrix.
+
     Examples:
         We may generate a random unitary matrix. Here is an example of how we may be able to generate a
         random \(2\)-dimensional random unitary matrix with complex entries.

--- a/toqito/state_opt/state_distinguishability.py
+++ b/toqito/state_opt/state_distinguishability.py
@@ -103,6 +103,11 @@ def state_distinguishability(
         The optimal probability with which Bob can guess the state he was not given from `states` along with the optimal
         set of measurements.
 
+    Raises:
+        ValueError: If `measurement` is not 'positive' or 'ppt', `primal_dual` is not 'primal' or 'dual',
+            `strategy` is not 'min_error' or 'unambiguous', the vectors do not all have the same dimension,
+            the number of probabilities does not equal the number of states, or any probability is negative.
+
     Examples:
         Minimal-error state distinguishability for the Bell states (which are perfectly distinguishable).
 

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -164,6 +164,12 @@ def state_exclusion(
         The optimal probability with which Bob can guess the state he was not given from `states` along with the optimal
         set of measurements.
 
+    Raises:
+        ValueError: If `measurement` is not 'positive', 'ppt', or 'locc', `primal_dual` is not 'primal' or
+            'dual', `strategy` is not 'min_error' or 'unambiguous', the vectors do not all have the same
+            dimension, the number of probabilities does not equal the number of states, any probability is
+            negative, or `measurement` is 'locc' without `strategy='min_error'` and a length-two `dimensions`.
+
     Examples:
         Consider the following two Bell states
 

--- a/toqito/state_opt/symmetric_extension_hierarchy.py
+++ b/toqito/state_opt/symmetric_extension_hierarchy.py
@@ -89,6 +89,10 @@ def symmetric_extension_hierarchy(
         distinguishability value for `objective="distinguish"`, or the exclusion error for
         `objective="exclude"`.
 
+    Raises:
+        ValueError: If `objective` is not 'distinguish' or 'exclude', no states are provided, the
+            probabilities do not sum to 1, or a scalar `dim` does not evenly divide the length of the state.
+
     Examples:
         It is known from [@cosentino2015quantum] that distinguishing three Bell states along with a resource
         state \(|\tau_{\epsilon}\rangle\) via separable measurements has the following closed form

--- a/toqito/state_props/is_antidistinguishable_circulant.py
+++ b/toqito/state_props/is_antidistinguishable_circulant.py
@@ -39,6 +39,9 @@ def is_antidistinguishable_circulant(
     Returns:
         `True` if the vectors are antidistinguishable; `False` otherwise.
 
+    Raises:
+        ValueError: If the Gram matrix of `states` is not circulant.
+
     Examples:
         The trine states are a well-known example of antidistinguishable states. They are defined as:
 

--- a/toqito/state_props/renyi_entropy.py
+++ b/toqito/state_props/renyi_entropy.py
@@ -37,6 +37,9 @@ def renyi_entropy(rho: np.ndarray, alpha: float) -> float:
     Returns:
         The Rényi entropy of order `alpha` of `rho`.
 
+    Raises:
+        ValueError: If `rho` is not a density operator, or `alpha` is negative.
+
     Examples:
         Consider the following Bell state:
 

--- a/toqito/state_props/von_neumann_entropy.py
+++ b/toqito/state_props/von_neumann_entropy.py
@@ -35,6 +35,9 @@ def von_neumann_entropy(rho: np.ndarray) -> float:
     Returns:
         The von Neumann entropy of `rho`.
 
+    Raises:
+        ValueError: If `rho` is not a density operator.
+
     Examples:
         Consider the following Bell state:
 

--- a/toqito/states/horodecki.py
+++ b/toqito/states/horodecki.py
@@ -70,6 +70,9 @@ def horodecki(a_param: float, dim: list[int] | None = None) -> np.ndarray:
     Returns:
         The Horodecki density matrix for the requested dimensions.
 
+    Raises:
+        ValueError: If `a_param` is outside the interval [0, 1], or `dim` is not [3, 3] or [2, 4].
+
     Examples:
         The following code generates a Horodecki state in \(\mathbb{C}^3 \otimes \mathbb{C}^3\)
 

--- a/toqito/states/max_entangled.py
+++ b/toqito/states/max_entangled.py
@@ -23,6 +23,9 @@ def max_entangled(dim: int, is_sparse: bool = False, is_normalized: bool = True)
     Returns:
         The maximally entangled state of dimension `dim`.
 
+    Raises:
+        ValueError: If `dim` is not a positive integer.
+
     Examples:
         We can generate the canonical \(2\)-dimensional maximally entangled state
 

--- a/toqito/states/mutually_unbiased_basis.py
+++ b/toqito/states/mutually_unbiased_basis.py
@@ -23,6 +23,9 @@ def mutually_unbiased_basis(dim: int) -> list[np.ndarray]:
     Returns:
         The set of mutually unbiased bases of dimension `dim` (if known).
 
+    Raises:
+        ValueError: If `dim` is a prime power but not prime, or no MUB construction is known for `dim`.
+
     Examples:
         For the case of dimension 2, the three mutually unbiased bases are provided by:
 


### PR DESCRIPTION
Addresses #1888. All of the files originally listed in that issue were covered by #1905 and #1908, so this sweeps the remaining public functions that raise without documenting it.

## What this does

Adds a Google-style `Raises:` section to 24 public functions across `channel_ops`, `channel_props`, `matrices`, `matrix_ops`, `matrix_props`, `measurement_props`, `perms`, `rand`, `state_opt`, `state_props`, and `states`.

## How the conditions were derived

Each entry was written from the actual raise sites rather than inferred from the signature. I walked every `raise` in each function body with an AST pass, read the guarding condition, and described that condition. I then confirmed the exceptions genuinely fire by calling the functions with offending input, for example:

| call | result |
| --- | --- |
| `hadamard(0)` | ValueError |
| `pauli('q')` | ValueError |
| `max_entangled(-1)` | ValueError |
| `horodecki(2.0)` | ValueError |
| `mutually_unbiased_basis(6)` | ValueError |
| `von_neumann_entropy(diag(2,3))` | ValueError |
| `renyi_entropy(rho, -1)` | ValueError |
| `random_unitary([2,3])` | ValueError |
| `is_povm([])` | ValueError |
| `null_space(1d array)` | ValueError |

## Deliberate omission

`npa_constraints` also raises, but its only `raise` is `"Generated word list is empty. Check _gen_words logic."`, an internal invariant assertion aimed at developers rather than an input-validation error a caller can trigger. Documenting it as a user-facing `Raises:` entry would be misleading, so it is left alone.

## Notes

The added text deliberately uses no LaTeX, so none of these docstrings need to become raw strings and there is no escape-sequence risk. Docs-only; no behavior change.