### PR TITLE
docs: add runnable Examples sections to cone and entropy functions

### DIFF
--- a/toqito/cones/integral_relative_entropy_lower_cone.py
+++ b/toqito/cones/integral_relative_entropy_lower_cone.py
@@ -55,6 +55,27 @@ def integral_relative_entropy_lower_cone(
     Returns:
         A list of CVXPY constraints.
 
+    Examples:
+        The constraints form an epigraph, so minimizing the scalar bounds the relative entropy
+        from below. For these commuting states the exact value is 0.1308 nats.
+
+        ```python exec="1" source="above" result="text"
+        import cvxpy
+        import numpy as np
+
+        from toqito.cones import integral_relative_entropy_lower_cone
+
+        mat_x = cvxpy.Constant(np.diag([0.75, 0.25]))
+        mat_y = cvxpy.Constant(np.diag([0.5, 0.5]))
+        bound = cvxpy.Variable()
+        constraints = integral_relative_entropy_lower_cone(mat_x, mat_y, bound)
+        problem = cvxpy.Problem(cvxpy.Minimize(bound), constraints)
+        problem.solve(solver="SCS")
+
+        print(f"{float(np.asarray(bound.value).item()):.4f}")
+        ```
+
+
     """
     _require_square_2d(mat_x, "mat_x")
     _require_square_2d(mat_y, "mat_y")

--- a/toqito/cones/integral_relative_entropy_upper_cone.py
+++ b/toqito/cones/integral_relative_entropy_upper_cone.py
@@ -56,6 +56,27 @@ def integral_relative_entropy_upper_cone(
     Returns:
         A list of CVXPY constraints.
 
+    Examples:
+        The constraints form an epigraph, so minimizing the scalar bounds the relative entropy
+        from above. For these commuting states the exact value is 0.1308 nats.
+
+        ```python exec="1" source="above" result="text"
+        import cvxpy
+        import numpy as np
+
+        from toqito.cones import integral_relative_entropy_upper_cone
+
+        mat_x = cvxpy.Constant(np.diag([0.75, 0.25]))
+        mat_y = cvxpy.Constant(np.diag([0.5, 0.5]))
+        bound = cvxpy.Variable()
+        constraints = integral_relative_entropy_upper_cone(mat_x, mat_y, bound)
+        problem = cvxpy.Problem(cvxpy.Minimize(bound), constraints)
+        problem.solve(solver="SCS")
+
+        print(f"{float(np.asarray(bound.value).item()):.4f}")
+        ```
+
+
     """
     _require_square_2d(mat_x, "mat_x")
     _require_square_2d(mat_y, "mat_y")

--- a/toqito/cones/operator_relative_entropy_epi_cone.py
+++ b/toqito/cones/operator_relative_entropy_epi_cone.py
@@ -57,6 +57,27 @@ def operator_relative_entropy_epi_cone(
     Returns:
         A list of CVX constraints.
 
+    Examples:
+        Minimizing the trace of the epigraph variable recovers the relative entropy of the two
+        states, 0.1308 nats for this commuting pair.
+
+        ```python exec="1" source="above" result="text"
+        import cvxpy
+        import numpy as np
+
+        from toqito.cones import operator_relative_entropy_epi_cone
+
+        mat_x = cvxpy.Constant(np.diag([0.75, 0.25]))
+        mat_y = cvxpy.Constant(np.diag([0.5, 0.5]))
+        tau = cvxpy.Variable((2, 2), symmetric=True)
+        constraints = operator_relative_entropy_epi_cone(mat_x, mat_y, tau)
+        problem = cvxpy.Problem(cvxpy.Minimize(cvxpy.trace(tau)), constraints)
+        problem.solve(solver="SCS")
+
+        print(f"{float(np.trace(tau.value)):.4f}")
+        ```
+
+
     """
     _require_square_2d(X, "X")
     _require_square_2d(Y, "Y")

--- a/toqito/matrix_props/trace_matrix_log.py
+++ b/toqito/matrix_props/trace_matrix_log.py
@@ -47,6 +47,19 @@ def trace_matrix_log(
     Returns:
         A float representing the value of the trace of the matrix logarithm.
 
+    Examples:
+        For a diagonal matrix the trace of the matrix logarithm is the sum of the logarithms of
+        the eigenvalues, so this returns log(1) + log(2) = log(2).
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+
+        from toqito.matrix_props import trace_matrix_log
+
+        print(f"{trace_matrix_log(np.diag([1.0, 2.0])):.4f}")
+        ```
+
+
     """
     if not isinstance(mat_x, (np.ndarray, cvxpy.Expression)):
         raise ValueError("mat_x must be a numpy array or a cvxpy expression")

--- a/toqito/state_props/ln_quantum_entropy.py
+++ b/toqito/state_props/ln_quantum_entropy.py
@@ -35,6 +35,18 @@ def ln_quantum_entropy(mat_x: np.ndarray | cvxpy.Expression) -> float:
     Returns:
         The quantum entropy of the matrix as a float.
 
+    Examples:
+        The maximally mixed qubit state has entropy log(2) in nats.
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+
+        from toqito.state_props import ln_quantum_entropy
+
+        print(f"{ln_quantum_entropy(np.eye(2) / 2):.4f}")
+        ```
+
+
     """
     if not isinstance(mat_x, (np.ndarray, cvxpy.Expression)):
         raise ValueError("mat_x must be a numpy array or a cvxpy expression")


### PR DESCRIPTION
Addresses #1886. Most targets originally listed in that issue are now covered (#1903, #1906, #1907), so this picks up remaining public functions with no `Examples` section.

## What this does

Adds a runnable `Examples` block to five functions:

- `integral_relative_entropy_lower_cone`
- `integral_relative_entropy_upper_cone`
- `operator_relative_entropy_epi_cone`
- `trace_matrix_log`
- `ln_quantum_entropy`

## Values are checked against analytic results, not themselves

Since the docs build executes these blocks, a snippet that runs is not enough; the printed number has to be right. Each was verified against an independently computed value:

| function | prints | independent check |
| --- | --- | --- |
| `trace_matrix_log(diag(1, 2))` | `0.6931` | `log(1) + log(2) = log 2 = 0.69315` |
| `ln_quantum_entropy(I/2)` | `0.6931` | `-tr(X log X) = log 2 = 0.69315` |
| all three cones | `0.1308` | exact `D(X\|\|Y) = 0.13081` for `X = diag(0.75, 0.25)`, `Y = diag(0.5, 0.5)` |

That the three cone builders independently land on the exact relative entropy is a meaningful check on the constraints, not just on the plumbing.

## Cone direction

Both integral cones are epigraphs, so the objective is `Minimize`, matching how `evaluate_relative_entropy_integral` drives them internally. Maximizing the lower cone is unbounded, so an example written that way would have looked plausible and silently failed.

## Cost to the docs build

Each cone solve runs in under 0.05s on SCS, so these add negligible build time.

## Not included

`has_symmetric_inner_extension` is also missing an `Examples` section, but @Jethin10 claimed it on #1886, so it is deliberately left for them. That means #1886 should stay open after this merges.