### PR TITLE
test: close coverage gaps in xor_game, extended_nonlocal_game, and symmetric_extension_hierarchy

### DIFF
--- a/toqito/matrix_props/tests/test_sk_norm.py
+++ b/toqito/matrix_props/tests/test_sk_norm.py
@@ -189,3 +189,20 @@ def test_sk_norm_randomized_start_vec_low_schmidt_rank_used_as_init():
     product = np.kron(np.array([1.0, 0.0]), np.array([1.0, 0.0]))
     result = __lower_bound_sk_norm_randomized(np.eye(4), k=1, dim=dim, tol=1e-4, start_vec=product)
     assert np.isfinite(result)
+
+
+def test_sk_operator_norm_k_greater_than_one_sdp_branch():
+    """A positive operator with k > 1 exercises the non-PPT SDP upper bound.
+
+    For k = 1 the SDP constrains the partial transpose; for k > 1 it instead uses
+    the k-times partial-trace constraint, which no other test reaches.
+    """
+    rng = np.random.default_rng(1)
+    mat = rng.normal(size=(9, 9))
+    mat = mat @ mat.T
+    mat = mat / np.trace(mat)
+
+    lower_bound, upper_bound = sk_operator_norm(mat, k=2, dim=[3, 3])
+
+    assert lower_bound <= upper_bound + 1e-6
+    assert lower_bound > 0

--- a/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
+++ b/toqito/nonlocal_games/tests/test_extended_nonlocal_game.py
@@ -1012,3 +1012,48 @@ class TestExtendedNonlocalGameVerbosePrints:
 
         # It should return current_best_lower_bound, which was 0.75 from problem_bob_ok.value
         assert np.isclose(res, 0.75)
+
+
+class TestAnswerEventLinearConstraint(unittest.TestCase):
+    """Unit tests for the answer-event constraint builder.
+
+    These call the builder directly rather than going through
+    ``commuting_measurement_value_upper_bound`` so that the operator and
+    index-validation branches are exercised without paying for an SDP solve.
+    """
+
+    @staticmethod
+    def _assemblage(referee_dim=2, num_a_out=2, num_b_out=2, num_a_in=2, num_b_in=2):
+        """Build an assemblage of the shape the builder expects."""
+        return {
+            (x, y): cvxpy.Variable((num_a_out * referee_dim, num_b_out * referee_dim), hermitian=True)
+            for x in range(num_a_in)
+            for y in range(num_b_in)
+        }
+
+    def test_sparse_index_out_of_range(self):
+        """A sparse key outside the game dimensions is rejected."""
+        assemblage = self._assemblage()
+        # num_b_out is 2, so b = 5 is out of range.
+        constraint = ({(0, 5, 0, 0): 1.0}, "==", 0.0)
+
+        with self.assertRaises(ValueError):
+            ExtendedNonlocalGame._answer_event_linear_constraint(assemblage, constraint, 2, 2, 2, 2, 2)
+
+    def test_less_than_or_equal_operator(self):
+        """The '<=' operator produces an inequality constraint."""
+        assemblage = self._assemblage()
+        constraint = ({(0, 1, 0, 0): 1.0}, "<=", 0.5)
+
+        built = ExtendedNonlocalGame._answer_event_linear_constraint(assemblage, constraint, 2, 2, 2, 2, 2)
+
+        self.assertIsInstance(built, cvxpy.constraints.constraint.Constraint)
+
+    def test_greater_than_or_equal_operator(self):
+        """The '>=' operator produces an inequality constraint."""
+        assemblage = self._assemblage()
+        constraint = ({(0, 1, 0, 0): 1.0}, ">=", 0.25)
+
+        built = ExtendedNonlocalGame._answer_event_linear_constraint(assemblage, constraint, 2, 2, 2, 2, 2)
+
+        self.assertIsInstance(built, cvxpy.constraints.constraint.Constraint)

--- a/toqito/nonlocal_games/tests/test_xor_game.py
+++ b/toqito/nonlocal_games/tests/test_xor_game.py
@@ -2,7 +2,9 @@
 
 import re
 import unittest
+from unittest import mock
 
+import cvxpy
 import numpy as np
 import pytest
 
@@ -190,3 +192,19 @@ def test_xor_game_invalid_input(prob_mat, pred_mat, expected_msg):
     """Constructor raises for a shape mismatch or an invalid probability matrix."""
     with pytest.raises(ValueError, match=re.escape(expected_msg)):
         XORGame(prob_mat, pred_mat)
+
+
+class TestXORGameSolverFailure(unittest.TestCase):
+    """The SDP-failure path is reported rather than silently returning None."""
+
+    def test_quantum_value_raises_when_sdp_does_not_solve(self):
+        """A solve that leaves the problem without a value raises ValueError."""
+        prob_mat = np.array([[1 / 4, 1 / 4], [1 / 4, 1 / 4]])
+        pred_mat = np.array([[0, 0], [0, 1]])
+        chsh = XORGame(prob_mat, pred_mat)
+
+        # Patch solve to a no-op so `problem.value` stays None, which is what the
+        # guard in `quantum_value` is there to catch.
+        with mock.patch.object(cvxpy.Problem, "solve", lambda self, *args, **kwargs: None):
+            with self.assertRaisesRegex(ValueError, "did not solve successfully"):
+                chsh.quantum_value()

--- a/toqito/state_opt/tests/test_symmetric_extension_hierarchy.py
+++ b/toqito/state_opt/tests/test_symmetric_extension_hierarchy.py
@@ -272,3 +272,13 @@ def test_invalid_objective_raises():
     states = [bell(0) @ bell(0).conj().T, bell(1) @ bell(1).conj().T]
     with pytest.raises(ValueError, match="objective"):
         symmetric_extension_hierarchy(states=states, level=1, objective="antidistinguish")
+
+
+def test_symmetric_extension_hierarchy_dim_as_sequence():
+    """A sequence `dim` is accepted alongside the scalar form and gives the same value."""
+    states = [bell(0) @ bell(0).conj().T, bell(1) @ bell(1).conj().T]
+
+    scalar_dim = symmetric_extension_hierarchy(states=states, probs=[0.5, 0.5], level=1, dim=2)
+    sequence_dim = symmetric_extension_hierarchy(states=states, probs=[0.5, 0.5], level=1, dim=[2, 2])
+
+    assert np.isclose(scalar_dim, sequence_dim)


### PR DESCRIPTION
Takes three modules to **100% statement and branch coverage**, and improves a fourth. Test-only; no library code is touched.

## Result

Measured with `--runslow` (the branches involved are only reached by slow tests):

| module | before | after |
| --- | ---: | ---: |
| `nonlocal_games/extended_nonlocal_game.py` | 97.96% | **100.00%** |
| `nonlocal_games/xor_game.py` | 95.91% | **100.00%** |
| `state_opt/symmetric_extension_hierarchy.py` | 98.14% | **100.00%** |
| `matrix_props/sk_norm.py` | 96.95% | improved (see below) |

`extended_nonlocal_game.py` reports 295 statements and 208 branches with 0 missed and 0 partial.

## What was uncovered and how it is reached

- **extended_nonlocal_game** (missed 608, 621, 623; partial 607, 620, 622): the sparse out-of-range index check and the `<=` / `>=` operator arms of `_answer_event_linear_constraint`. The new tests call that builder directly with a small hand-built assemblage rather than going through `commuting_measurement_value_upper_bound`, so the branches are covered without an SDP solve and the tests stay fast.
- **xor_game** (missed 244, partial 243): the `problem.value is None` guard. Covered by patching `cvxpy.Problem.solve` to a no-op so the problem is left without a value, matching the monkeypatch style already used in `test_integral_relative_entropy.py`.
- **symmetric_extension_hierarchy** (partial 204): the `isinstance(dim, int)` check only ever saw scalars. The new test passes `dim=[2, 2]` and asserts it agrees with the scalar form.
- **sk_norm** (missed 223, partial 220/237): the `k > 1` SDP arm, which uses the partial-trace constraint instead of the partial transpose. No existing test reached it. I confirmed the branch is hit deterministically across repeated runs before adding the test, so it is not flaky.

## Why sk_norm is not at 100%

One line remains: the recursive `return __lower_bound_sk_norm_randomized(...)` taken when the Schmidt rank drops below `k` mid-iteration. It is not reachable from a random positive operator (I tried 12 seeds), and it cannot be set up through `start_vec` because of a separate latent bug, which I have filed separately rather than fix here.

## Not included

`is_separable.py` is the largest remaining gap, but it is deliberately left alone: it is #1915, published as a good first issue.