### PR TITLE
docs: document toqito return values

### DIFF
--- a/toqito/matrices/gell_mann.py
+++ b/toqito/matrices/gell_mann.py
@@ -69,6 +69,10 @@ def gell_mann(ind: int, is_sparse: bool = False) -> np.ndarray | csr_array:
         ind: An integer between 0 and 8 (inclusive).
         is_sparse: Boolean to determine whether array is sparse. Default value is `False`.
 
+    Returns:
+        The Gell-Mann matrix as a dense `numpy.ndarray`, or as a sparse
+        `scipy.sparse.csr_array` when `is_sparse` is `True`.
+
     Raises:
         ValueError: Indices must be integers between 0 and 8.
 

--- a/toqito/states/w_state.py
+++ b/toqito/states/w_state.py
@@ -22,6 +22,9 @@ def w_state(num_qubits: int, coeff: list[int] | None = None) -> np.ndarray:
         num_qubits: An integer representing the number of qubits.
         coeff: default is `[1, 1, ..., 1]/sqrt(num_qubits)`: a 1-by-`num_qubits` vector of coefficients.
 
+    Returns:
+        A dense `numpy.ndarray` containing the W-state column vector.
+
     Raises:
         ValueError: The number of qubits must be at least 2.
 


### PR DESCRIPTION
Fixes #1916

Add Google-style Returns sections to `gell_mann` and `w_state`, documenting dense and sparse return types.