### PR TITLE
perf: vectorize channel Gram matrix construction

### DIFF
--- a/toqito/channel_ops/channel_gram_matrix.py
+++ b/toqito/channel_ops/channel_gram_matrix.py
@@ -79,9 +79,5 @@ def channel_gram_matrix(
     elif sigma.shape != (dim_in, dim_in):
         raise ValueError("sigma must be a (dim_in, dim_in) density operator.")
 
-    n = len(isometries)
-    gram = np.zeros((n, n), dtype=complex)
-    for i in range(n):
-        for j in range(n):
-            gram[i, j] = np.trace(isometries[j].conj().T @ isometries[i] @ sigma)
-    return gram
+    mats = np.stack(isometries)
+    return np.einsum("jab,iac,cb->ij", mats.conj(), mats, sigma, dtype=complex, optimize=True)

--- a/toqito/channel_ops/tests/test_channel_gram_matrix.py
+++ b/toqito/channel_ops/tests/test_channel_gram_matrix.py
@@ -40,6 +40,24 @@ def test_custom_sigma():
     assert np.isclose(gram[0, 1], 0.5)
 
 
+def test_vectorized_result_matches_reference_for_rectangular_isometries():
+    """The vectorized contraction agrees with the entry-by-entry definition."""
+    rng = np.random.default_rng(0)
+    isometries = [np.linalg.qr(rng.normal(size=(5, 3)) + 1j * rng.normal(size=(5, 3)))[0] for _ in range(4)]
+    sigma_factor = rng.normal(size=(3, 3)) + 1j * rng.normal(size=(3, 3))
+    sigma = sigma_factor @ sigma_factor.conj().T
+    sigma /= np.trace(sigma)
+    expected = np.array(
+        [[np.trace(right.conj().T @ left @ sigma) for right in isometries] for left in isometries],
+        dtype=complex,
+    )
+
+    result = channel_gram_matrix(isometries, sigma)
+
+    assert result.dtype == np.dtype(complex)
+    assert np.allclose(result, expected)
+
+
 def test_non_isometry_raises():
     """A non-isometry operator is rejected."""
     with pytest.raises(ValueError, match="must be an isometry"):


### PR DESCRIPTION
## Description

Vectorize the O(n²) Python loop in channel_gram_matrix as a single optimized NumPy contraction while preserving the public signature, validation behavior, output values, and complex return dtype.

Closes #1913

## Changes

- stack the validated isometries once and compute all Gram entries with np.einsum
- explicitly retain the existing complex output dtype
- add a regression test against the entry-by-entry definition using complex rectangular isometries and a nontrivial density matrix

## Benchmark

Median of 7 repeats with 10 calls per repeat on arm64 macOS, Python 3.12.13, and NumPy 2.4.1. Timings include the existing validation.

| isometries | local dim | before | after | speedup |
| ---: | ---: | ---: | ---: | ---: |
| 8 | 4 | 0.375 ms | 0.174 ms | 2.2x |
| 20 | 8 | 2.919 ms | 0.461 ms | 6.3x |
| 40 | 16 | 11.740 ms | 0.954 ms | 12.3x |

## Checklist

- [x] ruff check and ruff format --check pass for channel_ops
- [x] channel_ops test suite passes: 71 passed
- [ ] documentation build not run locally because this change does not touch docs