### PR TITLE
perf(channels): build depolarizing Kraus operators without a nested loop

### DIFF
--- a/toqito/channels/depolarizing.py
+++ b/toqito/channels/depolarizing.py
@@ -113,11 +113,9 @@ def depolarizing(dim: int, param_p: float = 0, return_kraus_ops: bool = False) -
             kraus_ops.append(np.sqrt(param_p) * np.eye(dim))
         coeff = np.sqrt((1 - param_p) / dim)
         if coeff > 0:
-            for i in range(dim):
-                for j in range(dim):
-                    op = np.zeros((dim, dim))
-                    op[i, j] = coeff
-                    kraus_ops.append(op)
+            # The single-entry operators |i><j| for all i, j are the d^2 rows of the
+            # (d^2)-identity reshaped into d-by-d matrices, in row-major (i then j) order.
+            kraus_ops.extend(coeff * np.eye(dim * dim).reshape(dim * dim, dim, dim))
         return kraus_ops
 
     result = np.zeros((dim**2, dim**2), dtype=np.float64)


### PR DESCRIPTION
Closes #1914.

Builds the depolarizing Kraus operators without the `d^2` nested-loop allocations.

The single-entry operators `sqrt((1-p)/d) |i><j|` are exactly the `d^2` rows of the `(d^2)`-identity reshaped into `d`-by-`d` matrices, so the loop is replaced by a single construction:

```python
kraus_ops.extend(coeff * np.eye(dim * dim).reshape(dim * dim, dim, dim))
```

**Preserved**, as requested in the issue:
- **Ordering** — row-major over `i` then `j` (the `reshape` of the identity yields exactly that order).
- **Guards** — the `param_p > 0` (keeps `sqrt(p)·I`) and `coeff > 0` (drops zero-weight ops) branches are untouched.

**Verification** — for `dim ∈ {1..5}` and `p ∈ {0, 0.3, 0.5, 1.0}`, the new construction returns an identical list (count, ordering, and values) to the old nested loop:

```
IDENTICAL for all dims/p (count, ordering, values). vectorized fix correct.
```

No behavior change, only the internal construction.

---
🤖 Assisted by Claude (disclosed).
