### PR TITLE
fix: zero-pad start_vec with Schmidt rank below k in sk-norm lower bound

### DIFF
--- a/toqito/matrix_props/sk_norm.py
+++ b/toqito/matrix_props/sk_norm.py
@@ -326,9 +326,9 @@ def __lower_bound_sk_norm_randomized(
             )
         else:
             opt_vec = start_vec
-            opt_schmidt = np.zeros((max(dim) * k, max(dim) * k))
-            opt_schmidt[: k * dim_a, 0] = np.ravel(vt_mat @ np.diag(singular_vals), order="F")
-            opt_schmidt[: k * dim_b, 1] = np.ravel(u_mat, order="F")
+            opt_schmidt = np.zeros((max(dim) * k, 2), dtype=complex)
+            opt_schmidt[: s_rank * dim_a, 0] = np.ravel(vt_mat @ np.diag(singular_vals.ravel()), order="F")
+            opt_schmidt[: s_rank * dim_b, 1] = np.ravel(u_mat, order="F")
 
     if opt_vec is None:
         opt_schmidt = np.random.randn(max(dim) * k, 2) + 1j * np.random.randn(max(dim) * k, 2)

--- a/toqito/matrix_props/tests/test_sk_norm.py
+++ b/toqito/matrix_props/tests/test_sk_norm.py
@@ -189,3 +189,27 @@ def test_sk_norm_randomized_start_vec_low_schmidt_rank_used_as_init():
     product = np.kron(np.array([1.0, 0.0]), np.array([1.0, 0.0]))
     result = __lower_bound_sk_norm_randomized(np.eye(4), k=1, dim=dim, tol=1e-4, start_vec=product)
     assert np.isfinite(result)
+
+
+def test_sk_norm_randomized_start_vec_schmidt_rank_below_k_zero_padded():
+    """Private helper: `start_vec` with Schmidt rank < k is zero-padded into the k-sized workspace."""
+    dim = [2, 2]
+    product = np.kron(np.array([1.0, 0.0]), np.array([1.0, 0.0]))
+    result = __lower_bound_sk_norm_randomized(np.eye(4), k=2, dim=dim, tol=1e-4, start_vec=product)
+    np.testing.assert_allclose(result, 1.0)
+
+
+def test_sk_norm_randomized_start_vec_full_schmidt_rank_gt_one():
+    """Private helper: `start_vec` with Schmidt rank == k > 1 is used directly as the iteration seed."""
+    dim = [2, 2]
+    max_ent = max_entangled(2, is_normalized=True).reshape(-1)
+    result = __lower_bound_sk_norm_randomized(np.eye(4), k=2, dim=dim, tol=1e-4, start_vec=max_ent)
+    np.testing.assert_allclose(result, 1.0)
+
+
+def test_sk_norm_randomized_start_vec_complex_below_k():
+    """Private helper: complex `start_vec` with Schmidt rank < k is handled without a casting error."""
+    dim = [3, 3]
+    product = np.kron(np.array([1j, 0.0, 0.0]), np.array([1.0, 0.0, 0.0]))
+    result = __lower_bound_sk_norm_randomized(np.eye(9), k=2, dim=dim, tol=1e-4, start_vec=product)
+    assert np.isfinite(result)


### PR DESCRIPTION
## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->

Fixes #1918.

The randomized S(k)-norm lower bound crashed when a caller-supplied `start_vec` had Schmidt rank strictly below `k`. The Schmidt data was written assuming `k` blocks, but `vt_mat`/`u_mat` only have `s_rank` columns, so the raveled length (`dim_a * s_rank`) did not match the assignment slice (`k * dim_a`), raising an opaque broadcast error. The seed is now zero-padded into the `k`-sized workspace so a lower-rank `start_vec` is used as intended.

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [x] Write the Schmidt components into the leading `s_rank` blocks, zero-padding the remaining `k - s_rank` blocks, matching the intent of the existing `s_rank <= k` guard.
  -  [x] Build the diagonal scaling matrix from `singular_vals.ravel()`. `schmidt_decomposition` returns `singular_vals` as an `(s_rank, 1)` column, so `np.diag` previously extracted the diagonal instead of forming a matrix; that only worked by accident for `s_rank == 1` and raised a matmul mismatch for `s_rank > 1`.
  -  [x] Allocate `opt_schmidt` as `(max(dim) * k, 2)` with `complex` dtype to match the random-init path. The old square shape left all-zero columns that produced a divide-by-zero for `k > 1`, and the real dtype discarded the imaginary part of complex `start_vec`.
  -  [x] Add tests covering `s_rank < k`, `s_rank == k > 1`, and complex `start_vec`. These also make the mid-iteration rank-collapse branch (`schmidt_rank(opt_vec) < k`) reachable from a public call.

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://vprusso.github.io/toqito/contributing-guide/).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [ ] Check the documentation build does not lead to any failures.
