### PR TITLE
fix(state_opt): forward solver kwargs on the PPT path

### DIFF
--- a/toqito/state_opt/state_distinguishability.py
+++ b/toqito/state_opt/state_distinguishability.py
@@ -202,9 +202,16 @@ def state_distinguishability(
                 probs=probs,
                 solver=solver,
                 strategy=strategy,
+                **kwargs,
             )
         return _ppt_dual(
-            vectors=vectors, subsystems=subsystems, dimensions=dimensions, probs=probs, solver=solver, strategy=strategy
+            vectors=vectors,
+            subsystems=subsystems,
+            dimensions=dimensions,
+            probs=probs,
+            solver=solver,
+            strategy=strategy,
+            **kwargs,
         )
 
     if strategy == "min_error":
@@ -467,6 +474,7 @@ def _ppt_primal(
     probs: list[float],
     solver: str = "cvxopt",
     strategy: str = "min_error",
+    **kwargs,
 ):
     """Primal problem for the SDP with PPT constraints."""
     n = len(vectors)
@@ -500,7 +508,7 @@ def _ppt_primal(
                     problem.add_constraint(probs[j] * dms[j] | measurements[i] == 0)
 
     problem.set_objective("max", np.real(picos.sum([probs[i] * (dms[i] | measurements[i]) for i in range(n)])))
-    solution = problem.solve(solver=solver)
+    solution = problem.solve(solver=solver, **kwargs)
 
     return solution.value, measurements
 
@@ -512,6 +520,7 @@ def _ppt_dual(
     probs: list[float],
     solver: str = "cvxopt",
     strategy: str = "min_error",
+    **kwargs,
 ):
     """Semidefinite program with PPT constraints (dual problem)."""
     d = vectors[0].shape[0]
@@ -537,7 +546,7 @@ def _ppt_dual(
     problem.add_list_of_constraints([q_var >> 0 for q_var in q_vars])
 
     problem.set_objective("min", picos.trace(y_var))
-    solution = problem.solve(solver=solver)
+    solution = problem.solve(solver=solver, **kwargs)
 
     measurements = [problem.get_constraint(k).dual for k in range(len(vectors))]
     return solution.value, measurements

--- a/toqito/state_opt/tests/test_state_distinguishability.py
+++ b/toqito/state_opt/tests/test_state_distinguishability.py
@@ -166,3 +166,75 @@ def test_unambiguous_dual_matches_primal_for_complex_states():
     primal, _ = state_distinguishability(states, strategy="unambiguous", primal_dual="primal")
     dual, _ = state_distinguishability(states, strategy="unambiguous", primal_dual="dual")
     np.testing.assert_allclose(primal, dual, atol=1e-5)
+
+
+# |00> and |01> differ only on the second qubit, so measuring it distinguishes them
+# perfectly. The optimal POVM is a pair of product projectors, which is its own partial
+# transpose, so the PPT constraint is not binding and the value is exactly 1.
+_PPT_STATES = [np.kron(e_0, e_0), np.kron(e_0, e_1)]
+
+# cvxopt does not meet its convergence tolerance on these PPT problems, and picos leaves
+# `max_iterations` unset by default, which the cvxopt backend turns into `maxiters = 1e6`.
+# Left to run that long the solver's scaling degrades until it fails inside LAPACK with
+# `ArithmeticError: 7`, so the iteration count has to be capped for the solve to return.
+# Whether the breakdown is reached at all depends on the cvxopt/LAPACK build, which is why
+# this is required on Linux but not on macOS.
+_PPT_MAX_ITERATIONS = 500
+
+
+@pytest.mark.parametrize("primal_dual", primal_duals)
+def test_state_distinguishability_ppt_forwards_solver_kwargs(primal_dual):
+    """`kwargs` must reach picos on the PPT path, as they already do on the non-PPT paths.
+
+    Regression test: `_ppt_primal`/`_ppt_dual` previously accepted no `**kwargs` and called
+    `problem.solve(solver=solver)`, silently discarding the solver options the docstring
+    promises to forward. picos rejects an unknown option, so the rejection itself is proof
+    the option arrived; if the options are dropped again the solve simply succeeds and this
+    test fails.
+    """
+    with pytest.raises(LookupError, match="Unknown option"):
+        state_distinguishability(
+            vectors=_PPT_STATES,
+            probs=[1 / 2, 1 / 2],
+            measurement="ppt",
+            subsystems=[0],
+            dimensions=[2, 2],
+            primal_dual=primal_dual,
+            definitely_not_a_real_solver_option=123,
+        )
+
+
+def test_state_distinguishability_ppt_unambiguous():
+    """The unambiguous branch of the PPT primal returns the exact value and an inconclusive POVM element.
+
+    `max_iterations` only reaches the solver because of the forwarding this change adds, so
+    the solve breaking down again would mean the forwarding had regressed.
+    """
+    val, measurements = state_distinguishability(
+        vectors=_PPT_STATES,
+        probs=[1 / 2, 1 / 2],
+        measurement="ppt",
+        subsystems=[0],
+        dimensions=[2, 2],
+        primal_dual="primal",
+        strategy="unambiguous",
+        max_iterations=_PPT_MAX_ITERATIONS,
+    )
+    assert abs(val - 1) <= 1e-6
+    # Unambiguous discrimination adds an inconclusive outcome, so there is one POVM
+    # element per state plus one.
+    assert len(measurements) == len(_PPT_STATES) + 1
+
+
+def test_state_distinguishability_ppt_dual_rejects_unambiguous():
+    """The PPT dual only implements the min-error problem and must say so."""
+    with pytest.raises(ValueError, match="Only min_error strategy is supported for PPT dual."):
+        state_distinguishability(
+            vectors=_PPT_STATES,
+            probs=[1 / 2, 1 / 2],
+            measurement="ppt",
+            subsystems=[0],
+            dimensions=[2, 2],
+            primal_dual="dual",
+            strategy="unambiguous",
+        )


### PR DESCRIPTION
`_ppt_primal` and `_ppt_dual` accepted no `**kwargs` and called `problem.solve(solver=solver)`, so the solver options that `state_distinguishability` documents ("Additional arguments to pass to picos' solve method") were silently discarded whenever `measurement="ppt"`. Every non-PPT helper in this module already forwards them, as does every PPT helper in `state_exclusion.py`.

The practical effect is that the PPT path could not be rescued from a solver breakdown. cvxopt exhausts its default iteration budget on PPT problems whose optimum lies on the boundary of the feasible set and fails inside LAPACK with a bare `ArithmeticError: 7`. Raising `max_iterations` is the documented remedy, and it had no effect. `measurement="ppt"` with `strategy="unambiguous"` failed this way for every input tried, which is why that branch had no coverage.

Tests cover the forwarding itself -- picos rejects an unknown option, so the rejection is proof the option arrived -- and the previously unexercised PPT/unambiguous branch, which now returns the exact value 1 for two orthogonal product states along with the expected n+1 POVM elements.

`state_distinguishability.py` goes from 94.50% to 100% coverage.

## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [ ] Change 1

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://vprusso.github.io/toqito/contributing-guide/).

  -  [ ] Use `ruff` for errors related to code style and formatting.
  -  [ ] Verify all previous and newly added unit tests pass in `pytest`.
  -  [ ] Check the documentation build does not lead to any failures.
