### PR TITLE
test(docs): assert BB84 parallel repetition values

### DIFF
--- a/docs/content/examples/extended_nonlocal_games/parallel_repetition.py
+++ b/docs/content/examples/extended_nonlocal_games/parallel_repetition.py
@@ -93,6 +93,8 @@ omega_ue = bb84.unentangled_value()
 omega_ns = bb84.nonsignaling_value()
 exact = np.cos(np.pi / 8) ** 2
 
+np.testing.assert_allclose([omega_ue, omega_ns], exact, rtol=1e-3)
+
 print(f"Unentangled value:    {omega_ue:.5f}")
 print(f"Non-signaling value:  {omega_ns:.5f}")
 print(f"Exact (cos²(π/8)):    {exact:.5f}")
@@ -114,6 +116,8 @@ bb84_2_reps = ExtendedNonlocalGame(bb84_prob_mat, bb84_pred_mat, reps=2)
 
 omega_ue_2 = bb84_2_reps.unentangled_value()
 expected_ue_2 = exact**2
+
+np.testing.assert_allclose(omega_ue_2, expected_ue_2, rtol=1e-3)
 
 print(f"ω(G²) unentangled:   {omega_ue_2:.5f}")
 print(f"ω(G)² expected:      {expected_ue_2:.5f}")
@@ -138,6 +142,9 @@ print(f"Strong parallel rep holds: {np.isclose(omega_ue_2, expected_ue_2, atol=1
 # %%
 omega_ns_2 = bb84_2_reps.nonsignaling_value()
 expected_ns_2 = exact**2
+known_ns_2_value = 0.73826
+
+np.testing.assert_allclose(omega_ns_2, known_ns_2_value, rtol=1e-3)
 
 print(f"ω_ns(G²):            {omega_ns_2:.5f}")
 print(f"ω_ns(G)²:            {expected_ns_2:.5f}")


### PR DESCRIPTION
Follow-up to #1924 and #1926.

## Description

#1926 corrected the BB84 predicate-axis ordering in the parallel-repetition gallery. This follow-up adds executable regression assertions so the gallery fails loudly if its computed values ever drift from the cited results instead of silently rendering contradictory output.

## Changes

- [x] Assert the single-game unentangled and non-signaling values against `cos²(π/8)`.
- [x] Assert the two-repetition unentangled value against `cos⁴(π/8)`.
- [x] Assert the two-repetition non-signaling value against the `0.73826` numerical value reported in Russo's thesis.

No library code, predicate construction, or narrative claims are changed.

## Validation

- Rebased onto current `master` after #1926.
- Executed the parallel-repetition gallery successfully with all assertions passing.
- Passed the four focused `ExtendedNonlocalGame` BB84 tests.
- Passed forced Ruff check and format on the gallery file.
- Passed `git diff --check`.

## Checklist

- [x] The title is concise and informative.
- [x] The description explains the regression protection.
- [x] Linked the diagnosing issue and merged mechanical fix.
- [x] Added executable regression assertions.
- [ ] Full upstream CI refresh.

## AI assistance

Codex assisted with collision checking, diagnosis, rebase conflict resolution, and drafting. The contribution was reviewed against the cited papers, executable outputs, repository conventions, maintainer feedback, and existing regression tests.
