### PR TITLE
docs: fix BB84 predicate axis order in the parallel-repetition gallery

### DIFF
--- a/docs/content/examples/extended_nonlocal_games/parallel_repetition.py
+++ b/docs/content/examples/extended_nonlocal_games/parallel_repetition.py
@@ -71,11 +71,13 @@ e_0, e_1 = np.array([[1], [0]]), np.array([[0], [1]])
 e_p = (e_0 + e_1) / np.sqrt(2)
 e_m = (e_0 - e_1) / np.sqrt(2)
 
-bb84_pred_mat = np.zeros([2, 2, 2, 2, dim_referee, dim_referee], dtype=complex)
-bb84_pred_mat[0, 0, 0, 0] = e_0 @ e_0.conj().T
-bb84_pred_mat[1, 1, 0, 0] = e_1 @ e_1.conj().T
-bb84_pred_mat[0, 0, 1, 1] = e_p @ e_p.conj().T
-bb84_pred_mat[1, 1, 1, 1] = e_m @ e_m.conj().T
+# `ExtendedNonlocalGame` expects the referee's row and column to be the
+# leading axes: `pred_mat[:, :, a, b, x, y]` holds V(a,b|x,y).
+bb84_pred_mat = np.zeros([dim_referee, dim_referee, 2, 2, 2, 2])
+bb84_pred_mat[:, :, 0, 0, 0, 0] = e_0 @ e_0.conj().T
+bb84_pred_mat[:, :, 1, 1, 0, 0] = e_1 @ e_1.conj().T
+bb84_pred_mat[:, :, 0, 0, 1, 1] = e_p @ e_p.conj().T
+bb84_pred_mat[:, :, 1, 1, 1, 1] = e_m @ e_m.conj().T
 
 bb84_prob_mat = np.array([[0.5, 0], [0, 0.5]])
 


### PR DESCRIPTION
Fixes #1924.

## Problem

`docs/content/examples/extended_nonlocal_games/parallel_repetition.py` built the predicate tensor with the axes ordered `(alice_out, bob_out, alice_in, bob_in, referee_row, referee_col)`, but `ExtendedNonlocalGame` expects the referee axes first. Every dimension in the example is 2, so the wrong order is shape-compatible and is accepted without complaint — it simply encodes a different game.

The rendered page therefore contradicted its own narrative on every claim it makes:

```text
Unentangled value:    0.75000
Non-signaling value:  0.75000
Exact (cos²(π/8)):    0.85355
ω(G²) unentangled:   0.56250
ω(G)² expected:      0.72855
Strong parallel rep holds: False
ω_ns(G²):            0.56250
ω_ns(G)²:            0.72855
ω_ns(G²) > ω_ns(G)²: False
```

## Fix

Index as `pred_mat[:, :, a, b, x, y]`, matching `enlg_bb84.py` and the existing `ExtendedNonlocalGame` BB84 tests, with a comment stating the expected layout so it does not drift back.

I also dropped `dtype=complex`. The BB84 predicate operators are real, and the complex array only produced a `ComplexWarning` from `extended_nonlocal_game.py:79` on every run; `enlg_bb84.py` already uses the real default.

No library code is touched — the public methods were already correct.

## Verification

Running the gallery script from this branch:

```text
Unentangled value:    0.85355
Non-signaling value:  0.85356
Exact (cos²(π/8)):    0.85355
ω(G²) unentangled:   0.72855
ω(G)² expected:      0.72855
Strong parallel rep holds: True
ω_ns(G²):            0.73819
ω_ns(G)²:            0.72855
ω_ns(G²) > ω_ns(G)²: True
```

Every figure now agrees with the cited sources: cos²(π/8) ≈ 0.85355 and cos⁴(π/8) ≈ 0.72855 from Johnston, Mittal, Russo and Watrous (2016), and ω_ns(G²) ≈ 0.73819 against the 0.73826 reported in Russo's thesis, §6.2 (6.47)–(6.49). Both narrative claims — strong parallel repetition holding for unentangled strategies and failing for non-signaling ones — now come out True.

🤖 Generated with [Claude Code](https://claude.com/claude-code)