### PR TITLE
test: cover the see-saw step cap in NonlocalGame.quantum_value_lower_bound

### DIFF
--- a/toqito/nonlocal_games/tests/test_nonlocal_game.py
+++ b/toqito/nonlocal_games/tests/test_nonlocal_game.py
@@ -119,6 +119,25 @@ class TestNonlocalGame(unittest.TestCase):
         res = chsh.quantum_value_lower_bound(tol=1e-1, seed=42)
         self.assertLessEqual(res, np.cos(np.pi / 8) ** 2 + 1e-2)
 
+    def test_chsh_lower_bound_runs_to_step_cap(self):
+        """With a tolerance the convergence check can never meet, the see-saw runs every step.
+
+        Counterpart to ``test_chsh_lower_bound_converges_early``. That test covers the
+        ``break`` in the see-saw loop; this one covers the loop instead running to the
+        internal ``max_seesaw_steps`` cap and falling through, which is the path a game
+        that fails to converge would take. The step cap is not a parameter, so the only
+        way to reach it from the public API is a tolerance the step-to-step change never
+        drops below.
+        """
+        prob_mat, pred_mat = self.chsh_nonlocal_game()
+        chsh = NonlocalGame(prob_mat, pred_mat)
+        res = chsh.quantum_value_lower_bound(iters=1, tol=1e-20, seed=1)
+
+        # Exhausting the cap must still return the best value seen, not a partial or
+        # degenerate one, so the usual bounds on a see-saw lower bound still hold.
+        self.assertGreater(res, 0.0)
+        self.assertLessEqual(res, np.cos(np.pi / 8) ** 2 + 1e-2)
+
     def test_chsh_lower_bound_seed_reproducible(self):
         """A fixed seed makes the see-saw lower bound reproducible and a valid bound."""
         prob_mat, pred_mat = self.chsh_nonlocal_game()


### PR DESCRIPTION
Closes the last uncovered branch in `nonlocal_games/nonlocal_game.py`. Test-only; no library code is touched.

## The gap

Codecov flagged line 432 in `quantum_value_lower_bound`. It is a *partial branch*, not a missed line, which is why it is easy to overlook:

```python
for _step in range(max_seesaw_steps):   # line 432
    ...
    if abs(lower_bound - prev_win) <= tol:
        break                            # line 456
prev_win = lower_bound
```

A `for` statement has two outcomes: enter the body, or exhaust the iterator and fall through. The body runs constantly; the fall-through never happened, because every existing test converges and leaves through the `break`. Traced on CHSH with the default `tol=1e-6`: 4 iterations, one `break`, fall-through never reached.

## Why it was awkward to hit

`max_seesaw_steps = 100` is an internal constant, not a parameter, so there is no direct knob. The lever is `tol`: make it small enough that `abs(lower_bound - prev_win) <= tol` never holds and the loop runs the full cap.

```
tol=1e-6   ->    5 loop-line hits, 1 break,  last _step = 3
tol=1e-20  ->  101 loop-line hits, 0 breaks, last _step = 99
```

Worth noting for anyone comparing the two game classes: `ExtendedNonlocalGame` already has `test_quantum_lb_max_steps_reached_verbose_print`, but that does not transfer, because there `iters` *is* the see-saw cap, whereas in `NonlocalGame` `iters` is the number of random restarts.

## The test

Added as the direct counterpart to the existing `test_chsh_lower_bound_converges_early`, which covers the `break`. It asserts the returned value is still a sane lower bound, so exhausting the cap cannot silently return a partial or degenerate result.

Measured effect on `nonlocal_game.py`, running only this test file:

| | partial branches | missing |
| --- | ---: | --- |
| without the new test | 1 | `432->459` |
| with it | 0 | none |

It costs 0.80s against 0.14s for the default call, so it does not need a `slow` marker.

Beyond the coverage number, this is the only test that exercises the non-convergence path, which is what a pathological game would actually hit.