### PR TITLE
test: cover four unexercised criterion branches in is_separable

### DIFF
--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from toqito.channel_ops.partial_channel import partial_channel
+from toqito.channels import partial_trace
 from toqito.matrix_props import is_density, is_positive_semidefinite
 from toqito.matrix_props.trace_norm import trace_norm
 from toqito.rand import random_density_matrix
@@ -19,7 +20,10 @@ from toqito.state_props.is_separable import (
     _filter_cmc_xi_sum,
     _filter_normal_form,
     _iterative_product_state_subtraction,
+    _positive_map_witness_criteria,
+    _qubit_qudit_ppt_criteria,
     _range_projector_product_overlap_3x3_rank4,
+    _reduction_ppt_criterion,
 )
 from toqito.states import basis, bell, horodecki, isotropic, max_entangled, tile
 
@@ -1716,3 +1720,112 @@ def test_is_separable_n_by_2_ordering_swapped():
     sep, reason = is_separable(_real_product_mixture(3, 12, 4, 2), dim=[4, 2], level=1)
     assert sep is True
     assert "Hildebrand" in reason
+
+
+# --- Individual criterion branches -------------------------------------------
+#
+# The criteria below sit late in the dispatch chain in `is_separable`, so an
+# end-to-end call is normally decided by an earlier, cheaper test and never
+# reaches them. These exercise each helper directly on a state chosen to land on
+# that specific branch, so a wrong verdict from one criterion cannot hide behind
+# a correct verdict from another.
+
+
+def _maximally_entangled_density(d: int) -> np.ndarray:
+    """Density matrix of the maximally entangled state on a d x d system."""
+    vec = sum(np.kron(basis(d, i), basis(d, i)) for i in range(d)) / np.sqrt(d)
+    return vec @ vec.conj().T
+
+
+def test_reduction_criterion_flags_the_maximally_entangled_state():
+    """The reduction criterion (Horodecki 1999) must reject a maximally entangled state.
+
+    rho_A (x) I - rho is not PSD for it, which is the criterion's violation
+    condition.
+    """
+    rho = _maximally_entangled_density(3)
+    rho_a = partial_trace(rho, sys=[1], dim=[3, 3])
+    rho_b = partial_trace(rho, sys=[0], dim=[3, 3])
+
+    verdict = _reduction_ppt_criterion(rho, rho_a, rho_b, 3, 3, 1e-8)
+
+    assert verdict is not None
+    is_sep, reason = verdict
+    assert is_sep is False
+    assert "reduction criterion" in reason
+
+
+def test_reduction_criterion_is_silent_on_the_maximally_mixed_state():
+    """A control: the criterion must abstain, not certify, when it is not violated."""
+    rho = np.eye(9) / 9.0
+    rho_a = partial_trace(rho, sys=[1], dim=[3, 3])
+    rho_b = partial_trace(rho, sys=[0], dim=[3, 3])
+
+    assert _reduction_ppt_criterion(rho, rho_a, rho_b, 3, 3, 1e-8) is None
+
+
+@pytest.mark.parametrize(
+    ("dims", "d_a", "d_b", "min_dim", "max_dim", "prod_dim"),
+    [
+        # Neither local dimension is 2, so the 2xN block algebra does not apply.
+        ([3, 3], 3, 3, 3, 3, 9),
+        ([3, 4], 3, 4, 3, 4, 12),
+        # A zero product dimension must abstain rather than divide the state up.
+        ([2, 3], 2, 3, 2, 3, 0),
+    ],
+)
+def test_qubit_qudit_criteria_abstain_when_not_a_2xn_system(dims, d_a, d_b, min_dim, max_dim, prod_dim):
+    """The 2xN criteria only apply when a local dimension is 2.
+
+    Otherwise the helper must return None rather than running the 2xN block
+    algebra on blocks that do not have the shape it assumes.
+    """
+    rho = np.eye(d_a * d_b) / (d_a * d_b)
+    eigs = np.sort(np.linalg.eigvalsh(rho))[::-1]
+
+    assert _qubit_qudit_ppt_criteria(rho, dims, d_a, d_b, min_dim, max_dim, prod_dim, 1e-8, eigs) is None
+
+
+def test_range_projector_overlap_abstains_below_rank_four():
+    """The rank-4 3x3 range criterion must abstain on a lower-rank state.
+
+    Its Plucker/range argument is only defined at rank 4, so a rank-1 input has
+    to return None rather than a numeric overlap.
+    """
+    prod = np.kron(basis(3, 0), basis(3, 0))
+    rho_rank1 = prod @ prod.conj().T
+
+    assert _range_projector_product_overlap_3x3_rank4(rho_rank1, 1e-8) is None
+
+
+def test_choi_positive_map_witness_flags_a_3x3_entangled_state():
+    """The Choi 1975 positive map detects the 3x3 maximally entangled state."""
+    verdict = _positive_map_witness_criteria(_maximally_entangled_density(3), [3, 3], 3, 3, 1e-8)
+
+    assert verdict is not None
+    is_sep, reason = verdict
+    assert is_sep is False
+    assert "Choi 1975" in reason
+
+
+def test_breuer_hall_positive_map_witness_flags_a_4x4_entangled_state():
+    """The Breuer-Hall map needs an even local dimension, so 4x4 is its smallest case."""
+    verdict = _positive_map_witness_criteria(_maximally_entangled_density(4), [4, 4], 4, 4, 1e-8)
+
+    assert verdict is not None
+    is_sep, reason = verdict
+    assert is_sep is False
+    assert "Breuer-Hall" in reason
+
+
+@pytest.mark.parametrize(("dims", "d_a", "d_b"), [([3, 3], 3, 3), ([4, 4], 4, 4), ([3, 4], 3, 4)])
+def test_positive_map_witnesses_abstain_on_the_maximally_mixed_state(dims, d_a, d_b):
+    """A control across all three witness shapes.
+
+    The maximally mixed state is separable, so every witness must abstain. This
+    pins that the tests above are detecting entanglement rather than simply
+    firing on whatever they are handed.
+    """
+    rho = np.eye(d_a * d_b) / (d_a * d_b)
+
+    assert _positive_map_witness_criteria(rho, dims, d_a, d_b, 1e-8) is None


### PR DESCRIPTION
Towards #1915. A first pass, kept small so it is easy to review, as you suggested.

## Which criteria

`is_separable` runs its criteria in a chain and returns on the first verdict, so the later ones are unreachable end-to-end — a cheaper criterion always decides first. That is also why they were uncovered. A wrong verdict from one of those branches would surface as a wrong separability answer, not an exception, so I tested each helper directly on a state chosen to land on it:

| criterion | state | branch |
|---|---|---|
| Reduction (Horodecki 1999) violated | 3x3 maximally entangled | `_reduction_ppt_criterion` |
| Choi 1975 positive-map witness | 3x3 maximally entangled | `_positive_map_witness_criteria` |
| Breuer-Hall positive-map witness | 4x4 maximally entangled | `_positive_map_witness_criteria` |
| rank-4 3x3 range criterion abstaining below rank 4 | rank-1 product state | `_range_projector_product_overlap_3x3_rank4` |

Testing the private helpers rather than going through `is_separable` follows what the file already does for `_filter_normal_form`, `_iterative_product_state_subtraction` and `_range_projector_product_overlap_3x3_rank4`.

Every positive test is paired with a control on the maximally mixed state asserting the criterion **abstains** (returns `None`). Without those, a helper that fired on everything would pass the positive tests.

I did not touch `is_separable.py`, per the issue.

## Coverage

`is_separable.py`: **92.18% -> 93.28%** (32 -> 28 uncovered lines).

```
uv run pytest --cov-config=.coveragerc --cov=toqito --cov-report=term-missing \
  toqito/state_props/tests/test_is_separable.py
```

`ruff check` and `ruff format --check` are clean on the test file.

## Two branches that look unreachable

While mapping the uncovered lines I hit three I could not reach by any input, because an earlier guard subsumes them. Reporting rather than testing, since a test would have to fake the arguments to get there:

- **`is_separable.py:1118` and `:1124`** — `_horodecki_low_rank_ppt_criteria` returns early on `state_rank <= max_dim_val`. The next two checks are `state_rank <= rank(rho_A)` and `state_rank <= rank(rho_B)`, but `rank(rho_A) <= d_A <= max_dim_val`, so anything satisfying them already returned. (The placeholder `test_horodecki_rank_le_marginal_rank` in the test file targets exactly these, which is presumably why it was left as `pass`.)
- **`is_separable.py:1230`** — `_qubit_qudit_ppt_criteria` returns early unless `min_dim_val == 2`. Reaching line 1230 needs `min_dim_val == 2` together with `d_a != 2` and `d_b != 2`, and `min(d_a, d_b) == 2` makes one of them 2.

Happy to open a separate issue for these if you'd like them tracked — I left them alone here rather than mixing a source change into a test PR.

I have tests for a few more branches (`_filter_normal_form`, the iterative subtraction budget) that I'd rather send as a follow-up once you've had a look at the shape of this one.

## AI disclosure

Written with Claude Code (Claude Opus 5): it mapped the uncovered lines to criteria, searched for states that reach each branch, and wrote the tests and this description. The coverage numbers, the test run and the unreachability arguments above were checked by hand.