### PR TITLE
refactor: remove unreachable separability branches

### DIFF
--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -548,7 +548,7 @@ def is_separable(
 
     # --- 7. Operational Criteria for Low-Rank PPT States (Horodecki et al. 2000) ---
     verdict, rho_A_marginal, rho_B_marginal = _horodecki_low_rank_ppt_criteria(
-        current_state, dims_list, state_rank, max_dim_val, tol
+        current_state, dims_list, state_rank, max_dim_val
     )
     if verdict is not None:
         return verdict
@@ -1104,7 +1104,6 @@ def _horodecki_low_rank_ppt_criteria(
     dims: list[int],
     state_rank: int,
     max_dim_val: int,
-    tol: float,
 ) -> tuple[tuple[bool, str] | None, np.ndarray | None, np.ndarray | None]:
     """Run the Horodecki low-rank PPT criteria and return cached marginals."""
     if state_rank <= max_dim_val:
@@ -1112,20 +1111,6 @@ def _horodecki_low_rank_ppt_criteria(
 
     rho_a_marginal = partial_trace(state, sys=[1], dim=dims)
     rho_b_marginal = partial_trace(state, sys=[0], dim=dims)
-    rank_marg_a = np.linalg.matrix_rank(rho_a_marginal, tol=tol)
-    rank_marg_b = np.linalg.matrix_rank(rho_b_marginal, tol=tol)
-    if state_rank <= rank_marg_a:
-        return (
-            (True, f"rank(rho)={state_rank} <= rank(rho_A)={rank_marg_a} (Horodecki et al. 2000)"),
-            rho_a_marginal,
-            rho_b_marginal,
-        )
-    if state_rank <= rank_marg_b:
-        return (
-            (True, f"rank(rho)={state_rank} <= rank(rho_B)={rank_marg_b} (Horodecki et al. 2000)"),
-            rho_a_marginal,
-            rho_b_marginal,
-        )
     return None, rho_a_marginal, rho_b_marginal
 
 
@@ -1226,8 +1211,6 @@ def _qubit_qudit_ppt_criteria(
     if d_a != 2 and d_b == 2:
         state_t_2xn = swap(state, sys=[1, 2], dim=dims)
         dim_for_hildebrand_map = [d_b, d_a]
-    elif d_a != 2:
-        return None
 
     if state_t_2xn is state:
         current_lam_2xn = sorted_eigs_desc

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -369,12 +369,6 @@ def test_skip_horodecki_if_not_applicable_proceeds_entangled_tiles(tiles_state_3
 # --- Specialized Tests (Edge Cases, Mocking, XFAIL for Incomplete Features) ---
 
 
-@pytest.mark.skip(reason="Requires specific state for Horodecki rank <= marginal rank test.")
-def test_horodecki_rank_le_marginal_rank():
-    """Placeholder for PPT state where rank <= marginal rank implies separability."""
-    pass
-
-
 def test_entangled_by_reduction_criterion_non_psd_choi_T():
     """is_separable expects PSD input; Choi of Transpose map is non-PSD for d>1."""
     d = 3


### PR DESCRIPTION
## Description

This is intended to be a behavior-preserving refactor. It removes three branches in `is_separable` that cannot be reached under the dimension and rank invariants established by their callers. The marginal ranks cannot exceed their subsystem dimensions, so the earlier `rank(rho) <= max(d_A, d_B)` check always wins; after `min(d_A, d_B) == 2`, the 2xN fallback cannot observe both dimensions as non-2.

Closes #1930

## Changes

- remove the redundant marginal-rank verdicts and their now-unused tolerance parameter
- remove the contradictory 2xN fallback
- delete the skipped placeholder test for an input that cannot be constructed

## Behavior preservation

The maintainer compared `is_separable` before and after this change across 112 inputs, covering random density matrices, random separable product mixtures over multiple bipartite dimensions, and representative entangled and bound-entangled states. There were zero differences in either verdicts or reason strings.

## Validation

- `uv run pytest toqito/state_props/tests/test_is_separable.py -q` — 139 passed, 5 skipped, 2 xfailed
- `uvx --from ruff==0.15.0 ruff check toqito/state_props/is_separable.py toqito/state_props/tests/test_is_separable.py`
- `uvx --from ruff==0.15.0 ruff format --check toqito/state_props/is_separable.py toqito/state_props/tests/test_is_separable.py`
- `git diff --check`
- GitHub CI passed the full test matrix on Python 3.12, 3.13, and 3.14 across Ubuntu and macOS

## Checklist

- [x] Ruff lint and formatting checks pass with the version pinned by CI.
- [x] The complete `is_separable` test module passes.
- [x] The full GitHub CI test matrix passes.
