### PR TITLE
docs: add runnable Examples to the three public functions still missing them

### DIFF
--- a/toqito/state_opt/optimal_clone.py
+++ b/toqito/state_opt/optimal_clone.py
@@ -145,6 +145,30 @@ def primal_problem(q_a: np.ndarray, pperm: np.ndarray, num_reps: int) -> float:
     Returns:
         The optimal value of performing a counterfeit attack.
 
+    Examples:
+        `optimal_clone` builds `q_a` and calls this for you; calling it directly means
+        constructing \(Q = \sum_k p_k |\psi_k \otimes \psi_k \otimes \overline{\psi_k}
+        \rangle \langle \cdot |\) yourself. For the four BB84 states the optimal
+        counterfeiting probability is \(3/4\).
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.matrix_ops import tensor
+        from toqito.states import basis
+        from toqito.state_opt.optimal_clone import primal_problem
+
+        e_0, e_1 = basis(2, 0), basis(2, 1)
+        e_p, e_m = (e_0 + e_1) / np.sqrt(2), (e_0 - e_1) / np.sqrt(2)
+        states, probs = [e_0, e_1, e_p, e_m], [1 / 4] * 4
+
+        q_a = np.zeros((len(states[0]) ** 3,) * 2, dtype=complex)
+        for prob, state in zip(probs, states):
+            ket = tensor(state, state, state.conj())
+            q_a += prob * ket @ ket.conj().T
+
+        print(round(primal_problem(q_a, np.array([1]), 1), 4))
+        ```
+
     """
     num_spaces = 3
 
@@ -174,6 +198,29 @@ def dual_problem(q_a: np.ndarray, pperm: np.ndarray, num_reps: int) -> float:
 
     Returns:
         The optimal value of performing a counterfeit attack.
+
+    Examples:
+        The dual is what `optimal_clone` solves by default, since its variable is
+        \(2^n \times 2^n\) rather than \(8^n \times 8^n\). It agrees with the primal at
+        \(3/4\) for the four BB84 states, as strong duality requires.
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.matrix_ops import tensor
+        from toqito.states import basis
+        from toqito.state_opt.optimal_clone import dual_problem
+
+        e_0, e_1 = basis(2, 0), basis(2, 1)
+        e_p, e_m = (e_0 + e_1) / np.sqrt(2), (e_0 - e_1) / np.sqrt(2)
+        states, probs = [e_0, e_1, e_p, e_m], [1 / 4] * 4
+
+        q_a = np.zeros((len(states[0]) ** 3,) * 2, dtype=complex)
+        for prob, state in zip(probs, states):
+            ket = tensor(state, state, state.conj())
+            q_a += prob * ket @ ket.conj().T
+
+        print(round(dual_problem(q_a, np.array([1]), 1), 4))
+        ```
 
     """
     y_var = cvxpy.Variable((2**num_reps, 2**num_reps), hermitian=True)

--- a/toqito/state_props/has_symmetric_inner_extension.py
+++ b/toqito/state_props/has_symmetric_inner_extension.py
@@ -44,6 +44,32 @@ def has_symmetric_inner_extension(
     Raises:
         ValueError: If the dimensions are incompatible or ``level < 2``.
 
+    Examples:
+        The two-qubit maximally mixed state \(\mathbb{I}_4 / 4\) is separable, and the
+        inner extension detects it at the default level.
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.state_props import has_symmetric_inner_extension
+
+        print(has_symmetric_inner_extension(np.identity(4) / 4))
+        ```
+
+        A Bell state is entangled, so it lies outside the cone.
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.states import bell
+        from toqito.state_props import has_symmetric_inner_extension
+
+        rho = bell(0) @ bell(0).conj().T
+
+        print(has_symmetric_inner_extension(rho))
+        ```
+
+        Note the asymmetry: `True` proves separability, while `False` proves nothing --
+        the state may be separable but outside this inner approximation.
+
     """
     if level < 2:
         raise ValueError("`level` must be an integer >= 2 for symmetric inner extensions.")


### PR DESCRIPTION
Refs #1886.

The docs build executes the ` ```python exec="1" ` blocks, so an `Examples` section is both documentation and a lightweight smoke test that the function still runs as described.

## Which functions actually still need one

An AST sweep over `toqito/` for public module-level functions whose docstring has no `Examples:` section returns five names. Most of the targets the issue lists already have one — `measure`, `dicke`, `integral_relative_entropy` and every file under `cones/` are covered — so what is left is:

| function | status |
|---|---|
| `state_props/has_symmetric_inner_extension.py::has_symmetric_inner_extension` | added (named in the issue) |
| `state_opt/optimal_clone.py::primal_problem` | added |
| `state_opt/optimal_clone.py::dual_problem` | added |
| `perms/unique_perms.py::perm_unique_helper` | left alone — internal recursion helper of `unique_perms`, not something a user calls |

## The examples

**`has_symmetric_inner_extension`** gets two blocks, because one does not convey the contract. The maximally mixed two-qubit state returns `True`; a Bell state returns `False`; and the prose says why those are not symmetric — `True` proves separability, `False` proves nothing, since this is an *inner* approximation to the separable cone.

**`primal_problem` / `dual_problem`** take `q_a` and `pperm`, which `optimal_clone` normally builds internally and never hands back. Each example therefore constructs \(Q\) the same way `optimal_clone` does, and notes why the dual is the default (its variable is \(2^n \times 2^n\) rather than \(8^n \times 8^n\)). Both print `0.75` — the known optimal counterfeiting probability for the four BB84 states, and strong duality holding between the two formulations.

## Verification

Every snippet was extracted from the docstrings and executed the way the docs build runs them:

```
OK  has_symmetric_inner_extension block 0 -> 'True'
OK  has_symmetric_inner_extension block 1 -> 'False'
OK  optimal_clone block 0 -> '0.75'
OK  primal_problem block 0 -> '0.75'
OK  dual_problem block 0 -> '0.75'

5 snippets executed, all clean
```

All five blocks in the two touched files run clean and print exactly what the surrounding prose claims. The dual is rounded to 4 places because SCS returns `0.750004`, and an unrounded solver residual in rendered docs reads as a wrong answer.

`ruff check` and `ruff format --check` pass on both files; `toqito/state_opt/tests/test_optimal_clone.py` is 5 passed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)