### PR TITLE
test: cover the DPS and eigenvalue helpers' error-handling branches

### DIFF
--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -16,6 +16,7 @@ from toqito.state_props.is_ppt import is_ppt
 from toqito.state_props.is_separable import (
     _TERHAL_2000_TILE_WITNESS_3X3,
     _choi_1975_choi_matrix,
+    _dps_hierarchy_criterion,
     _filter_cmc_bound,
     _filter_cmc_xi_sum,
     _filter_normal_form,
@@ -24,6 +25,7 @@ from toqito.state_props.is_separable import (
     _qubit_qudit_ppt_criteria,
     _range_projector_product_overlap_3x3_rank4,
     _reduction_ppt_criterion,
+    _sorted_real_eigs_desc,
 )
 from toqito.states import basis, bell, horodecki, isotropic, max_entangled, tile
 
@@ -1829,3 +1831,82 @@ def test_positive_map_witnesses_abstain_on_the_maximally_mixed_state(dims, d_a, 
     rho = np.eye(d_a * d_b) / (d_a * d_b)
 
     assert _positive_map_witness_criteria(rho, dims, d_a, d_b, 1e-8) is None
+
+
+# --- Error-handling branches of the DPS and eigenvalue helpers (#1915) ---
+#
+# Both helpers degrade rather than propagate: the DPS hierarchy abstains when no solver is
+# available, and the eigenvalue helper falls back from ``eigvalsh`` to the general
+# ``eigvals``. Neither path was reached by any test, so a regression that turned an abstain
+# into a crash -- or, worse, into a confident verdict -- would not have shown up.
+
+
+def _separable_3x3():
+    """Return a state the DPS stage would actually be asked about."""
+    return np.eye(9) / 9
+
+
+def test_dps_hierarchy_abstains_when_no_solver_is_installed():
+    """ImportError means "cannot answer", which must not be reported as a verdict."""
+    with mock.patch(
+        "toqito.state_props.is_separable.has_symmetric_extension",
+        side_effect=ImportError("No module named 'cvxpy'"),
+    ):
+        assert _dps_hierarchy_criterion(_separable_3x3(), [3, 3], 2, 1e-8) is None
+
+
+def test_dps_hierarchy_abstains_when_the_solver_fails():
+    """A solver that errors out is also an abstain, not an entanglement claim."""
+    with mock.patch(
+        "toqito.state_props.is_separable.has_symmetric_extension",
+        side_effect=RuntimeError("solver failed to converge"),
+    ):
+        assert _dps_hierarchy_criterion(_separable_3x3(), [3, 3], 2, 1e-8) is None
+
+
+def test_dps_hierarchy_abstains_when_the_inner_cone_check_fails():
+    """The second call inside the try is covered by the same handler."""
+    with (
+        mock.patch("toqito.state_props.is_separable.has_symmetric_extension", return_value=True),
+        mock.patch(
+            "toqito.state_props.is_separable.has_symmetric_inner_extension",
+            side_effect=RuntimeError("solver failed to converge"),
+        ),
+    ):
+        assert _dps_hierarchy_criterion(_separable_3x3(), [3, 3], 2, 1e-8) is None
+
+
+def test_dps_hierarchy_declines_below_level_two():
+    """Level 1 is the PPT test, which earlier stages already did."""
+    assert _dps_hierarchy_criterion(_separable_3x3(), [3, 3], 1, 1e-8) is None
+
+
+def test_sorted_real_eigs_desc_returns_descending_eigenvalues():
+    """The happy path, so the fallbacks below are known to be fallbacks."""
+    state = np.diag([0.5, 0.3, 0.2])
+
+    result = _sorted_real_eigs_desc(state)
+
+    assert result is not None
+    np.testing.assert_allclose(result, [0.5, 0.3, 0.2])
+    assert np.all(np.diff(result) <= 0), "eigenvalues must come back descending"
+
+
+def test_sorted_real_eigs_desc_falls_back_to_eigvals():
+    """``eigvalsh`` can fail on a matrix LAPACK considers non-convergent."""
+    state = np.diag([0.5, 0.3, 0.2])
+
+    with mock.patch("numpy.linalg.eigvalsh", side_effect=np.linalg.LinAlgError("no convergence")):
+        result = _sorted_real_eigs_desc(state)
+
+    assert result is not None
+    np.testing.assert_allclose(result, [0.5, 0.3, 0.2])
+
+
+def test_sorted_real_eigs_desc_returns_none_when_both_solvers_fail():
+    """The caller checks for None and skips the Vidal-Tarrach stage; it must get None."""
+    with (
+        mock.patch("numpy.linalg.eigvalsh", side_effect=np.linalg.LinAlgError("no convergence")),
+        mock.patch("numpy.linalg.eigvals", side_effect=np.linalg.LinAlgError("no convergence")),
+    ):
+        assert _sorted_real_eigs_desc(np.diag([0.5, 0.3, 0.2])) is None


### PR DESCRIPTION
Refs #1915

Taking the issue up on "a PR that covers even a handful of branches is welcome, and it is easier to review that way."

## Coverage

**`toqito/state_props/is_separable.py`: 93.28% → 94.79%** (uncovered lines 28 → 17). Lines now covered: **1354-1359, 1368-1372.**

## Criteria targeted, and why these

Both are helpers that **degrade rather than propagate**, which makes them the worst place to have no coverage: a regression that turned an abstain into a confident verdict would return a *wrong separability answer* instead of raising — exactly the failure mode the issue describes as easy to miss.

**`_dps_hierarchy_criterion`** — neither `except` handler was reached:

- `ImportError` (no CVXPY/solver installed) → asserts `None`, i.e. "cannot answer", **not** `False`
- a generic `RuntimeError` (solver failed to converge) → same
- the `has_symmetric_inner_extension` call, since the second call in the `try` goes through the same handler
- the `level < 2` early return, for completeness

**`_sorted_real_eigs_desc`** — neither `LinAlgError` fallback was reached:

- `eigvalsh` fails → the `eigvals` fallback still returns correct descending eigenvalues
- both fail → returns `None`, which is what the caller checks before skipping the Vidal–Tarrach stage
- plus the happy path, so the fallbacks are known to *be* fallbacks

These patch `numpy.linalg` globally but call the helper directly, so they don't trip the `is_positive_semidefinite` / `eigvalsh` interaction the file's existing comment warns about.

## Deliberately not attempted

Worth saying explicitly, since they're the bulk of what's left:

- **1118, 1124, 1230** — the unreachable branches from #1930, being removed in #1931. Writing tests for code that's about to be deleted seemed like wasted review time.
- **469, 479, 481** — defensive `raise`s after the dimension arithmetic. They look unreachable for the same reason: a zero local dimension with a non-empty state is already rejected by the product-mismatch check above them. I'd rather flag that than assert it — probably belongs in #1930's sweep.
- **904, 916, 1307** — 904/916 are `_filter_normal_form` giving up after its iteration budget; 1307 guards `1 - t + t**2` against being zero, which it never is for real `t` (minimum 0.75). Reaching these needs a purpose-built pathological state, or dead-code removal.

Happy to take another pass at the genuine criteria branches (578, 741→752, 811→826, 1044, 1067, 1237-1238, 1258-1279) in a follow-up — those need states with known separability status rather than monkeypatching, so they're a different kind of work.

**`is_separable.py` itself is untouched**, per the issue.

## Verification

```
pytest toqito/state_props/tests/test_is_separable.py
→ 146 passed, 6 skipped, 2 xfailed

ruff check / ruff format --check → clean
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)