### PR TITLE
docs(state_opt): document the cvxopt failure mode for PPT distinguishability

### DIFF
--- a/toqito/state_opt/state_distinguishability.py
+++ b/toqito/state_opt/state_distinguishability.py
@@ -173,6 +173,34 @@ def state_distinguishability(
         print(np.around(res, decimals=2))
         ```
 
+        PPT-constrained minimum-error state distinguishability.
+
+        ```python
+        import numpy as np
+        from toqito.state_opt import state_distinguishability
+        from toqito.states import bell
+
+        states = [bell(0), bell(1), bell(2)]
+
+        res, _ = state_distinguishability(
+            states,
+            measurement="ppt",
+            subsystems=[0],
+            dimensions=[2, 2],
+            primal_dual="primal",
+            cvxopt_kktsolver="ldl",
+        )
+
+        print(np.around(res, decimals=2))
+        ```
+
+        !!! Note
+            If you encounter a `ZeroDivisionError` or an `ArithmeticError` when using cvxopt as a solver (which is the
+            default), you might want to set the `abs_ipm_opt_tol` option to a lower value (the default being `1e-8`) or
+            to set the `cvxopt_kktsolver` option to `ldl`.
+
+            See https://gitlab.com/picos-api/picos/-/issues/341
+
     """
     if measurement not in {"positive", "ppt"}:
         raise ValueError("Argument `measurement` must be either 'positive' or 'ppt'.")


### PR DESCRIPTION
`state_exclusion` warns that cvxopt can fail with a `ZeroDivisionError` or an
`ArithmeticError` on PPT problems, and points at `abs_ipm_opt_tol` or
`cvxopt_kktsolver="ldl"`, with a link to picos#341. `state_distinguishability`
has the same failure mode, carries no such note, and has no PPT example at all,
so a user who hits it has nothing in the docs to go on:

    state_distinguishability(
        [bell(0), bell(1), bell(2)],
        measurement="ppt", subsystems=[0], dimensions=[2, 2],
        primal_dual="primal",
    )
    # ArithmeticError: 7

Adds the same note, worded as in `state_exclusion`, and a PPT example passing
`cvxopt_kktsolver="ldl"`, which returns 0.67 on the same input. The example is a
static block rather than an executed one, matching the PPT example in
`state_exclusion` -- the only non-executed block in either module, presumably
for exactly this reason.

`ldl` clears every PPT instance tried here with the default iteration budget,
including ones a `max_iterations` cap does not rescue. Note the option only
reaches the solver at all because of #1923; before that the PPT helpers
discarded solver kwargs, so the documented remedy had no effect.

Docstring only; no behaviour change.

## Description
<!--Provide a brief description of the PR's purpose here. If your PR is supposed to fix an existing issue, use
a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link your PR to the issue. -->

## Changes
<!--Notable changes that this PR has either accomplished or will accomplish. Feel free to add more lines to the itemized list
below. -->

  -  [ ] Change 1

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://vprusso.github.io/toqito/contributing-guide/).

  -  [ ] Use `ruff` for errors related to code style and formatting.
  -  [ ] Verify all previous and newly added unit tests pass in `pytest`.
  -  [ ] Check the documentation build does not lead to any failures.
