### PR TITLE
docs(state_opt): add a runnable Examples section to npa_constraints

### DIFF
--- a/toqito/state_opt/npa_hierarchy.py
+++ b/toqito/state_opt/npa_hierarchy.py
@@ -33,6 +33,39 @@ def npa_constraints(
             I_R \otimes A_a^x B_b^y \big) \sigma \Big) |j \rangle
     \]
 
+    Examples:
+        The constraints returned here are meant to be handed straight to a cvxpy problem.
+        Maximising the CHSH winning probability over the level-1 relaxation recovers the
+        Tsirelson bound \(\cos^2(\pi/8) \approx 0.8536\), which is strictly above the
+        classical value of \(0.75\).
+
+        The CHSH game asks Alice and Bob a binary question each and accepts their binary
+        answers when \(a \oplus b = x \land y\):
+
+        ```python exec="1" source="above" result="text"
+        from collections import defaultdict
+
+        import cvxpy
+
+        from toqito.state_opt.npa_hierarchy import npa_constraints
+
+        assemblage = defaultdict(cvxpy.Variable)
+        for x in range(2):
+            for y in range(2):
+                assemblage[x, y] = cvxpy.Variable((2, 2), name=f"K({x},{y})")
+
+        p_win = cvxpy.Constant(0)
+        for x in range(2):
+            for y in range(2):
+                for a in range(2):
+                    for b in range(2):
+                        if a ^ b == x * y:
+                            p_win += 0.25 * assemblage[x, y][a, b]
+
+        problem = cvxpy.Problem(cvxpy.Maximize(p_win), npa_constraints(assemblage, k=1))
+        print(f"{problem.solve():.4f}")
+        ```
+
     Args:
         assemblage: The commuting measurement assemblage operator.
         k: The level of the NPA hierarchy to use (default=1).


### PR DESCRIPTION
Towards #1886.

## What

`npa_constraints` was one of the last public functions with no `Examples` section — the docstring explained the assemblage format in detail but never showed the constraints being *used*, which is the part a reader actually needs.

Added a CHSH example: build the 2×2 assemblage, maximise the winning probability over the level-1 relaxation, print the result.

```
0.8536
```

That's \(\cos^2(\pi/8)\), the Tsirelson bound. Picked deliberately over an arbitrary input — it's a number a reader recognises, and it sits visibly above the classical 0.75, so a regression produces an obviously wrong answer rather than a silently plausible one.

The block is `exec="1"`, so the docs build runs it every time and it doubles as a smoke test.

## Scope note

The five files the issue lists as "good targets" all already have `Examples` sections — they were covered by #1932. I re-scanned the package with an AST walk over every public function, and only two were still missing one:

- `toqito/state_opt/npa_hierarchy.py::npa_constraints` — this PR
- `toqito/perms/unique_perms.py::perm_unique_helper` — left alone deliberately; the name says helper and it isn't part of the documented surface. Happy to add one if you consider it public.

So this should close out #1886 for the public API, unless you want `perm_unique_helper` covered too.

Not touching `has_symmetric_inner_extension.py` — @Jethin10 claimed that one on the issue.

## Checks run locally

| gate | result |
| --- | --- |
| `ruff check` | pass |
| `ruff format --check` | already formatted |
| `pytest toqito/state_opt/tests/test_npa_hierarchy.py` | 103 passed |
| docstring block executed | prints `0.8536` |

I extracted the ` ```python exec="1" ` block from the compiled docstring and ran it the way the docs build does, rather than only running my draft in a scratch file — so the thing that's verified is the text as committed.
