### PR TITLE
perf(perms): build the index permutation directly in permute_systems

### DIFF
--- a/toqito/perms/permute_systems.py
+++ b/toqito/perms/permute_systems.py
@@ -197,14 +197,20 @@ def permute_systems(
         permuted_mat = functools.reduce(operator.iconcat, permuted_mat, [])
         return np.array(permuted_mat)
 
-    vec_arg = np.array(list(range(0, input_mat_dims[0])))
-
     # If the dimensions are specified, ensure they are given to the
     # recursive calls as flattened lists.
     if len(dim_arr[0][:]) == 1:
         dim_arr = functools.reduce(operator.iconcat, dim_arr, [])
 
-    row_perm = permute_systems(vec_arg, perm, dim_arr[0][:], False, inv_perm)
+    # Permuting the subsystems of an index vector is exactly a reshape into the
+    # subsystem dimensions, a transpose by `perm`, and a flatten, so build the
+    # index permutation directly instead of recursing. The recursive call
+    # rebuilt and revalidated the dimension arrays on every invocation and
+    # flattened its result through `functools.reduce(operator.iconcat, ...)`,
+    # which concatenates lists one element at a time in Python.
+    row_order = np.argsort(perm) if inv_perm else perm
+    row_dims = np.asarray(dim_arr[0][:], dtype=int).ravel()
+    row_perm = np.arange(int(np.prod(row_dims))).reshape(row_dims).transpose(row_order).ravel()
 
     # This condition is only necessary if the `input_mat` variable is sparse.
     if sparse.issparse(input_mat):
@@ -215,8 +221,8 @@ def permute_systems(
         permuted_mat = input_mat[row_perm, :]
 
     if not row_only:
-        vec_arg = np.array(list(range(0, input_mat_dims[1])))
-        col_perm = permute_systems(vec_arg, perm, dim_arr[1][:], False, inv_perm)
+        col_dims = np.asarray(dim_arr[1][:], dtype=int).ravel()
+        col_perm = np.arange(int(np.prod(col_dims))).reshape(col_dims).transpose(row_order).ravel()
         permuted_mat = permuted_mat[:, col_perm]
 
     return permuted_mat


### PR DESCRIPTION
`permute_systems` computed its row and column permutations by **calling itself** on an index vector. Each recursive call re-parsed and revalidated the dimension arrays, then flattened its result with `functools.reduce(operator.iconcat, ...)`, which concatenates lists one element at a time in Python. One top-level call cost three invocations.

Permuting the subsystems of an index vector is just a reshape into the subsystem dimensions, a transpose by `perm`, and a flatten. This builds that directly. The `inv_perm` case transposes by `argsort(perm)`, which I derived from the previous behaviour rather than assumed.

## Correctness

Compared against the previous implementation across **352 cases**: every permutation of dimensions `[2,2]`, `[2,3]`, `[3,2]`, `[2,2,2]`, `[2,3,4]`, `[4,2]`, `[2,2,2,2]`, for matrices and both vector orientations, with `row_only` and `inv_perm` set each way. Results compared with `np.array_equal`, and raised exceptions compared by type.

**Zero mismatches.** Bit-identical, not merely close.

## Speed

Single-threaded, minimum over 200 runs:

| subsystems | before | after | speedup |
| --- | ---: | ---: | ---: |
| 2 qubits | 76.0 us | 33.5 us | **2.27x** |
| 4 qubits | 80.5 us | 34.3 us | **2.34x** |
| 6 qubits | 99.2 us | 42.5 us | **2.33x** |
| 8 qubits | 993.3 us | 867.2 us | 1.15x |

The gain is largest where per-call overhead dominates and shrinks once data movement is the real cost, which is the expected shape for this kind of change.

## Why this function

It came out of a cross-library comparison against QuTiP in `toqito-bench`. `permute_systems` was measurably behind `Qobj.permute`; it now leads:

| | before | after |
| --- | --- | --- |
| 2 qubits | toqito 1.7x slower | toqito **1.29x faster** |
| 4 qubits | toqito 1.6x slower | toqito **1.51x faster** |
| 6 qubits | toqito 1.4x slower | toqito **1.61x faster** |

Measurements were taken with BLAS pinned to one thread and reported as minima, because this machine is loaded and threaded BLAS distorts cross-library ratios rather than slowing everything uniformly.

`permute_systems` is used throughout the library, including by `swap`, `permutation_operator` and the partial-trace paths, so the saving is not confined to direct callers.