### PR TITLE
perf(matrix_ops): use a broadcast-reshape Kronecker kernel in tensor

### DIFF
--- a/toqito/matrix_ops/tensor.py
+++ b/toqito/matrix_ops/tensor.py
@@ -3,6 +3,43 @@
 import numpy as np
 
 
+def _kron(mat_a: np.ndarray, mat_b: np.ndarray) -> np.ndarray:
+    """Compute the Kronecker product of two arrays.
+
+    This agrees with `numpy.kron` bitwise, but skips the per-call `expand_dims` and axis
+    normalization that dominate the runtime for the small operands `|toqito⟩` tensors together.
+    Inserting size-one axes with `reshape` is always a view, so non-contiguous operands are not
+    copied.
+
+    The `type(...) is not np.ndarray` test is deliberately stricter than `isinstance`. Subclasses
+    such as `np.matrix` and masked arrays, along with scipy sparse operands, are handed to
+    `numpy.kron` so that its `subok` wrapping and the sparse return types are preserved.
+    """
+    if type(mat_a) is not np.ndarray or type(mat_b) is not np.ndarray:
+        return np.kron(mat_a, mat_b)
+
+    if mat_a.ndim == 2 and mat_b.ndim == 2:
+        rows_a, cols_a = mat_a.shape
+        rows_b, cols_b = mat_b.shape
+        return (mat_a.reshape(rows_a, 1, cols_a, 1) * mat_b.reshape(1, rows_b, 1, cols_b)).reshape(
+            rows_a * rows_b, cols_a * cols_b
+        )
+
+    # `numpy.kron` pads the operand of lower dimension with leading singleton axes, so match that
+    # rule before interleaving the axes of the two operands.
+    ndim = max(mat_a.ndim, mat_b.ndim)
+    shape_a = (1,) * (ndim - mat_a.ndim) + mat_a.shape
+    shape_b = (1,) * (ndim - mat_b.ndim) + mat_b.shape
+    view_a: list[int] = []
+    view_b: list[int] = []
+    shape_out: list[int] = []
+    for dim_a, dim_b in zip(shape_a, shape_b, strict=True):
+        view_a += [dim_a, 1]
+        view_b += [1, dim_b]
+        shape_out.append(dim_a * dim_b)
+    return (mat_a.reshape(view_a) * mat_b.reshape(view_b)).reshape(shape_out)
+
+
 def tensor(*args: np.ndarray | int | list[np.ndarray]) -> np.ndarray:
     r"""Compute the Kronecker tensor product [@wikipediatensor].
 
@@ -115,9 +152,9 @@ def tensor(*args: np.ndarray | int | list[np.ndarray]) -> np.ndarray:
         if q == 1:
             return matrix
         tmp = fast_exp(matrix, q >> 1)
-        tmp = np.kron(tmp, tmp)
+        tmp = _kron(tmp, tmp)
         if q & 1:  # If q is odd
-            tmp = np.kron(matrix, tmp)
+            tmp = _kron(matrix, tmp)
         return tmp
 
     result = None
@@ -129,10 +166,10 @@ def tensor(*args: np.ndarray | int | list[np.ndarray]) -> np.ndarray:
         if len(args[0]) == 1:
             return args[0][0]
         if len(args[0]) == 2:
-            return np.kron(args[0][0], args[0][1])
+            return _kron(args[0][0], args[0][1])
         result = args[0][0]
         for i in range(1, len(args[0])):
-            result = np.kron(result, args[0][i])
+            result = _kron(result, args[0][i])
         return result
 
     # Tensor product one matrix `n` times with itself.
@@ -146,11 +183,11 @@ def tensor(*args: np.ndarray | int | list[np.ndarray]) -> np.ndarray:
 
     # Tensor product between two or more matrices.
     if len(args) == 2:
-        return np.kron(args[0], args[1])
+        return _kron(args[0], args[1])
     if len(args) >= 3:
         result = args[0]
         for i in range(1, len(args)):
-            result = np.kron(result, args[i])
+            result = _kron(result, args[i])
         return result
 
     raise ValueError("The `tensor` function must take either a matrix or vector.")

--- a/toqito/matrix_ops/tests/test_tensor.py
+++ b/toqito/matrix_ops/tests/test_tensor.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from toqito.matrix_ops import tensor
+from toqito.matrix_ops.tensor import _kron
 from toqito.states import basis
 
 e_0, e_1 = basis(2, 0), basis(2, 1)
@@ -82,3 +83,49 @@ def test_tensor_empty_list():
     r"""An empty input list raises ValueError rather than silently returning None."""
     with pytest.raises(ValueError, match="at least one matrix"):
         tensor([])
+
+
+@pytest.mark.parametrize(
+    "mat_a",
+    [
+        np.array(3.0),
+        np.array([1.0, 2.0, 3.0]),
+        np.array([[1.0, 2.0], [3.0, 4.0]]),
+        np.arange(8, dtype=np.complex128).reshape(2, 2, 2),
+    ],
+)
+@pytest.mark.parametrize(
+    "mat_b",
+    [
+        np.array(2.0 + 1j),
+        np.array([4.0, 5.0]),
+        np.array([[5.0, 6.0, 7.0], [8.0, 9.0, 1.0]]),
+        np.arange(12, dtype=np.float64).reshape(1, 3, 4),
+    ],
+)
+def test_kron_matches_numpy_on_mixed_dimensions(mat_a, mat_b):
+    r"""`_kron` reimplements NumPy's rule for padding the lower-dimensional operand.
+
+    Every other case delegates to `numpy.kron`, so this is the one behaviour that could
+    drift if NumPy ever changed how `kron` broadcasts. Compare bitwise, not approximately.
+    """
+    expected, actual = np.kron(mat_a, mat_b), _kron(mat_a, mat_b)
+
+    assert actual.shape == expected.shape
+    assert actual.dtype == expected.dtype
+    assert actual.tobytes() == expected.tobytes()
+
+
+@pytest.mark.filterwarnings("ignore:the matrix subclass:PendingDeprecationWarning")
+@pytest.mark.parametrize(
+    "mat_a",
+    [
+        np.matrix([[1.0, 2.0], [3.0, 4.0]]),
+        np.ma.masked_array([[1.0, 2.0], [3.0, 4.0]], mask=[[0, 1], [0, 0]]),
+    ],
+)
+def test_kron_preserves_ndarray_subclasses(mat_a):
+    r"""Subclasses route to `numpy.kron` so that its `subok` wrapping is preserved."""
+    plain = np.array([[1.0, 0.0], [0.0, 1.0]])
+
+    assert type(_kron(mat_a, plain)) is type(np.kron(mat_a, plain))


### PR DESCRIPTION
At the operand sizes `|toqito⟩` actually tensors together, `np.kron`'s runtime is not
arithmetic: it is the per-call `expand_dims`, `normalize_axis_tuple` and axis validation.
`cProfile` on `NonlocalGame(reps=5)` puts most of `__init__` inside those three, not inside
the multiply.

This replaces the kernel with a broadcast-reshape Kronecker product, building the two
interleaved views directly:

```python
a.reshape(m, 1, n, 1) * b.reshape(1, p, 1, q)  ->  reshape(m * p, n * q)
```

Dispatch, the left fold and `fast_exp` are untouched.

## What does not change

Dtype, shape, return type, exception types and messages, the left-fold association order
and the `fast_exp` squaring order. The result is bitwise identical to `np.kron`, not merely
close, so no tolerance anywhere is affected.

Anything that is not exactly an `np.ndarray` (scipy sparse, `np.matrix`, masked arrays)
falls through to `np.kron`, preserving its `subok` wrapping and the sparse return types.
The `type(...) is not np.ndarray` test is deliberately stricter than `isinstance` for that
reason, and is commented as such.

## Measurements

Single-threaded (`OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1`), both arms interleaved
round-robin inside one process so load drift hits them equally, per-arm minima rather than
means. Sanity check in the same session: `qr(256x256 complex)` at 10.3 ms against an 11 ms
unloaded reference, load average 7.0, so these are clean.

| case | before | after | |
|---|---:|---:|---:|
| `tensor([A]*2)`, A = 2x2 complex | 14.40 us | 3.40 us | 4.24x |
| `tensor([A]*4)` | 45.28 us | 11.47 us | 3.95x |
| `tensor([A]*6)` | 109.63 us | 51.37 us | 2.13x |
| `tensor(e_0, e_0, e_0)` | 28.46 us | 6.13 us | 4.64x |
| `NonlocalGame(reps=3)` | 2.249 ms | 0.725 ms | 3.10x |
| `NonlocalGame(reps=4)` | 13.949 ms | 4.643 ms | 3.00x |
| `NonlocalGame(reps=5)` | 89.525 ms | 39.715 ms | 2.25x |
| `ExtendedNonlocalGame(reps=2)` | 427.11 us | 208.59 us | 2.05x |
| `pauli([0,1,2,3])` dense | 106.85 us | 37.49 us | 2.85x |
| `brauer(2,2)` | 346.96 us | 308.32 us | 1.13x |

The gain is concentrated in small operands and decays to 1.00x once operands reach roughly
8x8, where arithmetic dominates: `d=8 n=3` and `d=16 n=3` both measure 1.00x. Sparse `pauli`
also measures 1.00x, since sparse operands take the `np.kron` fallback.

A balanced-tree reduction was prototyped and rejected. It is faster at n >= 7, but it
changes the multiplication association order and so is not bit-identical, and no call site
in the library reaches n >= 7.

## Equivalence

Checked by execution over 2021 cases, 0 differences. Equality is bitwise: exact Python
type, exact shape, exact dtype, and `tobytes()`, which catches `-0.0` against `0.0` and
differing NaN payloads that `np.array_equal` would let through. Where either side raises,
the exception type and message text must match.

Coverage: list and varargs forms; 2-D operands across 11 shapes including empty ones; 1-D
operands; mixed-ndim 0-D/1-D/2-D/3-D pairs; all 25 dtype-promotion pairs; the
`(matrix, int)` power form for q = 0..8; degenerate dispatch paths including the empty-list
and no-args errors; non-contiguous transposed, strided, reversed, F-order and sliced views;
NaN, infinities, signed zeros, subnormals and 1e308; object dtype; `np.matrix`; masked
arrays; scipy sparse in csr/csc/coo including sparse-dense mixes; and the real call sites
(`basis` kets, `max_entangled`, `pauli` dense and sparse).

Two tests are added, pinning the one behaviour the kernel reimplements rather than
delegates (NumPy's rule for padding the lower-dimensional operand) and the subclass
passthrough.
