### PR TITLE
test(kp_norm): compare against the norm of the same matrix, and seed it

### DIFF
--- a/toqito/matrix_props/tests/test_kp_norm.py
+++ b/toqito/matrix_props/tests/test_kp_norm.py
@@ -10,6 +10,12 @@ from toqito.matrix_props import kp_norm
 from toqito.rand import random_unitary
 from toqito.states import bell
 
+# A single fixed unitary, drawn once. Two separate `random_unitary(5)` calls would compare
+# `kp_norm` of one matrix against the Frobenius norm of a different one, which passes only
+# because that norm is the same for every 5x5 unitary. Seeding also keeps the generated test
+# ID stable, which parallel collection requires.
+_UNITARY_5 = random_unitary(5, seed=42)
+
 
 @pytest.mark.parametrize(
     "vector, k, p, norm_to_compare",
@@ -18,7 +24,7 @@ from toqito.states import bell
         (bell(0), 1, np.inf, 1),
         # When p=2 and k is greater than or equal to one of the input matrix dimensions, the value calculated is
         # the frobenius norm.
-        (random_unitary(5), 5, 2, np.linalg.norm(random_unitary(5), "fro")),
+        (_UNITARY_5, 5, 2, np.linalg.norm(_UNITARY_5, "fro")),
     ],
 )
 def test_kp_norm(vector, k, p, norm_to_compare):


### PR DESCRIPTION
The Frobenius-norm case built its parameters like this:

```python
(random_unitary(5), 5, 2, np.linalg.norm(random_unitary(5), "fro")),
```

Two separate draws. The test compared `kp_norm` of one random unitary against the Frobenius norm of a different one, and passed only because that norm is `sqrt(5)` for every 5x5 unitary. Nothing tied the expected value to the matrix under test, so the case could not have caught a `kp_norm` error that depended on its input.

This draws the matrix once and compares against its own norm.

Seeding it fixes a second problem. The unseeded call put a freshly computed float in the generated test ID, and that value differs in the last ulp between processes:

```
-toqito/matrix_props/tests/test_kp_norm.py::test_kp_norm[vector1-5-2-2.2360679774997902]
+toqito/matrix_props/tests/test_kp_norm.py::test_kp_norm[vector1-5-2-2.2360679774997894]
```

Under `pytest-xdist` the workers therefore collect different test sets and the run aborts before executing anything:

```
Different tests were collected between gw4 and gw2
```

This was the only such case in the suite. With it fixed, the full suite runs clean in parallel with identical results (3724 passed, 62 skipped, 3 xfailed at `-n 4`, `-n 12`, and serial).
