### PR TITLE
ci: run the test suite in parallel with pytest-xdist

### DIFF
--- a/.github/workflows/build-test-actions.yml
+++ b/.github/workflows/build-test-actions.yml
@@ -47,6 +47,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       PYTHON: ${{ matrix.python-version }}
+      # One BLAS thread per worker. Without this each xdist worker spawns a full
+      # thread pool and the workers fight each other for cores.
+      OMP_NUM_THREADS: 1
+      OPENBLAS_NUM_THREADS: 1
+      MKL_NUM_THREADS: 1
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
@@ -71,10 +76,10 @@ jobs:
           uv sync --group dev --no-group docs --no-group lint
       - name: Run tests
         if: matrix.python-version != '3.12' || matrix.os != 'ubuntu-latest'
-        run: uv run pytest -v -m "not slow"
+        run: uv run pytest -v -m "not slow" -n auto --dist worksteal
       - name: Run tests with coverage (including slow tests)
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
-        run: uv run pytest -v --runslow --cov-config=.coveragerc --cov-report=xml --cov-report term-missing:skip-covered --cov=toqito
+        run: uv run pytest -v --runslow -n auto --dist worksteal --cov-config=.coveragerc --cov-report=xml --cov-report term-missing:skip-covered --cov=toqito
       - name: Upload coverage information
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ repository = "https://github.com/vprusso/toqito"
 dev = [
     "pytest==9.1.0",
     "pytest-cov==7.1.0",
+    "pytest-xdist==3.8.0",
     "coverage==7.15.0",
     "distlib==0.4.0",
     "ipython==9.16.0",

--- a/uv.lock
+++ b/uv.lock
@@ -507,6 +507,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1837,6 +1846,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2356,6 +2378,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "setuptools" },
 ]
 docs = [
@@ -2402,6 +2425,7 @@ dev = [
     { name = "pre-commit", specifier = ">=3.0.0" },
     { name = "pytest", specifier = "==9.1.0" },
     { name = "pytest-cov", specifier = "==7.1.0" },
+    { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "setuptools", specifier = ">65.5.1" },
 ]
 docs = [


### PR DESCRIPTION
The suite takes about 33 minutes serially and CI runs it six times. This runs it in parallel. Nothing about the test set changes: same tests, same assertions, same tolerances, nothing skipped, nothing deferred to a nightly job.

## Why `worksteal` and not the default

The suite is very top-heavy. The 25 slowest of 3724 tests are 81% of the runtime:

| | share of the 2006 s suite |
|---|---:|
| `test_trace_matrix_log` (8 cases) | 38% |
| `test_channel_fidelity` (3 cases) | 17% |
| `cones/*epi_cone` (6 cases) | 13% |
| `channel_measured_relative_entropy` (3 cases) | 7% |

The default `--dist load` pre-assigns tests in chunks, so the three 160-210 s `trace_matrix_log` cases land on one worker late in the run and the other workers idle waiting on that tail. Work-stealing rebalances.

## Measurements

Full suite, local, identical results in every configuration (3724 passed, 62 skipped, 3 xfailed):

| configuration | wall | vs serial |
|---|---:|---:|
| serial (what CI does today) | 2006 s | 1.0x |
| `-n 4 --dist load` | 907 s | 2.2x |
| `-n 12 --dist load` | 870 s | 2.3x |
| `-n 4 --dist worksteal` | 561 s | 3.6x |

Four workers with work stealing beat twelve workers without it, so the scheduler mattered more than the core count. 561 s is close to the 502 s floor implied by the longest single test (281 s), which no amount of parallelism can go under.

## Coverage

The 3.12/ubuntu job combines `--cov` with this, so coverage has to aggregate correctly across workers. Verified on a six-package subset: serial and `-n 4 --dist worksteal` both report 7417 statements, 4219 missed, 3320 branches, 34 partial, 40.33%, with the same test counts. The 80% gate and the codecov numbers are unaffected.

## BLAS threads

`OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS` and `MKL_NUM_THREADS` are pinned to 1 at job level. Without that each worker starts its own thread pool and they contend for the same cores.

## Note on what this does not fix

Parallelism is close to exhausted after this. The remaining runtime is concentrated in four SDP test groups, and the 281 s single test is a hard floor. Getting materially below about 9 minutes means making those specific tests faster, most plausibly by reusing canonicalized cvxpy problems via `Parameter` rather than rebuilding per case. That is separate work and benefits library users too, not just CI.

Depends on #1940, which is required for parallel collection to succeed.
