### PR TITLE
test: solve the cone tests with CLARABEL instead of SCS

### DIFF
--- a/toqito/cones/tests/test_geometric_mean_epi_cone.py
+++ b/toqito/cones/tests/test_geometric_mean_epi_cone.py
@@ -65,7 +65,7 @@ def test_geometric_mean_epi_cone_trace_minimum(dim: int, w: float, hermitian: bo
     if hermitian:
         obj = cvxpy.real(obj)
     problem = cvxpy.Problem(cvxpy.Minimize(obj), constraints)
-    problem.solve(solver=cvxpy.SCS, eps=1e-8, max_iters=400_000, verbose=False)
+    problem.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert problem.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, problem.status
     assert t_var.value is not None

--- a/toqito/cones/tests/test_geometric_mean_hypo_cone.py
+++ b/toqito/cones/tests/test_geometric_mean_hypo_cone.py
@@ -63,7 +63,7 @@ def test_geometric_mean_hypo_cone_trace_maximum(dim: int, w: float, hermitian: b
     if hermitian:
         obj = cvxpy.real(obj)
     problem = cvxpy.Problem(cvxpy.Maximize(obj), constraints)
-    problem.solve(solver=cvxpy.SCS, verbose=False)
+    problem.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert problem.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, problem.status
     assert t_var.value is not None
@@ -87,7 +87,7 @@ def test_geometric_mean_hypo_cone_fullhyp_feasibility_matlab_example():
         hermitian=False,
     )
     problem = cvxpy.Problem(cvxpy.Minimize(0), constraints)
-    problem.solve(solver=cvxpy.SCS, verbose=False)
+    problem.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert problem.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, problem.status
     assert problem.value is not None
     np.testing.assert_allclose(float(problem.value), 0.0, atol=1e-6)
@@ -114,7 +114,7 @@ def test_geometric_mean_hypo_cone_weight_endpoints_restricted(
         hermitian=False,
     )
     problem = cvxpy.Problem(cvxpy.Minimize(0), constraints)
-    problem.solve(solver=cvxpy.SCS, verbose=False)
+    problem.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert problem.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, problem.status
 
 

--- a/toqito/cones/tests/test_integral_relative_entropy_cones.py
+++ b/toqito/cones/tests/test_integral_relative_entropy_cones.py
@@ -31,14 +31,14 @@ def test_integral_relative_entropy_cones_match_float_bounds():
     t_lo = cvxpy.Variable()
     cons_lo = integral_relative_entropy_lower_cone(cvxpy.Constant(mat_x), cvxpy.Constant(mat_y), t_lo)
     prob_lo = cvxpy.Problem(cvxpy.Minimize(t_lo), cons_lo)
-    val_lo = prob_lo.solve(solver=cvxpy.SCS, verbose=False, eps=1e-8)
+    val_lo = prob_lo.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob_lo.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob_lo.status
     assert val_lo == pytest.approx(ref_lo, abs=1e-4)
 
     t_hi = cvxpy.Variable()
     cons_hi = integral_relative_entropy_upper_cone(cvxpy.Constant(mat_x), cvxpy.Constant(mat_y), t_hi)
     prob_hi = cvxpy.Problem(cvxpy.Minimize(t_hi), cons_hi)
-    val_hi = prob_hi.solve(solver=cvxpy.SCS, verbose=False, eps=1e-8)
+    val_hi = prob_hi.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob_hi.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob_hi.status
     assert val_hi == pytest.approx(ref_hi, abs=1e-4)
     assert val_hi >= val_lo - 1e-6
@@ -60,7 +60,7 @@ def test_integral_relative_entropy_cones_explicit_mu_lam():
 
     t_auto = cvxpy.Variable()
     cons_auto = integral_relative_entropy_lower_cone(cvxpy.Constant(mat_x), cvxpy.Constant(mat_y), t_auto)
-    val_auto = cvxpy.Problem(cvxpy.Minimize(t_auto), cons_auto).solve(solver=cvxpy.SCS, verbose=False, eps=1e-8)
+    val_auto = cvxpy.Problem(cvxpy.Minimize(t_auto), cons_auto).solve(solver=cvxpy.CLARABEL, verbose=False)
 
     t_exp = cvxpy.Variable()
     cons_exp = integral_relative_entropy_lower_cone(
@@ -70,7 +70,7 @@ def test_integral_relative_entropy_cones_explicit_mu_lam():
         mu=mu,
         lam=lam,
     )
-    val_exp = cvxpy.Problem(cvxpy.Minimize(t_exp), cons_exp).solve(solver=cvxpy.SCS, verbose=False, eps=1e-8)
+    val_exp = cvxpy.Problem(cvxpy.Minimize(t_exp), cons_exp).solve(solver=cvxpy.CLARABEL, verbose=False)
     assert val_exp == pytest.approx(val_auto, abs=1e-5)
 
 
@@ -96,7 +96,7 @@ def test_integral_relative_entropy_lower_cone_composition_with_explicit_sandwich
         ]
     )
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val is not None
     assert np.isfinite(val)
@@ -114,7 +114,7 @@ def test_integral_relative_entropy_cones_complex_hermitian():
         hermitian=True,
     )
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False, eps=1e-8)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(
         evaluate_relative_entropy_integral(mat_x, mat_y, mean=False)[1],

--- a/toqito/cones/tests/test_lieb_ando_epi_cone.py
+++ b/toqito/cones/tests/test_lieb_ando_epi_cone.py
@@ -65,7 +65,7 @@ def test_lieb_ando_epi_cone_at_constant(dim: int, power: float, hermitian: bool)
         hermitian=hermitian,
     )
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    cvx_val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    cvx_val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert cvx_val is not None
@@ -89,7 +89,7 @@ def test_lieb_ando_epi_cone_identity_k():
         power,
     )
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(ref, abs=5e-2)
 
@@ -105,7 +105,7 @@ def test_lieb_ando_epi_cone_composition():
     cons = lieb_ando_epi_cone(a_var, cvxpy.Constant(mat_b), mat_k, t, 1.5)
     cons.extend([a_var >> eps * np.eye(n), a_var << np.eye(n)])
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     # For K=I, B=I, p=3/2: tr(A^{-1/2}), minimized on [eps I, I] at A=I.

--- a/toqito/cones/tests/test_lieb_ando_hypo_cone.py
+++ b/toqito/cones/tests/test_lieb_ando_hypo_cone.py
@@ -65,7 +65,7 @@ def test_lieb_ando_hypo_cone_at_constant(dim: int, power: float, hermitian: bool
         hermitian=hermitian,
     )
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    cvx_val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    cvx_val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert cvx_val is not None
@@ -89,7 +89,7 @@ def test_lieb_ando_hypo_cone_identity_k():
         power,
     )
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(ref, abs=2e-2)
 
@@ -105,7 +105,7 @@ def test_lieb_ando_hypo_cone_composition():
     cons = lieb_ando_hypo_cone(a_var, cvxpy.Constant(mat_b), mat_k, t, 0.5)
     cons.extend([a_var >> eps * np.eye(n), a_var << np.eye(n)])
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     # On this set, Lieb--Ando for K=I, B=I, t=1/2 is tr(A^{1/2}), max at A=I.

--- a/toqito/cones/tests/test_ln_quantum_entropy_hypo_cone.py
+++ b/toqito/cones/tests/test_ln_quantum_entropy_hypo_cone.py
@@ -56,7 +56,7 @@ def test_ln_quantum_entropy_hypo_cone_at_constant(dim: int, mk: int, apx: int, h
         hermitian=hermitian,
     )
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    cvx_val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    cvx_val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert cvx_val is not None
@@ -79,7 +79,7 @@ def test_ln_quantum_entropy_hypo_cone_composition():
     cons = ln_quantum_entropy_hypo_cone(x_var, t, m=3, k=3, apx=0, hermitian=False)
     cons.extend([x_var >> 0, cvxpy.trace(x_var) == 1])
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     # Maximally mixed state maximizes von Neumann entropy among density matrices.
@@ -95,7 +95,7 @@ def test_ln_quantum_entropy_hypo_cone_maximally_mixed_constant():
     t = cvxpy.Variable()
     cons = ln_quantum_entropy_hypo_cone(cvxpy.Constant(mat_x), t, m=3, k=3, apx=0)
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(float(np.log(n)), rel=0, abs=1e-2)
 

--- a/toqito/cones/tests/test_operator_relative_entropy_epi_cone.py
+++ b/toqito/cones/tests/test_operator_relative_entropy_epi_cone.py
@@ -71,7 +71,7 @@ def test_operator_relative_entropy_epi_cone_trace_minimum(dim: int, mk: int, apx
     if hermitian:
         obj = cvxpy.real(obj)
     prob = cvxpy.Problem(cvxpy.Minimize(obj), cons)
-    prob.solve(solver=cvxpy.SCS, verbose=False)
+    prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert TAU.value is not None
@@ -109,7 +109,7 @@ def test_operator_relative_entropy_epi_cone_projected_subspace():
         hermitian=False,
     )
     prob = cvxpy.Problem(cvxpy.Minimize(cvxpy.trace(TAU)), cons)
-    prob.solve(solver=cvxpy.SCS, verbose=False)
+    prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert TAU.value is not None

--- a/toqito/cones/tests/test_quantum_conditional_entropy_hypo_cone.py
+++ b/toqito/cones/tests/test_quantum_conditional_entropy_hypo_cone.py
@@ -40,7 +40,7 @@ def test_quantum_conditional_entropy_hypo_cone_bell_and_product(sys: int, rho: n
     t = cvxpy.Variable()
     cons = quantum_conditional_entropy_hypo_cone(cvxpy.Constant(rho), t, _DIM, sys=sys)
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(ref, abs=2e-2)
 
@@ -64,7 +64,7 @@ def test_quantum_conditional_entropy_hypo_cone_numpy_integer_dim():
     t = cvxpy.Variable()
     cons = quantum_conditional_entropy_hypo_cone(cvxpy.Constant(rho), t, np.array([2, 2], dtype=np.int64), sys=0)
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(ref, abs=2e-2)
 
@@ -78,7 +78,7 @@ def test_quantum_conditional_entropy_hypo_cone_at_constant(sys: int, seed: int):
     t = cvxpy.Variable()
     cons = quantum_conditional_entropy_hypo_cone(cvxpy.Constant(rho), t, _DIM, sys=sys)
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(ref, abs=3e-2)
 
@@ -91,7 +91,7 @@ def test_quantum_conditional_entropy_hypo_cone_composition():
     cons = quantum_conditional_entropy_hypo_cone(rho_var, t, _DIM, sys=0, hermitian=False)
     cons.extend([rho_var >> 0, cvxpy.trace(rho_var) == 1])
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(float(np.log(2)), abs=5e-2)

--- a/toqito/cones/tests/test_quantum_relative_entropy_epi_cone.py
+++ b/toqito/cones/tests/test_quantum_relative_entropy_epi_cone.py
@@ -55,7 +55,7 @@ def test_quantum_relative_entropy_epi_cone_at_constant(dim: int, mk: int, apx: i
         hermitian=hermitian,
     )
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val is not None
@@ -88,7 +88,7 @@ def test_quantum_relative_entropy_epi_cone_pure_vs_maximally_mixed():
         apx=0,
     )
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(float(np.log(2)), abs=2e-2)
 
@@ -110,7 +110,7 @@ def test_quantum_relative_entropy_epi_cone_composition():
     )
     cons.extend([x_var >> 0, cvxpy.trace(x_var) == 1])
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(0.0, abs=5e-2)

--- a/toqito/cones/tests/test_relative_entropy_quadrature_epi_cone.py
+++ b/toqito/cones/tests/test_relative_entropy_quadrature_epi_cone.py
@@ -36,7 +36,7 @@ def test_relative_entropy_quadrature_epi_cone_at_constant(n: int, mk: int, apx: 
         apx=apx,
     )
     prob = cvxpy.Problem(cvxpy.Minimize(cvxpy.sum(z)), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val is not None
@@ -53,7 +53,7 @@ def test_relative_entropy_quadrature_epi_cone_known_pair():
     z = cvxpy.Variable(2)
     cons = relative_entropy_quadrature_epi_cone(cvxpy.Constant(vec_x), cvxpy.Constant(vec_y), z)
     prob = cvxpy.Problem(cvxpy.Minimize(cvxpy.sum(z)), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(float(np.sum(ref)), abs=2e-2)
 
@@ -69,7 +69,7 @@ def test_relative_entropy_quadrature_epi_cone_broadcast_scalar_x():
         z,
     )
     prob = cvxpy.Problem(cvxpy.Minimize(cvxpy.sum(z)), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(float(np.sum(ref)), abs=2e-2)
     assert z.value is not None
@@ -87,7 +87,7 @@ def test_relative_entropy_quadrature_epi_cone_broadcast_scalar_y():
         z,
     )
     prob = cvxpy.Problem(cvxpy.Minimize(cvxpy.sum(z)), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(float(np.sum(ref)), abs=2e-2)
 
@@ -102,7 +102,7 @@ def test_relative_entropy_quadrature_epi_cone_both_scalars():
         z,
     )
     prob = cvxpy.Problem(cvxpy.Minimize(z), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(ref, abs=2e-2)
 
@@ -127,7 +127,7 @@ def test_relative_entropy_quadrature_epi_cone_composition():
     cons = relative_entropy_quadrature_epi_cone(x_var, cvxpy.Constant(vec_y), z)
     cons.append(cvxpy.sum(x_var) == 1)
     prob = cvxpy.Problem(cvxpy.Minimize(cvxpy.sum(z)), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(0.0, abs=5e-2)

--- a/toqito/cones/tests/test_trace_matrix_log_hypo_cone.py
+++ b/toqito/cones/tests/test_trace_matrix_log_hypo_cone.py
@@ -59,7 +59,7 @@ def test_trace_matrix_log_hypo_cone_at_constant(dim: int, mk: int, apx: int, her
         hermitian=hermitian,
     )
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    cvx_val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    cvx_val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert cvx_val is not None
@@ -82,7 +82,7 @@ def test_trace_matrix_log_hypo_cone_default_mat_c_is_identity():
     t = cvxpy.Variable()
     cons = trace_matrix_log_hypo_cone(cvxpy.Constant(mat_x), t, m=3, k=3, apx=0)
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     ref = float(np.real(np.trace(logm(mat_x))))
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(ref, rel=0, abs=1e-2)
@@ -98,7 +98,7 @@ def test_trace_matrix_log_hypo_cone_composition():
     # Bounded feasible set so Maximize(tr(log X)) is well-posed.
     cons.extend([x_var >> eps * np.eye(n), x_var << np.eye(n)])
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     # Optimum of tr(log X) on eps I ⪯ X ⪯ I is at X = I.

--- a/toqito/cones/tests/test_trace_matrix_power_epi_cone.py
+++ b/toqito/cones/tests/test_trace_matrix_power_epi_cone.py
@@ -61,7 +61,7 @@ def test_trace_matrix_power_epi_cone_at_constant(dim: int, power: float, hermiti
         hermitian=hermitian,
     )
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    cvx_val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    cvx_val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert cvx_val is not None
@@ -75,7 +75,7 @@ def test_trace_matrix_power_epi_cone_default_mat_c_is_identity():
     t = cvxpy.Variable()
     cons = trace_matrix_power_epi_cone(cvxpy.Constant(mat_a), t, 1.5)
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(float(n), abs=1e-2)
 
@@ -89,7 +89,7 @@ def test_trace_matrix_power_epi_cone_composition():
     cons = trace_matrix_power_epi_cone(a_var, t, 1.5, hermitian=False)
     cons.extend([a_var >> eps * np.eye(n), a_var << np.eye(n)])
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     # Optimum of tr(A^{3/2}) on this set is at A = eps I.

--- a/toqito/cones/tests/test_trace_matrix_power_hypo_cone.py
+++ b/toqito/cones/tests/test_trace_matrix_power_hypo_cone.py
@@ -61,7 +61,7 @@ def test_trace_matrix_power_hypo_cone_at_constant(dim: int, power: float, hermit
         hermitian=hermitian,
     )
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    cvx_val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    cvx_val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert cvx_val is not None
@@ -75,7 +75,7 @@ def test_trace_matrix_power_hypo_cone_default_mat_c_is_identity():
     t = cvxpy.Variable()
     cons = trace_matrix_power_hypo_cone(cvxpy.Constant(mat_a), t, 0.5)
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(float(n), abs=1e-2)
 
@@ -89,7 +89,7 @@ def test_trace_matrix_power_hypo_cone_composition():
     cons = trace_matrix_power_hypo_cone(a_var, t, 0.5, hermitian=False)
     cons.extend([a_var >> eps * np.eye(n), a_var << np.eye(n)])
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(float(n), abs=5e-2)

--- a/toqito/cones/tests/test_tsallis_entropy_hypo_cone.py
+++ b/toqito/cones/tests/test_tsallis_entropy_hypo_cone.py
@@ -51,7 +51,7 @@ def test_tsallis_entropy_hypo_cone_at_constant(dim: int, order: float, hermitian
         hermitian=hermitian,
     )
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    cvx_val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    cvx_val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert cvx_val is not None
@@ -65,7 +65,7 @@ def test_tsallis_entropy_hypo_cone_maximally_mixed():
     t = cvxpy.Variable()
     cons = tsallis_entropy_hypo_cone(cvxpy.Constant(mat_x), t, 0.5)
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(ref, abs=2e-2)
 
@@ -79,7 +79,7 @@ def test_tsallis_entropy_hypo_cone_composition():
     cons = tsallis_entropy_hypo_cone(x_var, t, order, hermitian=False)
     cons.extend([x_var >> 0, cvxpy.trace(x_var) == 1])
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     ref = tsallis_entropy(np.eye(n) / n, order)
@@ -103,7 +103,7 @@ def test_tsallis_entropy_hypo_cone_order_zero():
     t = cvxpy.Variable()
     cons = tsallis_entropy_hypo_cone(cvxpy.Constant(mat_x), t, 0.0)
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(ref, abs=2e-2)
 

--- a/toqito/cones/tests/test_tsallis_relative_entropy_epi_cone.py
+++ b/toqito/cones/tests/test_tsallis_relative_entropy_epi_cone.py
@@ -56,7 +56,7 @@ def test_tsallis_relative_entropy_epi_cone_at_constant(dim: int, order: float, h
         hermitian=hermitian,
     )
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    cvx_val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    cvx_val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert cvx_val is not None
@@ -74,7 +74,7 @@ def test_tsallis_relative_entropy_epi_cone_equal_states():
         0.5,
     )
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(0.0, abs=2e-2)
 
@@ -92,7 +92,7 @@ def test_tsallis_relative_entropy_epi_cone_order_zero():
         0.0,
     )
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(ref, abs=2e-2)
 
@@ -113,7 +113,7 @@ def test_tsallis_relative_entropy_epi_cone_composition():
     )
     cons.extend([x_var >> 0, cvxpy.trace(x_var) == 1])
     prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     assert prob.status in {cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE}, prob.status
     assert val == pytest.approx(0.0, abs=5e-2)

--- a/toqito/matrix_props/tests/test_trace_matrix_log.py
+++ b/toqito/matrix_props/tests/test_trace_matrix_log.py
@@ -55,7 +55,7 @@ def _trace_matrix_log_sdp_at_fixed_a(
         hermitian=is_cplx,
     )
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     return val, prob.status
 
 

--- a/toqito/state_opt/tests/test_bell_inequality_max.py
+++ b/toqito/state_opt/tests/test_bell_inequality_max.py
@@ -69,7 +69,7 @@ def test_chsh_fc_classical(chsh_fc, desc_chsh):
     assert bim.bell_inequality_max(chsh_fc, desc_chsh, "fc", "classical") == pytest.approx(2.0, abs=ATOL)
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_chsh_fc_quantum(chsh_fc, desc_chsh):
     """Test quantum maximum (Tsirelson bound) for CHSH inequality in FC notation."""
     expected = 2 * np.sqrt(2)
@@ -78,7 +78,7 @@ def test_chsh_fc_quantum(chsh_fc, desc_chsh):
     )
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_chsh_fc_nosignal(chsh_fc, desc_chsh):
     """Test no-signalling maximum for CHSH inequality in FC notation."""
     assert bim.bell_inequality_max(chsh_fc, desc_chsh, "fc", "nosignal", tol=1e-9) == pytest.approx(4.0, abs=5e-5)
@@ -89,7 +89,7 @@ def test_chsh_cg_classical(chsh_cg, desc_chsh):
     assert bim.bell_inequality_max(chsh_cg, desc_chsh, "cg", "classical") == pytest.approx(0.0, abs=ATOL)
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_chsh_cg_quantum(chsh_cg, desc_chsh):
     """Test quantum maximum for CHSH inequality in CG notation."""
     expected = 1 / np.sqrt(2) - 0.5
@@ -98,7 +98,7 @@ def test_chsh_cg_quantum(chsh_cg, desc_chsh):
     )
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_chsh_cg_nosignal(chsh_cg, desc_chsh):
     """Test no-signalling maximum for CHSH inequality in CG notation."""
     assert bim.bell_inequality_max(chsh_cg, desc_chsh, "cg", "nosignal", tol=1e-9) == pytest.approx(0.5, abs=ATOL)
@@ -109,7 +109,7 @@ def test_chsh_game_fp_classical(chsh_game_fp, desc_chsh):
     assert bim.bell_inequality_max(chsh_game_fp, desc_chsh, "fp", "classical") == pytest.approx(0.75, abs=ATOL)
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_chsh_game_fp_quantum(chsh_game_fp, desc_chsh):
     """Test quantum maximum for CHSH game winning probability in FP notation."""
     expected = (1 + 1 / np.sqrt(2)) / 2
@@ -118,7 +118,7 @@ def test_chsh_game_fp_quantum(chsh_game_fp, desc_chsh):
     )
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_chsh_game_fp_nosignal(chsh_game_fp, desc_chsh):
     """Test no-signalling maximum for CHSH game winning probability in FP notation."""
     assert bim.bell_inequality_max(chsh_game_fp, desc_chsh, "fp", "nosignal", tol=1e-9) == pytest.approx(1.0, abs=ATOL)
@@ -129,7 +129,7 @@ def test_i3322_cg_classical(i3322_cg, desc_i3322):
     assert bim.bell_inequality_max(i3322_cg, desc_i3322, "cg", "classical") == pytest.approx(1.0, abs=ATOL)
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 @pytest.mark.parametrize(
     "k_level, expected_val_toqito",
     [
@@ -146,7 +146,7 @@ def test_i3322_cg_quantum(i3322_cg, desc_i3322, k_level, expected_val_toqito):
     )
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_i3322_cg_nosignal(i3322_cg, desc_i3322):
     """Test no-signalling maximum for I3322 inequality in CG notation."""
     assert bim.bell_inequality_max(i3322_cg, desc_i3322, "cg", "nosignal", tol=1e-9) == pytest.approx(2.0, abs=ATOL)
@@ -194,7 +194,7 @@ def test_invalid_mtype(chsh_fc, desc_chsh):
         bim.bell_inequality_max(chsh_fc, desc_chsh, "fc", "invalid_type")
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_quantum_infeasible_setup_via_call():
     """Test solver detects infeasibility when manually added constraints make it so."""
     desc = [2, 2, 1, 1]
@@ -211,7 +211,7 @@ def test_quantum_infeasible_setup_via_call():
         pytest.fail("NPA constraint generation failed unexpectedly.")
 
     problem = cvxpy.Problem(objective, constraints)
-    problem.solve(solver=cvxpy.SCS, eps=1e-8)
+    problem.solve(solver=cvxpy.CLARABEL)
 
     assert problem.status in [cvxpy.INFEASIBLE, cvxpy.INFEASIBLE_INACCURATE]
 
@@ -270,7 +270,7 @@ def test_classical_binary_mb0_cg():
     assert bim.bell_inequality_max(coeffs_cg, desc_mb0, "cg", "classical") == pytest.approx(1.0, abs=ATOL)
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_nosignal_oa1():
     """Test no-signalling calculation when Alice has only one output (oa=1)."""
     desc = [1, 2, 2, 2]
@@ -278,7 +278,7 @@ def test_nosignal_oa1():
     assert bim.bell_inequality_max(coeffs_cg, desc, "cg", "nosignal", tol=1e-9) == pytest.approx(2.0, abs=ATOL)
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_nosignal_ob1():
     """Test no-signalling calculation when Bob has only one output (ob=1)."""
     desc = [2, 1, 2, 2]
@@ -286,7 +286,7 @@ def test_nosignal_ob1():
     assert bim.bell_inequality_max(coeffs_cg, desc, "cg", "nosignal", tol=1e-9) == pytest.approx(2.0, abs=ATOL)
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_nosignal_fc_nonbinary_error():
     """Test ValueError for no-signalling calculation with FC notation and non-binary outputs."""
     desc = [3, 2, 2, 2]
@@ -295,7 +295,7 @@ def test_nosignal_fc_nonbinary_error():
         bim.bell_inequality_max(dummy_fc, desc, "fc", "nosignal")
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_quantum_fc_nonbinary_error():
     """Test ValueError for quantum calculation with FC notation and non-binary outputs."""
     desc = [3, 2, 2, 2]
@@ -304,7 +304,7 @@ def test_quantum_fc_nonbinary_error():
         bim.bell_inequality_max(dummy_fc, desc, "fc", "quantum")
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_quantum_invalid_k_error(chsh_cg, desc_chsh):
     """Test ValueError is raised for invalid NPA level 'k' inputs."""
     with pytest.raises(ValueError, match="Invalid NPA level k=-1"):
@@ -375,7 +375,7 @@ def test_classical_nonbinary_fp_dense():
     assert result >= 0
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_nosignal_cg_shape_error(desc_chsh):
     """Test ValueError for no-signalling calculation if CG coefficients have wrong shape."""
     invalid_coeffs_cg = np.zeros((3, 4))  # Correct shape is (3, 3)
@@ -383,7 +383,7 @@ def test_nosignal_cg_shape_error(desc_chsh):
         bim.bell_inequality_max(invalid_coeffs_cg, desc_chsh, "cg", "nosignal")
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_quantum_cg_shape_error(desc_chsh):
     """Test ValueError for quantum calculation if CG coefficients have wrong shape."""
     invalid_coeffs_cg = np.zeros((3, 4))  # Correct shape is (3, 3)
@@ -420,7 +420,7 @@ def test_classical_nonbinary_swap_triggered():
 # --- MOCKED TESTS---
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_nosignal_infeasible_status(capfd):
     """Test handling of infeasible solver status for no-signalling (mocked)."""
     mock_problem = MagicMock(spec=cvxpy.Problem)
@@ -438,7 +438,7 @@ def test_nosignal_infeasible_status(capfd):
             assert "Warning: Solver status for 'nosignal': infeasible" in captured.out
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_nosignal_unbounded_status(capfd):
     """Test handling of unbounded solver status for no-signalling (mocked)."""
     mock_problem = MagicMock(spec=cvxpy.Problem)
@@ -454,7 +454,7 @@ def test_nosignal_unbounded_status(capfd):
         assert "Warning: Solver status for 'nosignal': unbounded" in captured.out
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_quantum_infeasible_status(capfd):
     """Test handling of infeasible solver status for quantum (mocked)."""
     mock_problem = MagicMock(spec=cvxpy.Problem)
@@ -472,7 +472,7 @@ def test_quantum_infeasible_status(capfd):
             assert "Warning: Solver status for 'quantum' k=1: infeasible_inaccurate" in captured.out
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_quantum_unbounded_status(capfd):
     """Test handling of unbounded solver status for quantum (mocked)."""
     mock_problem = MagicMock(spec=cvxpy.Problem)
@@ -490,7 +490,7 @@ def test_quantum_unbounded_status(capfd):
             assert "Warning: Solver status for 'quantum' k=1: unbounded_inaccurate" in captured.out
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_quantum_npa_error(chsh_cg, desc_chsh):
     """Test ValueError is raised if bell_npa_constraints fails."""
     # PATCH THE MODULE ALIAS
@@ -499,7 +499,7 @@ def test_quantum_npa_error(chsh_cg, desc_chsh):
             bim.bell_inequality_max(chsh_cg, desc_chsh, "cg", "quantum", k=1)
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_quantum_result_is_nan(chsh_cg, desc_chsh):
     """Test return value is -inf if solver returns NaN for quantum."""
     mock_problem = MagicMock(spec=cvxpy.Problem)
@@ -512,7 +512,7 @@ def test_quantum_result_is_nan(chsh_cg, desc_chsh):
             assert bim.bell_inequality_max(chsh_cg, desc_chsh, "cg", "quantum") == -np.inf
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_nosignal_result_is_nan(chsh_cg, desc_chsh):
     """Test return value is -inf if solver returns None/NaN for no-signalling."""
     mock_problem = MagicMock(spec=cvxpy.Problem)
@@ -523,7 +523,7 @@ def test_nosignal_result_is_nan(chsh_cg, desc_chsh):
         assert bim.bell_inequality_max(chsh_cg, desc_chsh, "cg", "nosignal") == -np.inf
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_nosignal_fp_conversion_internal_error(desc_chsh):
     """Test catching internal ValueError from fp_to_cg in nosignal path."""
     dummy_fp_coeffs = np.zeros((2, 2, 2, 2))
@@ -533,7 +533,7 @@ def test_nosignal_fp_conversion_internal_error(desc_chsh):
             bim.bell_inequality_max(dummy_fp_coeffs, desc_chsh, "fp", "nosignal")
 
 
-@pytest.mark.skipif(cvxpy.SCS not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
+@pytest.mark.skipif(cvxpy.CLARABEL not in cvxpy.installed_solvers(), reason="SCS solver not installed.")
 def test_quantum_fc_conversion_internal_error(chsh_fc, desc_chsh):
     """Test catching internal ValueError from fc_to_cg in quantum path."""
     # PATCH THE MODULE ALIAS

--- a/toqito/state_opt/tests/test_npa_hierarchy.py
+++ b/toqito/state_opt/tests/test_npa_hierarchy.py
@@ -494,7 +494,7 @@ def test_cglmp_inequality_npa_integration(k_npa):
 
     objective = cvxpy.Maximize(i_b_objective)
     problem = cvxpy.Problem(objective, npa_constraints_list)
-    val = problem.solve(solver=cvxpy.SCS, verbose=False)
+    val = problem.solve(solver=cvxpy.CLARABEL, verbose=False)
 
     expected_cglmp_val = 2.9149
     assert val == pytest.approx(expected_cglmp_val, abs=1e-3)

--- a/toqito/state_props/tests/test_ln_quantum_entropy.py
+++ b/toqito/state_props/tests/test_ln_quantum_entropy.py
@@ -58,7 +58,7 @@ def _ln_quantum_entropy_sdp_at_fixed_x(
         hermitian=is_cplx,
     )
     prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-    val = prob.solve(solver=cvxpy.SCS, verbose=False)
+    val = prob.solve(solver=cvxpy.CLARABEL, verbose=False)
     return val, prob.status
 
 


### PR DESCRIPTION
`test_trace_matrix_log` alone was 38% of the test suite. This changes the 19 test files that pin SCS to use CLARABEL instead.

## Why

These tests exercise the cone constructions; the solver is incidental machinery. SCS is a first-order method and converges badly on them, and the problems are not large. The dim-8 `trace_matrix_log` case builds a 3305x449 constraint matrix with 2321 nonzeros and seven 32x32 PSD blocks:

| case | SCS | CLARABEL |
|---|---:|---:|
| dim 8, mk 3, apx −1 | 199.2 s | 2.01 s |
| dim 8, mk 3, apx 0 | 200.8 s | 2.71 s |
| dim 8, mk 1, apx −1 | 72.9 s | 0.62 s |
| dim 5, mk 3, apx −1 | 5.3 s | 0.45 s |

Canonicalization is not the issue and problem reuse would not have helped: it accounts for 0.07-0.12 s against a 199 s solve. The time is entirely inside the solver.

## Result

Full suite, same commit, same command (`-n 4 --dist worksteal`), identical outcomes (3732 passed, 62 skipped, 3 xfailed):

| | wall |
|---|---:|
| SCS | 529.3 s |
| CLARABEL | 310.6 s |

Across the full 30-case `trace_matrix_log` grid, solve time goes from 766 s to 12.1 s with zero assertion changes.

## The `eps` and `max_iters` arguments

Seven call sites passed `eps=1e-8`, one also `max_iters=400_000`. Those are SCS-specific names that CLARABEL rejects with `TypeError: unrecognized solver setting`, and they existed to tighten SCS's default tolerance of 1e-4.

CLARABEL already defaults `tol_gap_abs`, `tol_gap_rel` and `tol_feas` to exactly 1e-8, the same value being requested, so removing the arguments preserves the intent rather than loosening it. The large `max_iters` was only needed because SCS is first-order; CLARABEL's default of 200 iterations is ample for an interior-point method.

## Trade-off to weigh

CLARABEL returns `optimal_inaccurate` more often than SCS. The count of "Solution may be inaccurate" warnings rises from 3 to 17, spread across 13 test functions rather than 5. Almost all are the `*_at_constant` cases, where the cone is evaluated at a point that makes the constraint tight, which is where an interior-point method cannot certify convergence.

Every numeric assertion still passes. Where the true error was measured directly, on the `trace_matrix_log` grid, CLARABEL was the more accurate of the two: relative errors of 1e-5 to 1e-6, against the SCS overshoot that the test's own comment apologises for. `test_trace_matrix_log` in fact emits the inaccuracy warning under SCS and not under CLARABEL.

This is the part of the change worth a second opinion, since "passes the assertion" and "the solver certified convergence" are not the same claim.

CLARABEL ships with `cvxpy >= 1.9`, so this adds no dependency.
