### PR TITLE
test: cover final inconclusive return of is_separable with a real state

### DIFF
--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -551,10 +551,7 @@ def test_final_return_false_for_unclassified_entangled():
 
     verdict, reason = is_separable(rho, dim=[3, 3], level=2)
     assert verdict is False
-    assert reason == (
-        "inconclusive: PPT but no implemented sufficient condition "
-        "proved separability"
-    )
+    assert reason == ("inconclusive: PPT but no implemented sufficient condition proved separability")
 
 
 def test_2xN_johnston_lemma1_eig_A_fails():

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -530,10 +530,31 @@ def test_2xN_johnston_spectrum_lam_too_short_skips_proceeds(mock_eig):
     assert is_separable(rho_2x4, dim=[2, 4])[0]
 
 
-@pytest.mark.skip(reason="Needs specific state that evades criteria but is known entangled for `final return False`.")
 def test_final_return_false_for_unclassified_entangled():
-    """Placeholder for final False return on unclassified entangled state."""
-    pass
+    """A PPT state passing every implemented criterion reaches the final False.
+
+    The 3x3 Tile UPB complement (a rank-4 PPT entangled state) mixed with the
+    maximally mixed state at ratio 0.85 is positive semidefinite and PPT, but
+    evades each implemented sufficient condition: the realignment/CCNR norm
+    stays below one, the positive-map witnesses (Choi, Terhal, Ha-Kye,
+    Breuer-Hall) do not fire, and iterative product-state subtraction stalls.
+    The level-2 DPS hierarchy finds a 2-symmetric extension yet fails the
+    inner cone, so the finite hierarchy is inconclusive and the function
+    falls through to the final ``(False, ...)`` verdict.
+    """
+    tiles_proj = np.zeros((9, 9), dtype=complex)
+    for idx in range(5):
+        vec = tile(idx)
+        tiles_proj += np.outer(vec, vec.conj())
+    rho_tiles = (np.eye(9) - tiles_proj) / 4
+    rho = 0.85 * rho_tiles + 0.15 * np.eye(9) / 9
+
+    verdict, reason = is_separable(rho, dim=[3, 3], level=2)
+    assert verdict is False
+    assert reason == (
+        "inconclusive: PPT but no implemented sufficient condition "
+        "proved separability"
+    )
 
 
 def test_2xN_johnston_lemma1_eig_A_fails():


### PR DESCRIPTION
## Summary

Replaces the placeholder `test_final_return_false_for_unclassified_entangled` (currently a bare `pass` behind a skip marker) with a genuine end-to-end case that reaches the final inconclusive `(False, ...)` verdict of `is_separable`.

Closes the skipped portion of #1915.

## The state

\rho = 0.85 * rho_tiles + 0.15 * I/9, where rho_tiles = (I - sum|psi_i><psi_i|)/4 is the complement of the 3x3 Tile UPB (a rank-4 PPT entangled state, built with `toqito.states.tile` — no external fixtures).

## Why this state reaches the final verdict

- PSD and PPT (PT smallest eigenvalue ≈ +1.7e-2, far from the tolerance boundary);
- passes the realignment/CCNR criterion (||R(rho)||_1 ≈ 0.969 ≤ 1);
- not detected by any implemented positive-map witness (Choi/Terhal/Ha-Kye/Breuer-Hall);
- not decomposed by iterative product-state subtraction (the separable-decomposition boundary of this mixture lies between t=0.78 and t=0.80, so t=0.85 has a ~9% margin);
- the level-2 DPS hierarchy finds a 2-symmetric extension but fails the inner cone, so the finite hierarchy is inconclusive.

## Stability

- The state is deterministic (fixed construction from `tile()`), with margins: 3.1% on CCNR (deterministic SVD), 9% on iterative subtraction (fixed-seed random restarts);
- verified across 3 independent runs (different process seeds);
- full `test_is_separable.py` suite: 155 passed / 4 skipped / 2 xfailed (49.7s), unchanged baseline except this test now passes.

## Notes

- First real solver-backed (CVXPY/SCS) end-to-end coverage of the 12b/DPS fall-through path — previously only mocked.
- Test runtime ~9s (DPS SDP solve), acceptable for this file.
