### PR TITLE
Is separable  horodecki low rank ppt criteria

### DIFF
--- a/docs/content/contributing-guide.md
+++ b/docs/content/contributing-guide.md
@@ -250,7 +250,8 @@ serve locally:
 
 ``` bash
 uv sync --group docs
-uv run mkdocs serve -f docs/mkdocs.yml
+cd docs
+uv run mkdocs serve -f mkdocs.yml
 ```
 
 This starts a live-reloading server at `http://127.0.0.1:8000`.
@@ -258,7 +259,8 @@ This starts a live-reloading server at `http://127.0.0.1:8000`.
 To produce a static build instead:
 
 ``` bash
-uv run mkdocs build -f docs/mkdocs.yml
+cd docs
+uv run mkdocs build -f mkdocs.yml
 ```
 
 For more information, visit the

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -90,8 +90,8 @@ def is_separable(
 
         For PPT states (especially when \(d_A d_B > 6\)):
 
-        - If \(\text{rank}(\rho) \le \max(d_A, d_B)\), the state is separable
-          (Theorem 1 of the paper).
+        - If \(\text{rank}(\rho) \le \max(\text{rank}(\rho_A), \text{rank}(\rho_B))\),
+          the state is separable (Horodecki et al. 2000).
         - If \(\text{rank}(\rho) \le \text{rank}(\rho_A)\) or
           \(\text{rank}(\rho) \le \text{rank}(\rho_B)\), the state is separable.
           This is the "rank-marginal" corollary of Theorem 1 obtained by

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -548,7 +548,7 @@ def is_separable(
 
     # --- 7. Operational Criteria for Low-Rank PPT States (Horodecki et al. 2000) ---
     verdict, rho_A_marginal, rho_B_marginal = _horodecki_low_rank_ppt_criteria(
-        current_state, dims_list, state_rank, max_dim_val
+        current_state, dims_list, state_rank, tol
     )
     if verdict is not None:
         return verdict
@@ -1103,14 +1103,25 @@ def _horodecki_low_rank_ppt_criteria(
     state: np.ndarray,
     dims: list[int],
     state_rank: int,
-    max_dim_val: int,
+    tol: float,
 ) -> tuple[tuple[bool, str] | None, np.ndarray | None, np.ndarray | None]:
     """Run the Horodecki low-rank PPT criteria and return cached marginals."""
-    if state_rank <= max_dim_val:
-        return (True, "rank(rho) <= max(d_A, d_B) (Horodecki et al. 2000)"), None, None
-
     rho_a_marginal = partial_trace(state, sys=[1], dim=dims)
     rho_b_marginal = partial_trace(state, sys=[0], dim=dims)
+    rank_marg_a = np.linalg.matrix_rank(rho_a_marginal, tol=tol)
+    rank_marg_b = np.linalg.matrix_rank(rho_b_marginal, tol=tol)
+    if state_rank <= rank_marg_a:
+        return (
+            (True, f"rank(rho)={state_rank} <= rank(rho_A)={rank_marg_a} (Horodecki et al. 2000)"),
+            rho_a_marginal,
+            rho_b_marginal,
+        )
+    if state_rank <= rank_marg_b:
+        return (
+            (True, f"rank(rho)={state_rank} <= rank(rho_B)={rank_marg_b} (Horodecki et al. 2000)"),
+            rho_a_marginal,
+            rho_b_marginal,
+        )
     return None, rho_a_marginal, rho_b_marginal
 
 

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -1236,13 +1236,14 @@ def test_operator_schmidt_rank_two_classical_correlation_3x3_is_separable():
 
 # --- Tests for the Horodecki rank-marginal check (#1251b) ---
 
+
 def test_horodecki_rank_le_marginal_rank():
     """PPT state where rank <= marginal rank implies separability."""
     tol = 1e-8
     a = [basis(3, i) for i in range(3)] + [sum(basis(3, i) for i in range(3)) / np.sqrt(3)]
     b = [basis(4, i) for i in range(4)]
 
-    dims= [3,4]
+    dims = [3, 4]
     rho3x4 = np.array(sum(np.outer(np.kron(a[k], b[k]), np.kron(a[k], b[k]).conj()) for k in range(4)) / 4)
     state_rank = np.linalg.matrix_rank(rho3x4, tol=tol)
     sep_reason, _, _ = _horodecki_low_rank_ppt_criteria(rho3x4, dims, state_rank, tol)
@@ -1250,7 +1251,7 @@ def test_horodecki_rank_le_marginal_rank():
     sep, reason = sep_reason
     assert sep is True and f"rank(rho)={state_rank} <= rank(rho_B)" in reason
 
-    dims= [4,3]
+    dims = [4, 3]
     rho4x3 = np.array(sum(np.outer(np.kron(b[k], a[k]), np.kron(b[k], a[k]).conj()) for k in range(4)) / 4)
     state_rank = np.linalg.matrix_rank(rho4x3, tol=tol)
     sep_reason, _, _ = _horodecki_low_rank_ppt_criteria(rho4x3, dims, state_rank, tol)
@@ -1261,7 +1262,7 @@ def test_horodecki_rank_le_marginal_rank():
 
 def test_state_with_low_rank_embedded_in_higher_rank_space_is_not_detected(tiles_state_3x3_ppt_entangled):
     """A state embedded in a higher-dimension space isn't caught by the rank-marginal check."""
-    embedded_in_4x4 = np.pad(tiles_state_3x3_ppt_entangled, ((0,7), (0,7)))
+    embedded_in_4x4 = np.pad(tiles_state_3x3_ppt_entangled, ((0, 7), (0, 7)))
     perm = np.array([0, 1, 2, 15, 3, 4, 5, 14, 6, 7, 8, 13, 9, 10, 11, 12])
     embedded_in_4x4 = embedded_in_4x4[np.ix_(perm, perm)]
     tol = 1e-8
@@ -1269,7 +1270,7 @@ def test_state_with_low_rank_embedded_in_higher_rank_space_is_not_detected(tiles
     dA, dB = 4, 4
     state_rank = np.linalg.matrix_rank(embedded_in_4x4, tol=tol)
 
-    sep_reason, _, _ = _horodecki_low_rank_ppt_criteria(embedded_in_4x4, [dA,dB], state_rank, tol)
+    sep_reason, _, _ = _horodecki_low_rank_ppt_criteria(embedded_in_4x4, [dA, dB], state_rank, tol)
     assert sep_reason is None
 
 

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -20,6 +20,7 @@ from toqito.state_props.is_separable import (
     _filter_cmc_bound,
     _filter_cmc_xi_sum,
     _filter_normal_form,
+    _horodecki_low_rank_ppt_criteria,
     _iterative_product_state_subtraction,
     _positive_map_witness_criteria,
     _qubit_qudit_ppt_criteria,
@@ -1234,6 +1235,42 @@ def test_operator_schmidt_rank_two_classical_correlation_3x3_is_separable():
 
 
 # --- Tests for the Horodecki rank-marginal check (#1251b) ---
+
+def test_horodecki_rank_le_marginal_rank():
+    """PPT state where rank <= marginal rank implies separability"""
+    tol = 1e-8
+    a = [basis(3, i) for i in range(3)] + [sum(basis(3, i) for i in range(3)) / np.sqrt(3)]
+    b = [basis(4, i) for i in range(4)]  
+
+    dims= [3,4]
+    rho3x4 = np.array(sum(np.outer(np.kron(a[k], b[k]), np.kron(a[k], b[k]).conj()) for k in range(4)) / 4)
+    state_rank = np.linalg.matrix_rank(rho3x4, tol=tol)
+    sep_reason, _, _ = _horodecki_low_rank_ppt_criteria(rho3x4, dims, state_rank, tol)
+    assert sep_reason is not None
+    sep, reason = sep_reason
+    assert sep is True and f"rank(rho)={state_rank} <= rank(rho_B)" in reason
+
+    dims= [4,3]
+    rho4x3 = np.array(sum(np.outer(np.kron(b[k], a[k]), np.kron(b[k], a[k]).conj()) for k in range(4)) / 4)
+    state_rank = np.linalg.matrix_rank(rho4x3, tol=tol)
+    sep_reason, _, _ = _horodecki_low_rank_ppt_criteria(rho4x3, dims, state_rank, tol)
+    assert sep_reason is not None
+    sep, reason = sep_reason
+    assert sep is True and f"rank(rho)={state_rank} <= rank(rho_A)" in reason
+
+
+def test_state_with_low_rank_embedded_in_higher_rank_space_is_not_detected(tiles_state_3x3_ppt_entangled):
+    """Embedding A PPT entangled state in a higher dimensional space does not make it detectable by the horodecki low rank ppt criteria"""
+    embedded_in_4x4 = np.pad(tiles_state_3x3_ppt_entangled, ((0,7), (0,7)))
+    perm = np.array([0, 1, 2, 15, 3, 4, 5, 14, 6, 7, 8, 13, 9, 10, 11, 12])
+    embedded_in_4x4 = embedded_in_4x4[np.ix_(perm, perm)]
+    tol = 1e-8
+
+    dA, dB = 4, 4
+    state_rank = np.linalg.matrix_rank(embedded_in_4x4, tol=tol)
+
+    sep_reason, _, _ = _horodecki_low_rank_ppt_criteria(embedded_in_4x4, [dA,dB], state_rank, tol)
+    assert sep_reason is None
 
 
 # --- Tests for Choi's 1975 positive-map witness (#1249) ---

--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -1237,10 +1237,10 @@ def test_operator_schmidt_rank_two_classical_correlation_3x3_is_separable():
 # --- Tests for the Horodecki rank-marginal check (#1251b) ---
 
 def test_horodecki_rank_le_marginal_rank():
-    """PPT state where rank <= marginal rank implies separability"""
+    """PPT state where rank <= marginal rank implies separability."""
     tol = 1e-8
     a = [basis(3, i) for i in range(3)] + [sum(basis(3, i) for i in range(3)) / np.sqrt(3)]
-    b = [basis(4, i) for i in range(4)]  
+    b = [basis(4, i) for i in range(4)]
 
     dims= [3,4]
     rho3x4 = np.array(sum(np.outer(np.kron(a[k], b[k]), np.kron(a[k], b[k]).conj()) for k in range(4)) / 4)
@@ -1260,7 +1260,7 @@ def test_horodecki_rank_le_marginal_rank():
 
 
 def test_state_with_low_rank_embedded_in_higher_rank_space_is_not_detected(tiles_state_3x3_ppt_entangled):
-    """Embedding A PPT entangled state in a higher dimensional space does not make it detectable by the horodecki low rank ppt criteria"""
+    """A state embedded in a higher-dimension space isn't caught by the rank-marginal check."""
     embedded_in_4x4 = np.pad(tiles_state_3x3_ppt_entangled, ((0,7), (0,7)))
     perm = np.array([0, 1, 2, 15, 3, 4, 5, 14, 6, 7, 8, 13, 9, 10, 11, 12])
     embedded_in_4x4 = embedded_in_4x4[np.ix_(perm, perm)]

--- a/toqito/states/breuer.py
+++ b/toqito/states/breuer.py
@@ -30,9 +30,9 @@ def breuer(dim: int, lam: float) -> np.ndarray:
         ValueError: `lam` must be between 0 and 1.
 
     Examples:
-        We can generate a Breuer bound entangled state of local dimension \(4\) with weight \(0.1\). For even
-        local dimension at least \(4\) and any positive weight, the state satisfies the PPT criterion, but it
-        is entangled.
+        We can generate a Breuer bound entangled state of local dimension \(4\) with weight \(0.1\). For
+        even local dimension at least \(4\) and \(0 < \lambda \leq \frac{1}{d+2}\), the state satisfies the
+        PPT criterion, but it is entangled.
 
         ```python exec="1" source="above" result="text"
         from toqito.states import breuer

--- a/toqito/states/breuer.py
+++ b/toqito/states/breuer.py
@@ -14,7 +14,7 @@ def breuer(dim: int, lam: float) -> np.ndarray:
 
     Gives a Breuer state for two qudits of local dimension `dim`, with the `lam` parameter describing the
     weight of the singlet component as described in [@breuer2006optimal]. For even local dimensions
-    \(d \geq 4\) and \(\lambda > 0\), this construction gives bound entangled states.
+    \(d \geq 4\) and \(0 < \lambda \leq \frac{1}{d+2} \), this construction gives bound entangled states.
 
     This function was adapted from the QETLAB package [@qetlablink].
 


### PR DESCRIPTION
## Description
Bug in is_separable where a state with a low rank would be incorrectly detected by _horodecki_low_rank_ppt_criteria as separable.

## Changes
  -  [ ] Brought back the branches where the method would compare the state's rank to the rank of its marginals.
  -  [ ] Removed the branch where the method would check if the state's rank is lower or equal to the dimension of Alice's and Bob's systems instead of the rank of their marginals.
  - [ ] Breur state is bound entangled from 0 to 1/(d+2)
  - [ ] Contribution guide documentation did not build with provided snippet 
  
  ```
uv run mkdocs serve -f docs/mkdocs.yml
INFO    -  DeprecationWarning: warning_filter doesn't do anything since MkDocs 1.2 and will be removed soon. All messages on the `mkdocs` logger get counted automatically.
             File "C:\Users\anton\OneDrive\Desktop\GitHub\toqito\.venv\Lib\site-packages\mkdocs_gallery\mkdocs_compatibility.py", line 12, in <module>
               from mkdocs.utils import warning_filter
             File "C:\Users\anton\OneDrive\Desktop\GitHub\toqito\.venv\Lib\site-packages\mkdocs\utils\__init__.py", line 403, in __getattr__
               warnings.warn(
ERROR   -  Config value 'plugins': Plugin 'gallery' option 'examples_dirs': Error validating config item #1: The path 'content/examples' isn't an existing directory.

Aborted with a configuration error!
```

## Checklist
Before marking your PR ready for review, make sure you checked the following locally. If this is your first PR, you might be notified of some workflow failures after a maintainer has approved the workflow jobs to be run on your PR. 

Additional information is available in the [documentation](https://vprusso.github.io/toqito/contributing-guide/).

  -  [x] Use `ruff` for errors related to code style and formatting.
  -  [x] Verify all previous and newly added unit tests pass in `pytest`.
  -  [x] Check the documentation build does not lead to any failures.
