### PR TITLE
tooling: reconcile ruff version between CI and dev group

### DIFF
--- a/.github/workflows/build-test-actions.yml
+++ b/.github/workflows/build-test-actions.yml
@@ -22,7 +22,7 @@ jobs:
       # Pin ruff to the version in pyproject so CI formatting matches local/pre-commit.
       - uses: astral-sh/ruff-action@v3
         with:
-          version: "0.15.0"
+          version: "0.16.0"
       # Check only (no --fix / no in-place format): style and format violations must fail CI
       # rather than being silently auto-fixed in the runner and discarded.
       - run: ruff check

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ import numpy as np
 from toqito.nonlocal_games.xor_game import XORGame
 
 # The probability matrix.
-prob_mat = np.array([[1/4, 1/4], [1/4, 1/4]])
+prob_mat = np.array([[1 / 4, 1 / 4], [1 / 4, 1 / 4]])
 
 # The predicate matrix.
 pred_mat = np.array([[0, 0], [0, 1]])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ select = ["I", "E", "W", "D", "PL", "F"]
 exclude = []
 
 
-ignore = ["D407", "D203", "D213", "D416", "PLR0912", "PLR0911", "PLR0915", "PLR2004", "PLR0913", "F811", "E203"]
+ignore = ["D407", "D203", "D213", "D416", "PLR0912", "PLR0911", "PLR0915", "PLR2004", "PLR0913", "PLR0917", "F811", "E203"]
 # Rules Ignored
 
 # D407 - Ignored because ==== under a section heading is considered as a missing underline.
@@ -167,6 +167,7 @@ ignore = ["D407", "D203", "D213", "D416", "PLR0912", "PLR0911", "PLR0915", "PLR2
 # PLR0915 -- Checks for functions or methods with too many statements. The default number is 50. 
 # PLR2004 -- Checks if an equality or an inequality is compared to a variable or a num (prefers variable pre)
 # PLR0913 Too many arguments in function definition
+# PLR0917 Too many positional arguments (companion to PLR0913; enabled by default in ruff >= 0.16)
 # F811 -- Checks for variable definitions that redefine (or "shadow") unused variables 
 # E203 -- Whitespace before ':'. This rule conflicts with Black's formatting style.
 # It was removing definitions with the same name creating conflicts in test_is_stochastic.py


### PR DESCRIPTION
Closes: #1952

The CI ruff action was pinned to `0.15.0` while the dev dependency group pins `ruff==0.16.0`. On the current tree `0.15.0` passes clean but `0.16.0` reports 38 `PLR0917` (too-many-positional-arguments) errors, so `uv run ruff check` locally diverges from what CI enforces.

This adds `PLR0917` to the `[tool.ruff.lint] ignore` list, alongside its companion `PLR0913` (too-many-arguments) which was already ignored, and bumps the CI action pin from `0.15.0` to `0.16.0`. Verified that both `ruff@0.15.0 check` and `ruff@0.16.0 check` now pass clean on `toqito/`.