### PR TITLE
consistency: is_* predicates return Python bool, not np.bool_

### DIFF
--- a/toqito/matrix_props/is_equiangular_tight_frame.py
+++ b/toqito/matrix_props/is_equiangular_tight_frame.py
@@ -68,7 +68,7 @@ def is_equiangular_tight_frame(mat: np.ndarray, tol: float = 1e-8) -> bool:
 
     if num_vecs < 2:
         # A single vector trivially satisfies ETF conditions if it has unit norm.
-        return np.isclose(np.linalg.norm(mat[:, 0]), 1.0, rtol=0, atol=tol) if num_vecs == 1 else False
+        return bool(np.isclose(np.linalg.norm(mat[:, 0]), 1.0, rtol=0, atol=tol)) if num_vecs == 1 else False
 
     # 1. Check unit norms.
     norms = np.linalg.norm(mat, axis=0)

--- a/toqito/matrix_props/is_hermitian.py
+++ b/toqito/matrix_props/is_hermitian.py
@@ -68,4 +68,4 @@ def is_hermitian(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> b
     """
     if not is_square(mat):
         return False
-    return np.allclose(mat, mat.conj().T, rtol=rtol, atol=atol)
+    return bool(np.allclose(mat, mat.conj().T, rtol=rtol, atol=atol))

--- a/toqito/matrix_props/is_idempotent.py
+++ b/toqito/matrix_props/is_idempotent.py
@@ -63,4 +63,4 @@ def is_idempotent(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-8) -> b
     """
     if not is_square(mat):
         return False
-    return np.allclose(mat, mat @ mat, rtol=rtol, atol=atol)
+    return bool(np.allclose(mat, mat @ mat, rtol=rtol, atol=atol))

--- a/toqito/matrix_props/is_identity.py
+++ b/toqito/matrix_props/is_identity.py
@@ -77,4 +77,4 @@ def is_identity(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-8) -> boo
     if not is_square(mat):
         return False
     id_mat = np.eye(len(mat))
-    return np.allclose(mat, id_mat, rtol=rtol, atol=atol)
+    return bool(np.allclose(mat, id_mat, rtol=rtol, atol=atol))

--- a/toqito/matrix_props/is_ldoi.py
+++ b/toqito/matrix_props/is_ldoi.py
@@ -78,4 +78,4 @@ def is_ldoi(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool:
 
     # A matrix is LDOI if Φ_O(mat) = mat
     ldot_result = ldot_channel(mat)
-    return np.allclose(ldot_result, mat, rtol=rtol, atol=atol)
+    return bool(np.allclose(ldot_result, mat, rtol=rtol, atol=atol))

--- a/toqito/matrix_props/is_normal.py
+++ b/toqito/matrix_props/is_normal.py
@@ -79,4 +79,4 @@ def is_normal(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> bool
     """
     if not is_square(mat):
         return False
-    return np.allclose(mat @ mat.conj().T, mat.conj().T @ mat, rtol=rtol, atol=atol)
+    return bool(np.allclose(mat @ mat.conj().T, mat.conj().T @ mat, rtol=rtol, atol=atol))

--- a/toqito/matrix_props/is_orthonormal.py
+++ b/toqito/matrix_props/is_orthonormal.py
@@ -47,4 +47,4 @@ def is_orthonormal(vectors: list[np.ndarray]) -> bool:
     # Flatten each vector to 1-D so column vectors (n, 1) and row vectors (1, n) are handled the
     # same as plain 1-D arrays; the Gram matrix of an orthonormal set is the identity.
     mat = np.array([np.asarray(vec).reshape(-1) for vec in vectors])
-    return np.allclose(mat @ mat.conj().T, np.eye(len(vectors)))
+    return bool(np.allclose(mat @ mat.conj().T, np.eye(len(vectors))))

--- a/toqito/matrix_props/is_projection.py
+++ b/toqito/matrix_props/is_projection.py
@@ -70,4 +70,4 @@ def is_projection(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> 
     """
     if not is_square(mat):
         return False
-    return np.allclose(np.linalg.matrix_power(mat, 2), mat, rtol=rtol, atol=atol)
+    return bool(np.allclose(np.linalg.matrix_power(mat, 2), mat, rtol=rtol, atol=atol))

--- a/toqito/matrix_props/is_pseudo_hermitian.py
+++ b/toqito/matrix_props/is_pseudo_hermitian.py
@@ -97,4 +97,4 @@ def is_pseudo_hermitian(mat: np.ndarray, signature: np.ndarray, rtol: float = 1e
         return False
 
     eta_H_inv_eta = signature @ mat @ signature_inv
-    return np.allclose(eta_H_inv_eta, mat.conj().T, rtol=rtol, atol=atol)
+    return bool(np.allclose(eta_H_inv_eta, mat.conj().T, rtol=rtol, atol=atol))

--- a/toqito/matrix_props/is_symmetric.py
+++ b/toqito/matrix_props/is_symmetric.py
@@ -63,4 +63,4 @@ def is_symmetric(mat: np.ndarray, rtol: float = 1e-05, atol: float = 1e-08) -> b
     """
     if not is_square(mat):
         return False
-    return np.allclose(mat, mat.T, rtol=rtol, atol=atol)
+    return bool(np.allclose(mat, mat.T, rtol=rtol, atol=atol))

--- a/toqito/matrix_props/is_tight_frame.py
+++ b/toqito/matrix_props/is_tight_frame.py
@@ -69,4 +69,4 @@ def is_tight_frame(vectors: list[np.ndarray], tol: float = 1e-8) -> bool:
     if frame_bound < tol:
         return False
 
-    return np.allclose(frame_op, frame_bound * np.eye(dim), rtol=0, atol=tol)
+    return bool(np.allclose(frame_op, frame_bound * np.eye(dim), rtol=0, atol=tol))

--- a/toqito/state_props/in_separable_ball.py
+++ b/toqito/state_props/in_separable_ball.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 
-def in_separable_ball(mat: np.ndarray) -> bool | np.bool_:
+def in_separable_ball(mat: np.ndarray) -> bool:
     r"""Check whether an operator is contained in ball of separability [@gurvits2002largest].
 
     Determines whether `mat` is contained within the ball of separable operators centered
@@ -74,4 +74,4 @@ def in_separable_ball(mat: np.ndarray) -> bool | np.bool_:
 
     # The following check relies on the fact that we scaled the matrix so that trace(mat) = 1.
     # The following condition is then exactly the condition mentioned in [@gurvits2002largest].
-    return np.linalg.norm(mat / np.linalg.norm(mat, "fro") ** 2 - np.eye(max_dim), "fro") <= 1
+    return bool(np.linalg.norm(mat / np.linalg.norm(mat, "fro") ** 2 - np.eye(max_dim), "fro") <= 1)

--- a/toqito/state_props/is_antidistinguishable.py
+++ b/toqito/state_props/is_antidistinguishable.py
@@ -8,7 +8,7 @@ from toqito.state_opt.state_exclusion import state_exclusion
 # imported https://github.com/vprusso/toqito/issues/473
 
 
-def is_antidistinguishable(states: list[np.ndarray]) -> bool | np.bool_:
+def is_antidistinguishable(states: list[np.ndarray]) -> bool:
     r"""Check whether a collection of vectors are antidistinguishable or not.
 
     For more information, see [@heinosaari2018antidistinguishability].
@@ -65,4 +65,4 @@ def is_antidistinguishable(states: list[np.ndarray]) -> bool | np.bool_:
 
     # The dual problem is less computationally intensive to compute in comparison to primal.
     opt_val, _ = state_exclusion(vectors=states, probs=probs, primal_dual="dual")
-    return np.isclose(opt_val, 0)
+    return bool(np.isclose(opt_val, 0))

--- a/toqito/state_props/is_antidistinguishable_circulant.py
+++ b/toqito/state_props/is_antidistinguishable_circulant.py
@@ -15,7 +15,7 @@ def is_antidistinguishable_circulant(
     states: list[np.ndarray[tuple[int, Literal[1]], np.dtype[np.inexact[Any]]]]
     | np.ndarray[tuple[int, int], np.dtype[np.inexact[Any]]],
     skip_circulant_check: bool = False,
-) -> bool | np.bool_:
+) -> bool:
     r"""Check whether a circulant set of vectors is antidistinguishable or not.
 
     For more information, see [@johnston2025tight].
@@ -92,4 +92,4 @@ def is_antidistinguishable_circulant(
     lhs = first_sqrt_eigval
     rhs = np.sum(other_sqrt_eigvals)
 
-    return lhs <= rhs or np.isclose(lhs, rhs)
+    return bool(lhs <= rhs or np.isclose(lhs, rhs))

--- a/toqito/state_props/is_distinguishable.py
+++ b/toqito/state_props/is_distinguishable.py
@@ -8,7 +8,7 @@ from toqito.state_opt.state_distinguishability import state_distinguishability
 # imported https://github.com/vprusso/toqito/issues/473
 
 
-def is_distinguishable(states: list[np.ndarray], probs: list[float] | None = None) -> bool | np.bool_:
+def is_distinguishable(states: list[np.ndarray], probs: list[float] | None = None) -> bool:
     r"""Check whether a collection of vectors are (perfectly) distinguishable or not.
 
     The ability to determine whether a set of quantum states are distinguishable can be obtained via the state
@@ -46,4 +46,4 @@ def is_distinguishable(states: list[np.ndarray], probs: list[float] | None = Non
     """
     # The dual problem is less computationally intensive to compute in comparison to primal.
     opt_val, _ = state_distinguishability(vectors=states, probs=probs, primal_dual="dual")
-    return np.isclose(opt_val, 1)
+    return bool(np.isclose(opt_val, 1))

--- a/toqito/state_props/is_ensemble.py
+++ b/toqito/state_props/is_ensemble.py
@@ -62,4 +62,4 @@ def is_ensemble(states: list[np.ndarray]) -> bool:
             return False
     # Constraint: The sum of the traces of all states within the ensemble must
     # be equal to 1.
-    return np.allclose(trace_sum, 1)
+    return bool(np.allclose(trace_sum, 1))

--- a/toqito/state_props/is_mutually_orthogonal.py
+++ b/toqito/state_props/is_mutually_orthogonal.py
@@ -72,4 +72,4 @@ def is_mutually_orthogonal(vec_list: list[np.ndarray | list[float | Any]]) -> bo
     np.fill_diagonal(inner_product_matrix, 0)
 
     # Check if all off-diagonal elements are close to zero
-    return np.allclose(inner_product_matrix, 0)
+    return bool(np.allclose(inner_product_matrix, 0))


### PR DESCRIPTION
Closes: #1954

Many `is_*` predicates were annotated `-> bool` but returned the `np.bool_` scalar from `np.allclose` / `np.isclose`, so the annotation was inaccurate and callers using `is True` or strict typing got the numpy type.

This wraps those returns in `bool(...)` across `matrix_props` (`is_hermitian`, `is_symmetric`, `is_normal`, `is_projection`, `is_idempotent`, `is_identity`, `is_orthonormal`, `is_pseudo_hermitian`, `is_tight_frame`, `is_ldoi`, `is_equiangular_tight_frame`) and `state_props` (`is_mutually_orthogonal`, `is_ensemble`). Four predicates that were honestly annotated `-> bool | np.bool_` (`in_separable_ball`, `is_antidistinguishable`, `is_antidistinguishable_circulant`, `is_distinguishable`) also get `bool(...)` wrapping, and the `| np.bool_` is dropped, so the whole family returns Python `bool` with an accurate signature.

Verified: return type is now `bool`, and the `matrix_props` / touched `state_props` predicate tests pass (556 passed).