### PR TITLE
cleanup: fix has_symmetric_extension docstring and remove a dead prime guard

### DIFF
--- a/toqito/state_props/has_symmetric_extension.py
+++ b/toqito/state_props/has_symmetric_extension.py
@@ -60,7 +60,7 @@ def has_symmetric_extension(
         # Show the closed-form equation holds
         print(
         np.trace(np.linalg.matrix_power(partial_trace(rho, 1), 2))
-        >= np.trace(rho**2) - 4 * np.sqrt(np.linalg.det(rho)))
+        >= np.trace(np.linalg.matrix_power(rho, 2)) - 4 * np.sqrt(np.linalg.det(rho)))
         ```
 
         ```python exec="1" source="above" result="text" session="has_symmetric_example"

--- a/toqito/states/mutually_unbiased_basis.py
+++ b/toqito/states/mutually_unbiased_basis.py
@@ -96,8 +96,7 @@ def _is_prime_power(n: int) -> bool:
         return False
     for p in range(2, math.isqrt(n) + 1):
         if n % p == 0:
-            if not _is_prime(p):  # pragma: no cover - unreachable: smallest divisor of n is always prime
-                continue
+            # The smallest divisor of an integer is always prime, so p is prime here.
             while n % p == 0:
                 n //= p
             return n == 1


### PR DESCRIPTION
Closes: #1959

Two audit fixes.

1. The `has_symmetric_extension` docstring example wrote `np.trace(rho**2)` (elementwise square) where the criterion needs the matrix square; the library code correctly uses `matrix_power`. The docstring now uses `np.linalg.matrix_power(rho, 2)`, so the shown formula matches the implemented criterion. The exec block still prints `True`.

2. In `mutually_unbiased_basis._is_prime_power`, the `if not _is_prime(p): continue` guard was unreachable (already `# pragma: no cover`): the loop takes the smallest divisor of `n`, which is always prime. Removing it also drops a wasted primality test per factorization. `_is_prime` remains in use at its other call sites, and `_is_prime_power` was verified to still classify prime powers and non-prime-powers correctly.

## Scope note
The issue also listed the `# pragma: no cover` guards in `sk_norm` and `sandwiched_renyi_conditional_entropy` for deletion. I deliberately kept those: they are defensive checks (`problem.status != "optimal"` solver-failure raises and numerical support/eigenvalue guards). The `sk_norm` status checks are in fact the kind of guard that #1957 tracks for wider adoption, so removing them would work against that. Only the genuinely-redundant prime guard, which has a clean unreachability proof and no defensive value, was removed.