### PR TITLE
docs: reconcile solver choice, cone docstrings, Watrous notation, solver_option

### DIFF
--- a/docs/content/contributing-guide.md
+++ b/docs/content/contributing-guide.md
@@ -79,6 +79,27 @@ When adding a function, put it in the subpackage that matches what it operates
 on, add a test beside it under that subpackage's `tests/` directory, and export
 it from the subpackage `__init__.py`.
 
+## SDP solver choice
+
+Several routines reduce to a semidefinite or conic program. The solver is
+chosen per problem class, not uniformly, because no single solver is best
+everywhere:
+
+- Exponential-cone and matrix-logarithm problems (the `cones` routines and the
+  quantum-entropy measures) use CLARABEL, an interior-point solver that is
+  accurate and fast on these cones. The `cones` tests and docstring examples use
+  it.
+- Positive-semidefinite discrimination problems (for example `channel_fidelity`
+  and the cvxpy state-discrimination routines) use SCS, a first-order method
+  that is substantially faster than CLARABEL on this problem class.
+- The `state_opt` and `channel_opt` discrimination and exclusion routines, and
+  the `fidelity_of_separability` measures, are built on PICOS and solve with
+  cvxopt.
+
+When adding an SDP-backed routine, pick the solver that suits its cone
+structure rather than copying whichever one a nearby file happens to use, and
+say why in a comment if the choice is not obvious.
+
 ## Making Changes
 
 1.  Add some really awesome code to your local fork. It's usually a

--- a/toqito/channel_metrics/fidelity_of_separability.py
+++ b/toqito/channel_metrics/fidelity_of_separability.py
@@ -18,7 +18,7 @@ def fidelity_of_separability(
     psi_dims: list[int],
     k: int = 1,
     verbosity_option: int = 0,
-    solver_option: str = "cvxopt",
+    solver: str = "cvxopt",
 ) -> float:
     r"""Define the first benchmark introduced in Appendix I of [@philip2023schrodinger].
 
@@ -76,8 +76,8 @@ def fidelity_of_separability(
         verbosity_option: Parameter option for `picos`. Default value is
             `verbosity = 0`. For more info, visit
             https://picos-api.gitlab.io/picos/api/picos.modeling.options.html#option-verbosity.
-        solver_option: Optimization option for `picos` solver. Default option is
-            `solver_option="cvxopt"`. For more info, visit
+        solver: Optimization option for `picos` solver. Default option is
+            `solver="cvxopt"`. For more info, visit
             https://picos-api.gitlab.io/picos/api/picos.modeling.options.html#option-solver.
 
     Returns:
@@ -170,5 +170,5 @@ def fidelity_of_separability(
         sys = sys + [i]
         problem.add_constraint(picos.partial_transpose(choi, sys, choi_dims) >> 0)
 
-    solution = problem.solve(solver=solver_option)
+    solution = problem.solve(solver=solver)
     return 2 * solution.value - 1

--- a/toqito/cones/lieb_ando_epi_cone.py
+++ b/toqito/cones/lieb_ando_epi_cone.py
@@ -73,7 +73,7 @@ def lieb_ando_epi_cone(
             1.5,
         )
         prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-        print(f"{prob.solve(solver=cvxpy.SCS, verbose=False):.4f}")
+        print(f"{prob.solve(solver=cvxpy.CLARABEL, verbose=False):.4f}")
         ```
 
     """

--- a/toqito/cones/lieb_ando_hypo_cone.py
+++ b/toqito/cones/lieb_ando_hypo_cone.py
@@ -73,7 +73,7 @@ def lieb_ando_hypo_cone(
             0.5,
         )
         prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-        print(f"{prob.solve(solver=cvxpy.SCS, verbose=False):.4f}")
+        print(f"{prob.solve(solver=cvxpy.CLARABEL, verbose=False):.4f}")
         ```
 
     """

--- a/toqito/cones/ln_quantum_entropy_hypo_cone.py
+++ b/toqito/cones/ln_quantum_entropy_hypo_cone.py
@@ -73,7 +73,7 @@ def ln_quantum_entropy_hypo_cone(
         t = cvxpy.Variable()
         cons = ln_quantum_entropy_hypo_cone(x_c, t, m=3, k=3, apx=0)
         prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-        print(f"{prob.solve(solver=cvxpy.SCS, verbose=False):.4f}")
+        print(f"{prob.solve(solver=cvxpy.CLARABEL, verbose=False):.4f}")
         ```
 
     """

--- a/toqito/cones/quantum_conditional_entropy_hypo_cone.py
+++ b/toqito/cones/quantum_conditional_entropy_hypo_cone.py
@@ -88,7 +88,7 @@ def quantum_conditional_entropy_hypo_cone(
             cvxpy.Constant(bell), t, [2, 2], sys=0
         )
         prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-        print(f"{prob.solve(solver=cvxpy.SCS, verbose=False):.4f}")
+        print(f"{prob.solve(solver=cvxpy.CLARABEL, verbose=False):.4f}")
         ```
 
     """

--- a/toqito/cones/quantum_relative_entropy_epi_cone.py
+++ b/toqito/cones/quantum_relative_entropy_epi_cone.py
@@ -77,7 +77,7 @@ def quantum_relative_entropy_epi_cone(
             t,
         )
         prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-        print(f"{prob.solve(solver=cvxpy.SCS, verbose=False):.4f}")
+        print(f"{prob.solve(solver=cvxpy.CLARABEL, verbose=False):.4f}")
         ```
 
     """

--- a/toqito/cones/relative_entropy_quadrature_epi_cone.py
+++ b/toqito/cones/relative_entropy_quadrature_epi_cone.py
@@ -103,7 +103,7 @@ def relative_entropy_quadrature_epi_cone(
             z,
         )
         prob = cvxpy.Problem(cvxpy.Minimize(cvxpy.sum(z)), cons)
-        print(f"{prob.solve(solver=cvxpy.SCS, verbose=False):.4f}")
+        print(f"{prob.solve(solver=cvxpy.CLARABEL, verbose=False):.4f}")
         ```
 
     """

--- a/toqito/cones/trace_matrix_log_hypo_cone.py
+++ b/toqito/cones/trace_matrix_log_hypo_cone.py
@@ -77,7 +77,7 @@ def trace_matrix_log_hypo_cone(
         t = cvxpy.Variable()
         cons = trace_matrix_log_hypo_cone(x_c, t, m=3, k=3, apx=0)
         prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-        print(f"{prob.solve(solver=cvxpy.SCS, verbose=False):.4f}")
+        print(f"{prob.solve(solver=cvxpy.CLARABEL, verbose=False):.4f}")
         ```
 
     """

--- a/toqito/cones/trace_matrix_power_epi_cone.py
+++ b/toqito/cones/trace_matrix_power_epi_cone.py
@@ -68,7 +68,7 @@ def trace_matrix_power_epi_cone(
         t = cvxpy.Variable()
         cons = trace_matrix_power_epi_cone(a_c, t, 1.5)
         prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-        print(f"{prob.solve(solver=cvxpy.SCS, verbose=False):.4f}")
+        print(f"{prob.solve(solver=cvxpy.CLARABEL, verbose=False):.4f}")
         ```
 
     """

--- a/toqito/cones/trace_matrix_power_hypo_cone.py
+++ b/toqito/cones/trace_matrix_power_hypo_cone.py
@@ -67,7 +67,7 @@ def trace_matrix_power_hypo_cone(
         t = cvxpy.Variable()
         cons = trace_matrix_power_hypo_cone(a_c, t, 0.5)
         prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-        print(f"{prob.solve(solver=cvxpy.SCS, verbose=False):.4f}")
+        print(f"{prob.solve(solver=cvxpy.CLARABEL, verbose=False):.4f}")
         ```
 
     """

--- a/toqito/cones/tsallis_entropy_hypo_cone.py
+++ b/toqito/cones/tsallis_entropy_hypo_cone.py
@@ -69,7 +69,7 @@ def tsallis_entropy_hypo_cone(
         t = cvxpy.Variable()
         cons = tsallis_entropy_hypo_cone(cvxpy.Constant(mat_x), t, 0.5)
         prob = cvxpy.Problem(cvxpy.Maximize(t), cons)
-        print(f"{prob.solve(solver=cvxpy.SCS, verbose=False):.4f}")
+        print(f"{prob.solve(solver=cvxpy.CLARABEL, verbose=False):.4f}")
         ```
 
     """

--- a/toqito/cones/tsallis_relative_entropy_epi_cone.py
+++ b/toqito/cones/tsallis_relative_entropy_epi_cone.py
@@ -81,7 +81,7 @@ def tsallis_relative_entropy_epi_cone(
             0.5,
         )
         prob = cvxpy.Problem(cvxpy.Minimize(t), cons)
-        print(f"{prob.solve(solver=cvxpy.SCS, verbose=False):.4f}")
+        print(f"{prob.solve(solver=cvxpy.CLARABEL, verbose=False):.4f}")
         ```
 
     """

--- a/toqito/matrix_props/is_rank_one.py
+++ b/toqito/matrix_props/is_rank_one.py
@@ -20,7 +20,7 @@ def is_rank_one(mat: np.ndarray, rtol: float = 1e-08, atol: float = 1e-08) -> bo
         `True` if the matrix has rank at most one, `False` otherwise.
 
     Examples:
-        Consider the Bell state density matrix \(\rho = \ket{\Phi^+}\bra{\Phi^+}\). This matrix
+        Consider the Bell state density matrix \(\rho = \ket{\phi^+}\bra{\phi^+}\). This matrix
         has rank one.
 
         ```python exec="1" source="above" result="text"

--- a/toqito/state_metrics/fidelity_of_separability.py
+++ b/toqito/state_metrics/fidelity_of_separability.py
@@ -17,7 +17,7 @@ def fidelity_of_separability(
     input_state_rho_dims: list[int],
     k: int = 1,
     verbosity_option: int = 0,
-    solver_option: str = "cvxopt",
+    solver: str = "cvxopt",
 ) -> float:
     r"""Define the first benchmark introduced in Appendix H of [@philip2023schrodinger].
 
@@ -84,7 +84,7 @@ def fidelity_of_separability(
         k: value for k-extendibility.
         verbosity_option: Parameter option for `picos`. Default value is `verbosity = 0`. For more info, visit
             https://picos-api.gitlab.io/picos/api/picos.modeling.options.html#option-verbosity.
-        solver_option: Optimization option for `picos` solver. Default option is `solver_option="cvxopt"`. For more
+        solver: Optimization option for `picos` solver. Default option is `solver="cvxopt"`. For more
             info, visit https://picos-api.gitlab.io/picos/api/picos.modeling.options.html#option-solver.
 
     Returns:
@@ -175,5 +175,5 @@ def fidelity_of_separability(
         sys = sys + [i]
         problem.add_constraint(picos.partial_transpose(sigma_ab_k, sys, dim_direct_sum_ab_k) >> 0)
 
-    solution = problem.solve(solver=solver_option)
+    solution = problem.solve(solver=solver)
     return solution.value**2

--- a/toqito/state_props/is_separable.py
+++ b/toqito/state_props/is_separable.py
@@ -178,7 +178,7 @@ def is_separable(
           UPB product vectors in \(\mathbb{C}^3 \otimes \mathbb{C}^3\), of
           the form
           \(H = \sum_i |\alpha_i\rangle\langle\alpha_i|\otimes|\beta_i\rangle\langle\beta_i|
-          - d\varepsilon|\Psi\rangle\langle\Psi|\)
+          - d\varepsilon|\psi\rangle\langle\psi|\)
           where \(\varepsilon\) is the minimum of
           \(\sum_i |\langle\phi_A|\alpha_i\rangle|^2 |\langle\phi_B|\beta_i\rangle|^2\)
           over unit product states. Evaluated as \(\mathrm{tr}(H\rho) < 0\),
@@ -686,7 +686,7 @@ def _terhal_2000_tile_witness() -> np.ndarray:
     \[
         H = \sum_{i=0}^{4} |\alpha_i\rangle\langle\alpha_i| \otimes
             |\beta_i\rangle\langle\beta_i|
-            - d \varepsilon |\Psi\rangle\langle\Psi|
+            - d \varepsilon |\psi\rangle\langle\psi|
     \]
 
     is an indecomposable entanglement witness, where \(d = 3\),
@@ -697,17 +697,17 @@ def _terhal_2000_tile_witness() -> np.ndarray:
                            |\langle\phi_B|\beta_i\rangle|^2,
     \]
 
-    and \(|\Psi\rangle\) is a maximally entangled state with
-    \(\langle\Psi|\rho_{\text{tile}}|\Psi\rangle > 0\) (the ``standard''
+    and \(|\psi\rangle\) is a maximally entangled state with
+    \(\langle\psi|\rho_{\text{tile}}|\psi\rangle > 0\) (the ``standard''
     max-ent state \((|00\rangle+|11\rangle+|22\rangle)/\sqrt{3}\) fails
-    this condition for the tile UPB because \(|\Psi\rangle\) happens to
+    this condition for the tile UPB because \(|\psi\rangle\) happens to
     lie in the UPB span; we use \((|10\rangle+|21\rangle+|02\rangle)/\sqrt{3}\)
     instead, which satisfies it).
 
     A state \(\rho\) is detected as entangled iff
     \(\mathrm{tr}(H\rho) < 0\). Positivity on product states follows from
-    \(|\langle\Psi|\phi_A\otimes\phi_B\rangle|^2 \le 1/d\) for maximally
-    entangled \(|\Psi\rangle\) (Lemma 1 of the paper) combined with the
+    \(|\langle\psi|\phi_A\otimes\phi_B\rangle|^2 \le 1/d\) for maximally
+    entangled \(|\psi\rangle\) (Lemma 1 of the paper) combined with the
     definition of \(\varepsilon\).
     """
     # Factor each tile(i) vector into its A and B factors via SVD.


### PR DESCRIPTION
Closes: #1956

Four documentation and consistency fixes.

1. **Cone docstrings vs tests.** The `cones` module docstring examples printed with `solver=cvxpy.SCS` while their tests were standardized to CLARABEL. Swapped the 11 docstring solves to CLARABEL so the documented and tested solvers agree; CLARABEL is the appropriate interior-point solver for these exponential-cone problems. The cone tests pass.

2. **Solver-choice rationale.** Added a short section to the contributing guide documenting the per-problem-class solver choice: CLARABEL for exponential-cone / entropy problems, SCS for PSD discrimination (measured ~50x faster than CLARABEL there), PICOS+cvxopt for `state_opt`/`channel_opt`. The split is justified by measurement, so it is documented rather than homogenized.

3. **Watrous notation.** `is_separable` wrote the maximally entangled state as `\Psi` and `is_rank_one` wrote the Bell state as `\Phi^+`; capital Greek is reserved for maps in the project's Watrous convention. Changed to lowercase `\psi` / `\phi^+`. The genuine linear map `\Phi: M_3 \to M_3` in `is_separable` is correctly left as capital Greek.

4. **`solver_option` -> `solver`.** Renamed the parameter in both `fidelity_of_separability` functions to match every other solver-taking routine (hard rename, no shim, per the no-deprecation policy). Their tests pass.