### PR TITLE
robustness: check SDP status in optimal_clone before returning the value

### DIFF
--- a/toqito/state_opt/optimal_clone.py
+++ b/toqito/state_opt/optimal_clone.py
@@ -190,7 +190,10 @@ def primal_problem(q_a: np.ndarray, pperm: np.ndarray, num_reps: int) -> float:
     ]
     problem = cvxpy.Problem(objective, constraints)
 
-    return problem.solve(verbose=False)
+    optimal_value = problem.solve(verbose=False)
+    if problem.status not in (cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE):
+        raise ValueError(f"optimal_clone SDP did not solve to optimality (status: {problem.status}).")
+    return optimal_value
 
 
 def dual_problem(q_a: np.ndarray, pperm: np.ndarray, num_reps: int) -> float:
@@ -234,4 +237,7 @@ def dual_problem(q_a: np.ndarray, pperm: np.ndarray, num_reps: int) -> float:
         constraints = [cvxpy.real(kron_var) >> pperm @ q_a @ pperm.conj().T]
     problem = cvxpy.Problem(objective, constraints)
 
-    return problem.solve(verbose=False)
+    optimal_value = problem.solve(verbose=False)
+    if problem.status not in (cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE):
+        raise ValueError(f"optimal_clone SDP did not solve to optimality (status: {problem.status}).")
+    return optimal_value


### PR DESCRIPTION
Closes: #1957

`optimal_clone` builds two cvxpy programs (primal and dual) and returned `problem.solve(...)` directly with no status check. Unlike the PICOS-based routines, cvxpy does not raise on a failed solve: it returns `±inf` for infeasible/unbounded, so a solver failure would surface as a nonsense value rather than an error.

This adds the status guard the rest of the cvxpy code already uses to both solve sites:

```python
if problem.status not in (cvxpy.OPTIMAL, cvxpy.OPTIMAL_INACCURATE):
    raise ValueError(...)
```

The other solve sites named in the issue (`state_distinguishability`, `state_exclusion`, `completely_bounded_trace_norm`, both `fidelity_of_separability`) are built on PICOS, which raises `SolutionFailure` on a non-optimal solve. I verified this directly (an infeasible PICOS problem raises `SolutionFailure`), so those sites are already covered and are left unchanged rather than adding redundant checks.