### PR TITLE
perf: reuse spectrum in Renyi entropy

### DIFF
--- a/toqito/state_props/renyi_entropy.py
+++ b/toqito/state_props/renyi_entropy.py
@@ -2,8 +2,7 @@
 
 import numpy as np
 
-from toqito.matrix_props import is_density
-from toqito.state_props import von_neumann_entropy
+from toqito.matrix_props import is_hermitian
 
 
 def renyi_entropy(rho: np.ndarray, alpha: float) -> float:
@@ -92,17 +91,24 @@ def renyi_entropy(rho: np.ndarray, alpha: float) -> float:
         ```
 
     """
-    if not is_density(rho):
+    if not is_hermitian(rho) or not np.isclose(np.trace(rho), 1):
         raise ValueError("Rényi entropy is only defined for density operators.")
     if alpha < 0:
         raise ValueError("Rényi entropy is only defined for positive orders.")
+
+    # Compute the spectrum once: it validates positive semidefiniteness and is
+    # also needed to calculate the entropy for every order.
+    eigs = np.linalg.eigvalsh(rho)
+    scale = max(1.0, np.max(np.abs(eigs)))
+    if np.min(eigs) < -(1e-08 + 1e-05 * scale):
+        raise ValueError("Rényi entropy is only defined for density operators.")
+
     if alpha == 0:
         return np.log2(np.linalg.matrix_rank(rho))
-    if alpha == 1:
-        return von_neumann_entropy(rho)
 
-    eigs = np.linalg.eigvalsh(rho)
     eigs = eigs[eigs > 0]
+    if alpha == 1:
+        return float(-np.sum(eigs * np.log2(eigs)))
 
     if alpha == float("inf"):
         return -np.log2(eigs.max())

--- a/toqito/state_props/tests/test_renyi_entropy.py
+++ b/toqito/state_props/tests/test_renyi_entropy.py
@@ -44,3 +44,21 @@ def test_renyi_invalid_input(rho, alpha):
     """Test function works as expected for an invalid input."""
     with np.testing.assert_raises(ValueError):
         renyi_entropy(rho, alpha)
+
+
+@pytest.mark.parametrize("alpha", [0.0, 1.0, 2.0, float("inf")])
+def test_renyi_entropy_computes_spectrum_once(monkeypatch, alpha):
+    """Test each entropy order reuses one spectral decomposition."""
+    original_eigvalsh = np.linalg.eigvalsh
+    calls = 0
+
+    def count_eigvalsh(matrix):
+        nonlocal calls
+        calls += 1
+        return original_eigvalsh(matrix)
+
+    monkeypatch.setattr(np.linalg, "eigvalsh", count_eigvalsh)
+
+    renyi_entropy(RHO_TEST, alpha)
+
+    assert calls == 1


### PR DESCRIPTION
## Summary
- compute the density-matrix spectrum once in `renyi_entropy`
- reuse it for density validation and every Rényi order, including `alpha = 1`
- add a regression test asserting one `eigvalsh` call per order

Closes #1958

## Validation
- `uv run pytest toqito/state_props/tests/test_renyi_entropy.py -q`
- `uv run --group lint ruff check toqito/state_props/renyi_entropy.py toqito/state_props/tests/test_renyi_entropy.py`
- `uv run --group lint ruff format --check toqito/state_props/renyi_entropy.py toqito/state_props/tests/test_renyi_entropy.py`