### PR TITLE
perf: compute the spectrum once in von_neumann_entropy

### DIFF
--- a/toqito/state_props/tests/test_von_neumann_entropy.py
+++ b/toqito/state_props/tests/test_von_neumann_entropy.py
@@ -39,9 +39,30 @@ def test_von_neumann_entropy_complex_hermitian():
     [
         # Test von Neumann entropy on non-density matrix.
         (np.array([[1, 2], [3, 4]])),
+        # Hermitian with unit trace but a negative eigenvalue, so not positive semidefinite.
+        (np.array([[0.5, 3.0], [3.0, 0.5]])),
+        # Hermitian with unit trace, rank deficient (a zero eigenvalue), and not positive semidefinite.
+        (np.diag([1.0, 0.5, -0.5])),
     ],
 )
 def test_von_neumann_invalid_input(rho):
     """Test function works as expected for an invalid input."""
     with np.testing.assert_raises(ValueError):
         von_neumann_entropy(rho)
+
+
+def test_von_neumann_entropy_computes_spectrum_once(monkeypatch):
+    """The entropy is computed from a single spectral decomposition of rho."""
+    original_eigvalsh = np.linalg.eigvalsh
+    calls = 0
+
+    def count_eigvalsh(matrix):
+        nonlocal calls
+        calls += 1
+        return original_eigvalsh(matrix)
+
+    monkeypatch.setattr(np.linalg, "eigvalsh", count_eigvalsh)
+
+    von_neumann_entropy(max_mixed(2, is_sparse=False))
+
+    assert calls == 1

--- a/toqito/state_props/von_neumann_entropy.py
+++ b/toqito/state_props/von_neumann_entropy.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from toqito.matrix_props import is_density
+from toqito.matrix_props import is_hermitian
 
 
 def von_neumann_entropy(rho: np.ndarray) -> float:
@@ -89,10 +89,17 @@ def von_neumann_entropy(rho: np.ndarray) -> float:
         ```
 
     """
-    if not is_density(rho):
+    # A density operator is Hermitian with unit trace. Check both cheaply first; the positive-semidefinite
+    # check below reads the spectrum, so `rho` is only ever factorized once.
+    if not is_hermitian(rho) or not np.isclose(np.trace(rho), 1):
         raise ValueError("Von Neumann entropy is only defined for density operators.")
     # A density operator is Hermitian, so use eigvalsh, which returns real eigenvalues and avoids the spurious
-    # imaginary parts that np.linalg.eig can introduce.
+    # imaginary parts that np.linalg.eig can introduce. This single factorization both validates positive
+    # semidefiniteness (with the same tolerances as `is_positive_semidefinite`) and supplies the spectrum for
+    # the entropy computation.
     eigs = np.linalg.eigvalsh(rho)
+    scale = max(1.0, np.max(np.abs(eigs)))
+    if np.min(eigs) < -(1e-08 + 1e-05 * scale):
+        raise ValueError("Von Neumann entropy is only defined for density operators.")
     eigs = eigs[eigs > 0]
     return float(-np.sum(eigs * np.log2(eigs)))


### PR DESCRIPTION
## Summary

`von_neumann_entropy` currently validates `rho` with `is_density()` before computing its eigenvalues. For a valid input that means the matrix is factorized **twice**: once via the Cholesky fast path inside `is_positive_semidefinite`, and again by the `np.linalg.eigvalsh` call that supplies the spectrum for the entropy sum.

This PR applies the same single-factorization pattern as #1958 to `von_neumann_entropy` (that issue's fix for `renyi_entropy` is in flight in #1961 and #1966; this is the complementary change the issue describes as the reference pattern):

- Replace the `is_density()` gate with a cheap `is_hermitian()` + `np.isclose(np.trace(rho), 1)` check.
- Validate positive semidefiniteness from the spectrum that is already being computed, using the same tolerances as `is_positive_semidefinite` (`atol=1e-08`, `rtol=1e-05`, `scale = max(1, max|eigs|)`).
- Keep raising `ValueError` with the same message for non-density inputs.

The explicit Hermitian check is required: `np.linalg.eigvalsh` silently returns the spectrum of the Hermitian part for non-Hermitian input, so dropping it would silently accept non-Hermitian matrices instead of raising.

## Behavior

- Same `ValueError` for non-density inputs (non-Hermitian, non-square, trace != 1, not PSD).
- Identical entropy values for valid inputs — verified against the old implementation over 76 randomized valid/invalid cases (all agree, `atol=1e-10`).
- Perf: ~1.1x faster standalone; the `renyi_entropy(rho, 1)` path (which chains through `von_neumann_entropy`) drops one full Cholesky factorization. Once #1966 lands, the whole chain will be a single `eigvalsh`.

## Tests

- Added `test_von_neumann_entropy_computes_spectrum_once`, asserting a single `eigvalsh` call (mirrors the test in #1966).
- Extended the invalid-input parametrization with a Hermitian unit-trace non-PSD matrix and a rank-deficient non-PSD matrix.
- Full suite: `3739 passed, 60 skipped, 2 xfailed`; `ruff check` and `ruff format --check` clean.

Closes nothing directly — complements #1958, #1961, #1966.