### PR TITLE
test: cover reduction-criterion propagation and three abstain guards in is_separable

### DIFF
--- a/toqito/state_props/tests/test_is_separable.py
+++ b/toqito/state_props/tests/test_is_separable.py
@@ -26,6 +26,7 @@ from toqito.state_props.is_separable import (
     _range_projector_product_overlap_3x3_rank4,
     _reduction_ppt_criterion,
     _sorted_real_eigs_desc,
+    _vidal_tarrach_ppt_criterion,
 )
 from toqito.states import basis, bell, horodecki, isotropic, max_entangled, tile
 
@@ -1467,6 +1468,28 @@ def test_is_separable_returns_iter_sub_reason_when_helper_succeeds():
     assert mocked.called
 
 
+def test_is_separable_surfaces_reduction_criterion_reason_when_helper_fires():
+    """is_separable surfaces the reduction-criterion reason when the helper fires (#1915).
+
+    `_reduction_ppt_criterion` cannot actually fire on a state that reaches
+    section 8: the docstring at that call site notes that PPT already implies
+    the reduction criterion is satisfied, so every state that gets this far
+    passes it for real. `_RHO_ENT_SYMM_3x3_REACHES_12B` reaches section 8
+    without an earlier section returning first (see the 12b test above), so
+    mocking the helper here isolates the propagation line itself -- the
+    `return verdict` right after the call in `is_separable` -- from whether
+    the criterion can be genuinely violated at this point in the dispatch.
+    """
+    with mock.patch(
+        "toqito.state_props.is_separable._reduction_ppt_criterion",
+        return_value=(False, "mocked reduction criterion violation"),
+    ) as mocked:
+        sep, reason = is_separable(_RHO_ENT_SYMM_3x3_REACHES_12B, dim=[3, 3], level=1)
+    assert sep is False
+    assert reason == "mocked reduction criterion violation"
+    assert mocked.called
+
+
 def test_is_separable_strength_zero_skips_iter_sub():
     """Section 12b must not run at strength=0: the helper should never be called."""
     with mock.patch(
@@ -1886,6 +1909,20 @@ def test_qubit_qudit_swapped_eigvalsh_failure_falls_back_to_eigvals():
     assert verdict == (True, "Johnston spectral condition for 2xN PPT states (2013)")
 
 
+def test_vidal_tarrach_abstains_on_a_length_or_dimension_mismatch():
+    """The Vidal-Tarrach guard must abstain, not index, on a bad spectrum (#1915).
+
+    `is_separable` always calls this helper with a spectrum whose length
+    equals `prod_dim_val`, so the guard's False side is never taken through
+    the public entry point. Calling the helper directly with a mismatched
+    length, and separately with `prod_dim_val <= 1`, exercises both ways the
+    guard can fail without touching `is_separable` itself.
+    """
+    machine_eps = np.finfo(float).eps
+    assert _vidal_tarrach_ppt_criterion(np.array([0.6, 0.4]), 4, 1e-8, machine_eps) is None
+    assert _vidal_tarrach_ppt_criterion(np.array([1.0]), 1, 1e-8, machine_eps) is None
+
+
 def test_qubit_qudit_lemma1_block_eigvals_failure_returns_none():
     """Johnston Lemma 1 abstains when the block eigendecomposition fails."""
     rho = bell(2) @ bell(2).conj().T
@@ -1904,6 +1941,32 @@ def test_qubit_qudit_lemma1_block_eigvals_failure_returns_none():
     assert verdict is None
 
 
+def test_qubit_qudit_2xn_criteria_abstain_on_zero_size_blocks():
+    """The 2xN block algebra must abstain rather than index into empty blocks (#1915).
+
+    Through `is_separable`, `state` and `max_dim_val` always agree, so the A/B/C
+    blocks sliced out of it are never empty once the `min_dim_val == 2` guard is
+    passed. Calling the helper directly with a zero-sized state (but a nonzero
+    `prod_dim_val`, so the earlier guard does not short-circuit first) forces
+    `a_block`, `b_block`, and `c_block` all to be empty, which also means the
+    Johnston spectral condition's length check above it can't be satisfied
+    either -- both guards fail together, and the helper must still abstain
+    cleanly instead of raising.
+    """
+    verdict = _qubit_qudit_ppt_criteria(
+        state=np.zeros((0, 0)),
+        dims=[2, 2],
+        d_a=2,
+        d_b=2,
+        min_dim_val=2,
+        max_dim_val=2,
+        prod_dim_val=4,
+        tol=1e-8,
+        sorted_eigs_desc=np.array([]),
+    )
+    assert verdict is None
+
+
 def test_range_projector_overlap_abstains_below_rank_four():
     """The rank-4 3x3 range criterion must abstain on a lower-rank state.
 
@@ -1914,6 +1977,26 @@ def test_range_projector_overlap_abstains_below_rank_four():
     rho_rank1 = prod @ prod.conj().T
 
     assert _range_projector_product_overlap_3x3_rank4(rho_rank1, 1e-8) is None
+
+
+def test_range_projector_overlap_returns_best_effort_without_full_convergence():
+    """The alternating maximization must return its best overlap, not crash, on early truncation (#1915).
+
+    With the default 64 restarts and 100 inner iterations the loop always
+    converges before the budget is exhausted, so the "ran out of iterations"
+    fall-through is never taken. Forcing `max_iter=1` truncates every restart
+    before its break condition can fire, exercising that fall-through directly
+    while still returning a valid overlap in [0, 1].
+    """
+    rng = np.random.default_rng(1234)
+    vecs = rng.standard_normal((9, 4)) + 1j * rng.standard_normal((9, 4))
+    projector = vecs @ np.linalg.pinv(vecs.conj().T @ vecs) @ vecs.conj().T
+    rho_rank4 = projector / np.trace(projector).real
+
+    overlap = _range_projector_product_overlap_3x3_rank4(rho_rank4, 1e-8, n_restarts=1, max_iter=1)
+
+    assert overlap is not None
+    assert 0.0 <= overlap <= 1.0 + 1e-8
 
 
 def test_choi_positive_map_witness_flags_a_3x3_entangled_state():


### PR DESCRIPTION
## Description

Continues #1915. Adds four tests that reach lines and branches in `is_separable.py` that the test suite wasn't hitting yet, without touching `is_separable.py` itself.

## Changes

- Covers the reduction-criterion propagation line in `is_separable` by mocking `_reduction_ppt_criterion` on a state that already reaches section 8 (`_RHO_ENT_SYMM_3x3_REACHES_12B`, used by an existing test above it). A mock is needed here rather than a real violating state, because the comment right above that call notes that PPT already implies the reduction criterion holds, so no real PPT state can violate it once execution gets that far.
- Covers `_vidal_tarrach_ppt_criterion`'s guard-false branch directly, once with a mismatched spectrum length and once with `prod_dim_val <= 1`.
- Covers `_qubit_qudit_ppt_criteria`'s Johnston length guard and its empty-block guard together, by calling the helper directly with a zero-sized state and a nonzero `prod_dim_val`.
- Covers `_range_projector_product_overlap_3x3_rank4`'s loop-exhaustion fallback by forcing `max_iter=1` on a real rank-4 3x3 state.

Coverage of `toqito/state_props/is_separable.py` moves from 97.76% (475 statements, 5 missing, 240 branches, 11 partial) to 98.60% (475 statements, 4 missing, 240 branches, 6 partial).

The remaining misses look unreachable through any input without editing `is_separable.py`, which the issue asks to leave alone here, so I didn't attempt them:

- Lines 469, 479, and 481 guard internal-consistency invariants. Every branch of the `dim` normalization above them already guarantees a nonzero `dA` and `dB` whenever `state_len != 0`, so these `raise`s can't fire.
- Line 1290 guards `denom_ha` against being near zero, but `denom_ha = 1 - t + t^2` has a minimum of 0.75 over the real `t` values the loop iterates through, so it's the same situation.
- The `741->752` branch is inside `_terhal_2000_tile_witness`, which runs once at import time with a fixed seed and no caller-adjustable parameters, so its convergence loop can't be forced to run out from a test.
- The `1256->1262` branch checks `eig_a_real.size > 0` right after the enclosing `if a_block.size > 0 and b_block.size > 0 and c_block.size > 0:`. Since all three blocks share the same square dimension, a nonzero block size always means a nonzero eigenvalue count, so that inner guard can't fail on its own.

## Verification

```
uv run pytest toqito/state_props/tests/test_is_separable.py -q
162 passed, 3 skipped, 1 xfailed

uv run ruff check toqito/state_props/tests/test_is_separable.py
All checks passed!
```

## Checklist

- [x] Use `ruff` for errors related to code style and formatting.
- [x] Verify all previous and newly added unit tests pass in `pytest`.
- [x] Check the documentation build does not lead to any failures. (test-only change, no doc-facing symbols touched)
