### PR TITLE
refactor: de-duplicate SDP builders and Gauss-Legendre quadrature

### DIFF
--- a/toqito/_quadrature.py
+++ b/toqito/_quadrature.py
@@ -1,0 +1,26 @@
+"""Shared numerical quadrature helpers."""
+
+import numpy as np
+
+
+def _gauss_legendre_01(m: int) -> tuple[np.ndarray, np.ndarray]:
+    r"""Compute m-point Gauss-Legendre quadrature nodes and weights on [0, 1].
+
+    The nodes and weights are obtained from the standard Gauss-Legendre rule on
+    :math:`[-1, 1]` (via ``numpy.polynomial.legendre.leggauss``) and mapped
+    affinely onto :math:`[0, 1]`.
+
+    Args:
+        m: Number of quadrature points. Must be at least 1.
+
+    Returns:
+        Tuple of nodes and weights on the interval :math:`[0, 1]`.
+
+    Raises:
+        ValueError: If ``m`` is less than 1.
+
+    """
+    if m < 1:
+        raise ValueError("m must be at least 1.")
+    x, w = np.polynomial.legendre.leggauss(m)
+    return 0.5 * (x + 1), 0.5 * w

--- a/toqito/channel_metrics/channel_measured_relative_entropy.py
+++ b/toqito/channel_metrics/channel_measured_relative_entropy.py
@@ -5,6 +5,7 @@ import warnings
 import cvxpy as cvx
 import numpy as np
 
+from toqito._quadrature import _gauss_legendre_01
 from toqito.channel_props import is_completely_positive, is_quantum_channel
 
 
@@ -111,7 +112,7 @@ def channel_measured_relative_entropy(
     theta = cvx.Variable((n, n), hermitian=True)
     ts = [cvx.Variable((n, n), hermitian=True) for _ in range(m)]
     zs = [cvx.Variable((n, n), hermitian=True) for _ in range(k + 1)]
-    nodes, weights = _gauss_legendre_on_01(m)
+    nodes, weights = _gauss_legendre_01(m)
 
     Id = cvx.Constant(np.eye(out_dim))
     zblocks = [cvx.bmat(([zs[i], zs[i + 1]], [zs[i + 1], cvx.kron(rho, Id)])) for i in range(k)]
@@ -143,11 +144,3 @@ def channel_measured_relative_entropy(
         warnings.filterwarnings("ignore", message="Solution may be inaccurate")
         problem.solve(solver=cvx.SCS, eps=1e-8, verbose=False)
     return obj.value
-
-
-def _gauss_legendre_on_01(m: int) -> tuple[np.ndarray, np.ndarray]:
-    """m-point Gauss legendre quadrature weights on the interval [0,1]."""
-    x, w = np.polynomial.legendre.leggauss(m)
-    node = 0.5 * (x + 1)
-    weight = 0.5 * w
-    return node, weight

--- a/toqito/channel_opt/channel_distinguishability.py
+++ b/toqito/channel_opt/channel_distinguishability.py
@@ -195,8 +195,8 @@ def channel_distinguishability(
         return 1.0, []
 
     if primal_dual == "primal":
-        return _bayesian_primal(choi_matrices, probs_arr, dim_in, dim_out, solver=solver, **kwargs)
-    return _bayesian_dual(choi_matrices, probs_arr, dim_in, dim_out, solver=solver, **kwargs)
+        return _min_error_primal(choi_matrices, probs_arr, dim_in, dim_out, solver=solver, **kwargs)
+    return _min_error_dual(choi_matrices, probs_arr, dim_in, dim_out, solver=solver, **kwargs)
 
 
 def _two_channel_distinguishability(
@@ -261,15 +261,19 @@ def _validate_probs(probs: list[float] | None, num_channels: int) -> np.ndarray:
     return probs_arr / probs_sum
 
 
-def _bayesian_primal(
+def _min_error_primal(
     choi_matrices: list[np.ndarray],
     probs: np.ndarray,
     dimA: int,
     dimB: int,
+    sense: str = "max",
     solver: str = "cvxopt",
     **kwargs,
 ) -> tuple[float, list[np.ndarray]]:
-    """Find the primal problem for Bayesian discrimination of n quantum channels.
+    """Find the primal problem for the minimum-error quantum channel discrimination SDP.
+
+    The ``sense`` argument selects the objective sense: ``"max"`` for minimum-error
+    channel distinguishability and ``"min"`` for minimum-error channel exclusion.
 
     See Section 3.5 of [@watrous2018theory]. The Choi matrices live on input (x) output
     (subsystem 0 is the input space of dimension dimA, subsystem 1 the output space of
@@ -288,7 +292,7 @@ def _bayesian_primal(
     problem.add_constraint(pc.trace(rho) == 1)
 
     problem.set_objective(
-        "max", pc.sum([probs[i] * pc.trace(P_var[i] * choi_matrices[i]).real for i in range(num_channels)])
+        sense, pc.sum([probs[i] * pc.trace(P_var[i] * choi_matrices[i]).real for i in range(num_channels)])
     )
 
     problem.solve(solver=solver, **kwargs)
@@ -296,15 +300,21 @@ def _bayesian_primal(
     return problem.value, [np.array(var.value) for var in P_var]
 
 
-def _bayesian_dual(
+def _min_error_dual(
     choi_matrices: list[np.ndarray],
     probs: np.ndarray,
     dimA: int,
     dimB: int,
+    sense: str = "max",
     solver: str = "cvxopt",
     **kwargs,
 ) -> tuple[float, list[np.ndarray]]:
-    """Find the dual problem for Bayesian discrimination of n quantum channels.
+    """Find the dual problem for the minimum-error quantum channel discrimination SDP.
+
+    The ``sense`` argument selects the objective sense: ``"max"`` for minimum-error
+    channel distinguishability and ``"min"`` for minimum-error channel exclusion. The
+    constraint directions and objective sense flip together so the dual remains the
+    dual of the requested primal sense.
 
     See Section 3.5 of [@watrous2018theory]. Minimize lambda subject to Y >= p_i J(Phi_i) for all i
     and Tr_out(Y) <= lambda * I_in, i.e. minimize the largest eigenvalue of Tr_out(Y).
@@ -319,14 +329,18 @@ def _bayesian_dual(
     # Trace out the output space (subsystem index 1 in toqito's input (x) output Choi convention).
     Y0 = pc.partial_trace(Y_var, subsystems=1, dimensions=[dimA, dimB])
 
-    problem.add_list_of_constraints(Y_var >> probs[i] * choi_matrices[i] for i in range(num_channels))
-    problem.add_constraint(Y0 << a_var * np.eye(dimA))
+    if sense == "max":
+        problem.add_list_of_constraints(Y_var >> probs[i] * choi_matrices[i] for i in range(num_channels))
+        problem.add_constraint(Y0 << a_var * np.eye(dimA))
+        problem.set_objective("min", a_var)
+        problem.solve(solver=solver, **kwargs)
+        return problem.value, [np.array(Y_var.value)]
 
-    problem.set_objective("min", a_var)
-
+    dual_constraints = [problem.add_constraint(Y_var << probs[i] * choi_matrices[i]) for i in range(num_channels)]
+    problem.add_constraint(Y0 >> a_var * np.eye(dimA))
+    problem.set_objective("max", a_var)
     problem.solve(solver=solver, **kwargs)
-
-    return problem.value, [np.array(Y_var.value)]
+    return problem.value, [np.array(constraint.dual) for constraint in dual_constraints]
 
 
 def _minimax_dual(

--- a/toqito/channel_opt/channel_exclusion.py
+++ b/toqito/channel_opt/channel_exclusion.py
@@ -40,6 +40,7 @@ import numpy as np
 import picos as pc
 
 from toqito.channel_ops import kraus_to_choi
+from toqito.channel_opt.channel_distinguishability import _min_error_dual, _min_error_primal
 from toqito.channel_props.channel_dim import channel_dim
 
 
@@ -206,65 +207,9 @@ def channel_exclusion(
         return _unambiguous_primal(choi_channels, probs_arr.tolist(), dim_in, dim_out, solver=solver, **kwargs)
 
     if primal_dual == "primal":
-        return _min_error_primal(choi_channels, probs_arr.tolist(), dim_in, dim_out, solver=solver, **kwargs)
+        return _min_error_primal(choi_channels, probs_arr, dim_in, dim_out, sense="min", solver=solver, **kwargs)
 
-    return _min_error_dual(choi_channels, probs_arr.tolist(), dim_in, dim_out, solver=solver, **kwargs)
-
-
-def _min_error_primal(
-    channels: list[np.ndarray],
-    probs: list[float],
-    dim_in: int,
-    dim_out: int,
-    solver: str = "cvxopt",
-    **kwargs,
-) -> tuple[float, list[np.ndarray]]:
-    """Solve the primal SDP for minimum-error channel exclusion."""
-    n_channels = len(channels)
-    problem = pc.Problem()
-
-    strategy_ops = [
-        pc.HermitianVariable(f"W[{idx}]", (dim_in * dim_out, dim_in * dim_out)) for idx in range(n_channels)
-    ]
-    x_var = pc.HermitianVariable("X", (dim_in, dim_in))
-
-    problem.add_list_of_constraints(strategy_ops[idx] >> 0 for idx in range(n_channels))
-    problem.add_constraint(x_var >> 0)
-    problem.add_constraint(pc.trace(x_var) == 1)
-
-    # Choi operators are ordered as input x output, so the lifted marginal is X x I_out.
-    problem.add_constraint(pc.sum(strategy_ops) == x_var @ np.eye(dim_out))
-
-    objective = pc.sum([probs[idx] * (channels[idx] | strategy_ops[idx]).real for idx in range(n_channels)])
-    problem.set_objective("min", objective)
-
-    solution = problem.solve(solver=solver, **kwargs)
-    return solution.value, [np.array(var.value) for var in strategy_ops]
-
-
-def _min_error_dual(
-    channels: list[np.ndarray],
-    probs: list[float],
-    dim_in: int,
-    dim_out: int,
-    solver: str = "cvxopt",
-    **kwargs,
-) -> tuple[float, list[np.ndarray]]:
-    """Solve the dual SDP for minimum-error channel exclusion."""
-    n_channels = len(channels)
-    problem = pc.Problem()
-
-    y_var = pc.HermitianVariable("Y", (dim_in * dim_out, dim_in * dim_out))
-    lambda_var = pc.RealVariable("lambda")
-
-    dual_constraints = [problem.add_constraint(y_var << probs[idx] * channels[idx]) for idx in range(n_channels)]
-    problem.add_constraint(pc.partial_trace(y_var, 1, (dim_in, dim_out)) >> lambda_var * np.eye(dim_in))
-
-    problem.set_objective("max", lambda_var)
-    solution = problem.solve(solver=solver, **kwargs)
-
-    strategy_ops = [np.array(constraint.dual) for constraint in dual_constraints]
-    return solution.value, strategy_ops
+    return _min_error_dual(choi_channels, probs_arr, dim_in, dim_out, sense="min", solver=solver, **kwargs)
 
 
 def _unambiguous_primal(

--- a/toqito/cones/operator_relative_entropy_epi_cone.py
+++ b/toqito/cones/operator_relative_entropy_epi_cone.py
@@ -6,6 +6,7 @@
 import cvxpy
 import numpy as np
 
+from toqito._quadrature import _gauss_legendre_01
 from toqito.cones._utils import _require_square_2d, _symmetric_like_variable
 from toqito.cones.geometric_mean_hypo_cone import geometric_mean_hypo_cone
 
@@ -148,22 +149,11 @@ def operator_relative_entropy_epi_cone(
 
 
 def _gauss_legendre(m: int) -> tuple[np.ndarray, np.ndarray]:
-    """Compute Gauss-Legendre quadrature nodes and weights on [0,1].
+    """Compute Gauss-Legendre quadrature nodes and weights on [0, 1].
 
-    Based on the implementation in [@trefethen2008gauss].
+    Delegates to the shared :func:`toqito._quadrature._gauss_legendre_01` helper.
     """
-    if m < 1:
-        raise ValueError("m must be at least 1.")
-    if m == 1:
-        return np.array([0.5]), np.array([1.0])
-    k = np.arange(1, m, dtype=np.float64)
-    beta = 0.5 / np.sqrt(1 - (2 * k) ** (-2))
-    T = np.diag(beta, 1) + np.diag(beta, -1)
-    nodes_m11, V = np.linalg.eigh(T)
-    weights_m11 = 2 * V[0, :] ** 2
-    nodes = (nodes_m11 + 1) / 2
-    weights = weights_m11 / 2
-    return nodes, weights
+    return _gauss_legendre_01(m)
 
 
 def _gauss_radau(m: int, endpoint: int) -> tuple[np.ndarray, np.ndarray]:

--- a/toqito/state_metrics/measured_relative_entropy.py
+++ b/toqito/state_metrics/measured_relative_entropy.py
@@ -4,6 +4,7 @@ import cvxpy as cvx
 import numpy as np
 import scipy.linalg
 
+from toqito._quadrature import _gauss_legendre_01
 from toqito.matrix_props import is_density, is_positive_semidefinite
 
 
@@ -110,7 +111,7 @@ def measured_relative_entropy(rho: np.ndarray, sigma: np.ndarray, eps: float = 1
     w, theta = cvx.Variable((n, n), complex=True), cvx.Variable((n, n), hermitian=True)
     ts = [cvx.Variable((n, n), hermitian=True) for _ in range(m)]
     zs = [cvx.Variable((n, n), hermitian=True) for _ in range(k + 1)]
-    nodes, weights = _gauss_legendre_on_01(m)
+    nodes, weights = _gauss_legendre_01(m)
 
     Id = cvx.Constant(np.eye(n))
     zblocks = [cvx.bmat(((zs[i], zs[i + 1]), (zs[i + 1], Id))) for i in range(k)]
@@ -134,15 +135,6 @@ def measured_relative_entropy(rho: np.ndarray, sigma: np.ndarray, eps: float = 1
     problem = cvx.Problem(obj, constraints=cons)
     problem.solve(verbose=False)
     return obj.value
-
-
-def _gauss_legendre_on_01(m: int) -> tuple[np.ndarray, np.ndarray]:
-    """m-point Gauss legendre quadrature weights on the interval [0,1]."""
-    x = np.polynomial.legendre.leggauss(m)[0]
-    w = np.polynomial.legendre.leggauss(m)[1]
-    node = 0.5 * (x + 1)
-    weight = 0.5 * w
-    return node, weight
 
 
 def _compute_a(rho: np.ndarray, sigma: np.ndarray) -> float:

--- a/toqito/state_opt/state_distinguishability.py
+++ b/toqito/state_opt/state_distinguishability.py
@@ -287,10 +287,15 @@ def _min_error_primal(
     vectors: list[np.ndarray],
     dim: int,
     probs: list[float] | None = None,
+    sense: str = "max",
     solver: str = "cvxopt",
     **kwargs,
 ) -> tuple[float, list[picos.HermitianVariable]]:
-    """Find the primal problem for minimum-error quantum state distinguishability SDP."""
+    """Find the primal problem for the minimum-error quantum state discrimination SDP.
+
+    The ``sense`` argument selects the objective sense: ``"max"`` for minimum-error
+    state distinguishability and ``"min"`` for minimum-error state exclusion.
+    """
     n = len(vectors)
 
     problem = picos.Problem()
@@ -301,7 +306,7 @@ def _min_error_primal(
 
     dms = [to_density_matrix(vector) for vector in vectors]
 
-    problem.set_objective("max", np.real(picos.sum([(probs[i] * dms[i] | measurements[i]) for i in range(n)])))
+    problem.set_objective(sense, np.real(picos.sum([(probs[i] * dms[i] | measurements[i]) for i in range(n)])))
     solution = problem.solve(solver=solver, **kwargs)
     return solution.value, measurements
 
@@ -310,19 +315,32 @@ def _min_error_dual(
     vectors: list[np.ndarray],
     dim: int,
     probs: list[float] | None = None,
+    sense: str = "max",
     solver: str = "cvxopt",
     **kwargs,
 ) -> tuple[float, list[picos.HermitianVariable]]:
-    """Find the dual problem for minimum-error quantum state distinguishability SDP."""
+    """Find the dual problem for the minimum-error quantum state discrimination SDP.
+
+    The ``sense`` argument selects the objective sense: ``"max"`` for minimum-error
+    state distinguishability and ``"min"`` for minimum-error state exclusion. The
+    constraint direction and objective sense flip together so the dual remains the
+    dual of the requested primal sense.
+    """
     n = len(vectors)
     problem = picos.Problem()
 
     # Set up variables and constraints for SDP:
     y_var = picos.HermitianVariable("Y", (dim, dim))
-    problem.add_list_of_constraints([y_var >> probs[i] * to_density_matrix(vector) for i, vector in enumerate(vectors)])
-
-    # Objective function:
-    problem.set_objective("min", picos.trace(y_var))
+    if sense == "max":
+        problem.add_list_of_constraints(
+            [y_var >> probs[i] * to_density_matrix(vector) for i, vector in enumerate(vectors)]
+        )
+        problem.set_objective("min", picos.trace(y_var))
+    else:
+        problem.add_list_of_constraints(
+            [y_var << probs[i] * to_density_matrix(vector) for i, vector in enumerate(vectors)]
+        )
+        problem.set_objective("max", picos.trace(y_var))
     solution = problem.solve(solver=solver, primals=None, **kwargs)
 
     measurements = [problem.get_constraint(k).dual for k in range(n)]

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -9,6 +9,7 @@ import picos
 from toqito.matrix_ops import calculate_vector_matrix_dimension, partial_trace, to_density_matrix
 from toqito.matrix_props import has_same_dimension
 from toqito.rand import random_povm
+from toqito.state_opt.state_distinguishability import _min_error_dual, _min_error_primal
 
 
 def state_exclusion(
@@ -338,8 +339,8 @@ def state_exclusion(
 
     if strategy == "min_error":
         if primal_dual == "primal":
-            return _min_error_primal(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
-        return _min_error_dual(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
+            return _min_error_primal(vectors=vectors, dim=dim, probs=probs, sense="min", solver=solver, **kwargs)
+        return _min_error_dual(vectors=vectors, dim=dim, probs=probs, sense="min", solver=solver, **kwargs)
 
     if primal_dual == "primal":
         return _unambiguous_primal(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
@@ -379,52 +380,6 @@ def _ppt_dual_cone_constraint(
     return problem.add_constraint(
         expr - picos.partial_transpose(q_var, subsystems=subsystems, dimensions=dimensions) >> 0
     )
-
-
-def _min_error_primal(
-    vectors: list[np.ndarray],
-    dim: int,
-    probs: list[float] | None = None,
-    solver: str = "cvxopt",
-    **kwargs,
-) -> tuple[float, list[picos.HermitianVariable]]:
-    """Find the primal problem for minimum-error quantum state exclusion SDP."""
-    n = len(vectors)
-    problem = picos.Problem()
-    measurements = [picos.HermitianVariable(f"M[{i}]", (dim, dim)) for i in range(n)]
-
-    problem.add_list_of_constraints([meas >> 0 for meas in measurements])
-    problem.add_constraint(picos.sum(measurements) == picos.I(dim))
-
-    dms = [to_density_matrix(vector) for vector in vectors]
-
-    problem.set_objective("min", np.real(picos.sum([(probs[i] * dms[i] | measurements[i]) for i in range(n)])))
-    solution = problem.solve(solver=solver, **kwargs)
-    return solution.value, measurements
-
-
-def _min_error_dual(
-    vectors: list[np.ndarray],
-    dim: int,
-    probs: list[float] | None = None,
-    solver: str = "cvxopt",
-    **kwargs,
-) -> tuple[float, list[picos.HermitianVariable]]:
-    """Find the dual problem for minimum-error quantum state exclusion SDP."""
-    n = len(vectors)
-    problem = picos.Problem()
-
-    # Set up variables and constraints for SDP:
-    y_var = picos.HermitianVariable("Y", (dim, dim))
-    problem.add_list_of_constraints([y_var << probs[i] * to_density_matrix(vector) for i, vector in enumerate(vectors)])
-
-    # Objective function:
-    problem.set_objective("max", picos.trace(y_var))
-    solution = problem.solve(solver=solver, **kwargs)
-
-    measurements = [problem.get_constraint(k).dual for k in range(n)]
-
-    return solution.value, measurements
 
 
 def _ppt_min_error_primal(


### PR DESCRIPTION
## Summary

Addresses #1955 by de-duplicating two families of copied implementation:

1. **Gauss-Legendre quadrature** — three byte-for-byte copies of the same `[0,1]`
   quadrature rule (`_gauss_legendre_on_01` x2 in `state_metrics`/`channel_metrics`,
   and the Golub-Welsch variant `_gauss_legendre` in `cones`) now live in a single
   shared helper, `toqito._quadrature._gauss_legendre_01`. The cone's public-facing
   `_gauss_legendre` wrapper is kept (its tests exercise it) and now delegates.

2. **Minimum-error SDP builders** — the state and channel pairs each carried
   identical primal/dual builders for distinguishability and exclusion:
   - `state_distinguishability._min_error_primal/_min_error_dual` gained a
     `sense` argument (`"max"` = distinguishability, `"min"` = exclusion);
     `state_exclusion` now imports them instead of re-defining them.
   - `channel_distinguishability._bayesian_primal/_bayesian_dual` were renamed
     `_min_error_primal/_min_error_dual` and parameterized the same way;
     `channel_exclusion` now imports them.

Net: **-159 / +66 lines** across 8 files (7 modified + 1 new).

## Correctness notes

- The dual SDPs flip constraint direction *and* objective sense together so the
  dual remains the dual of the requested primal sense; return values are shaped
  per-sense (`[Y]` for distinguishability, constraint duals for exclusion) to
  preserve the existing public return contracts.
- The cone's Golub-Welsch `_gauss_legendre` and the `leggauss`-based version
  agree to machine precision (verified numerically; includes the `m == 1` case).

## Verification

- Full test suite: **3736 passed, 60 skipped, 2 xfailed**
- `ruff check` and `ruff format --check` clean
- Numeric equivalence checks of the refactored SDP builders against the
  pre-refactor implementations on random inputs: values agree to ~1e-9 or better
  (solver noise), for both primal and dual, both state and channel, both senses.