### PR TITLE
docs: make the lieb_ando and trace_matrix_power examples runnable

### DIFF
--- a/toqito/matrix_props/lieb_ando.py
+++ b/toqito/matrix_props/lieb_ando.py
@@ -55,14 +55,33 @@ def lieb_ando(
         ValueError: If affine or variable CVXPY inputs are passed.
 
     Examples:
-        ```python
+        For \(K = I\), the two endpoints of the exponent range are traces: \(t = 0\)
+        leaves \(\operatorname{tr}(A)\) and \(t = 1\) leaves \(\operatorname{tr}(B)\).
+        Here \(\operatorname{tr}(A) = 4\) and \(\operatorname{tr}(B) = 5\).
+
+        ```python exec="1" source="above" result="text"
         import numpy as np
         from toqito.matrix_props import lieb_ando
+
         mat_a = np.array([[2.0, 1.0], [1.0, 2.0]])
-        mat_b = np.array([[2.0, 1.0], [1.0, 2.0]])
+        mat_b = np.diag([4.0, 1.0])
         mat_k = np.eye(2)
-        t = 0.5
-        print(lieb_ando(mat_a, mat_b, mat_k, t))
+
+        for t in (0.0, 1.0):
+            print(lieb_ando(mat_a, mat_b, mat_k, t))
+        ```
+
+        An interior exponent interpolates between them.
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.matrix_props import lieb_ando
+
+        mat_a = np.array([[2.0, 1.0], [1.0, 2.0]])
+        mat_b = np.diag([4.0, 1.0])
+        mat_k = np.eye(2)
+
+        print(lieb_ando(mat_a, mat_b, mat_k, 0.5))
         ```
 
     """

--- a/toqito/matrix_props/trace_matrix_power.py
+++ b/toqito/matrix_props/trace_matrix_power.py
@@ -50,13 +50,31 @@ def trace_matrix_power(mat_a: np.ndarray | cvxpy.Expression, t: float, mat_c: np
         ValueError: If affine or variable CVXPY inputs are passed.
 
     Examples:
-        ```python
+        With \(C = I\) the result is the sum of the eigenvalues of \(A\) raised to
+        \(t\). For \(A\) with eigenvalues \(1\) and \(3\) and \(t = 1/2\), that is
+        \(1 + \sqrt{3}\).
+
+        ```python exec="1" source="above" result="text"
         import numpy as np
         from toqito.matrix_props import trace_matrix_power
+
         mat_a = np.array([[2.0, 1.0], [1.0, 2.0]])
-        t = 0.5
-        mat_c = np.array([[1, 0], [0, 1]])
-        print(trace_matrix_power(mat_a, t, mat_c))
+
+        print(trace_matrix_power(mat_a, 0.5))
+        ```
+
+        A weight matrix \(C\) selects part of that sum. Taking
+        \(C = \operatorname{diag}(1, 0)\) keeps only the first diagonal entry of
+        \(A^{1/2}\).
+
+        ```python exec="1" source="above" result="text"
+        import numpy as np
+        from toqito.matrix_props import trace_matrix_power
+
+        mat_a = np.array([[2.0, 1.0], [1.0, 2.0]])
+        mat_c = np.diag([1.0, 0.0])
+
+        print(trace_matrix_power(mat_a, 0.5, mat_c))
         ```
 
     """


### PR DESCRIPTION
Closes #1886.

`lieb_ando` and `trace_matrix_power` were the last two public modules without a runnable `Examples` section. Both already had an `Examples` block, but written as a plain ` ```python ` fence, so the docs build never executed it — it was documentation only, with none of the smoke-test value the `exec="1"` blocks give.

Both are now `exec="1" source="above" result="text"`, and the snippets are written around an anchor the reader can verify rather than an unexplained float:

- **`trace_matrix_power`** — with `C = I` the result is the sum of the eigenvalues of `A` raised to `t`. The example matrix has eigenvalues 1 and 3, so at `t = 1/2` the output is `1 + sqrt(3) = 2.732…`. A second block shows `C = diag(1, 0)` selecting part of that sum.
- **`lieb_ando`** — with `K = I` the exponent endpoints are traces: `t = 0` gives `tr(A)` and `t = 1` gives `tr(B)`. The example prints `4` and `5` for matrices with exactly those traces. A second block shows an interior exponent.

### Verified

- Extracted all four blocks from the docstrings and executed them as written; output matches the values quoted above (`2.7320508075688767`, `1.3660254037844384`, `3.999999999999999`, `4.999999999999999`, `4.098076211353315`).
- `pytest toqito/matrix_props/tests/test_lieb_ando.py toqito/matrix_props/tests/test_trace_matrix_power.py` — 114 passed.
- `ruff check` and `ruff format --check` clean.

I did not run the full `mkdocs build` locally (the docs group is not installed here), so the rendered page is CI's check; the snippets themselves are executed above.

No behaviour change — docstrings only.
