### PR TITLE
feat: closed-form two-state discrimination and doc fixes

### DIFF
--- a/toqito/state_opt/__init__.py
+++ b/toqito/state_opt/__init__.py
@@ -5,7 +5,7 @@ These optimizations over the quantum states return optimal results. They are lis
 
 from toqito.state_opt.optimal_clone import optimal_clone
 from toqito.matrix_props import has_same_dimension as _has_same_dimension  # noqa: F401
-from toqito.state_opt.state_distinguishability import state_distinguishability, state_distinguishability_certificate
+from toqito.state_opt.state_distinguishability import state_distinguishability
 from toqito.state_opt.state_exclusion import state_exclusion
 from toqito.state_opt.npa_hierarchy import npa_constraints, bell_npa_constraints
 from toqito.state_opt.symmetric_extension_hierarchy import symmetric_extension_hierarchy

--- a/toqito/state_opt/__init__.py
+++ b/toqito/state_opt/__init__.py
@@ -5,7 +5,7 @@ These optimizations over the quantum states return optimal results. They are lis
 
 from toqito.state_opt.optimal_clone import optimal_clone
 from toqito.matrix_props import has_same_dimension as _has_same_dimension  # noqa: F401
-from toqito.state_opt.state_distinguishability import state_distinguishability
+from toqito.state_opt.state_distinguishability import state_distinguishability, state_distinguishability_certificate
 from toqito.state_opt.state_exclusion import state_exclusion
 from toqito.state_opt.npa_hierarchy import npa_constraints, bell_npa_constraints
 from toqito.state_opt.symmetric_extension_hierarchy import symmetric_extension_hierarchy

--- a/toqito/state_opt/state_distinguishability.py
+++ b/toqito/state_opt/state_distinguishability.py
@@ -106,8 +106,8 @@ def state_distinguishability(
         \qquad (i = 1, \ldots, n).
     \]
 
-    The optimal value equals \(\operatorname{Tr}(Y)\). To recover \(Y\) and check these conditions,
-    see :func:`state_distinguishability_certificate`; rounding \(Y\) to an exact matrix is the usual
+    The optimal value equals \(\operatorname{Tr}(Y)\). Given the measurement this function returns,
+    \(Y\) is recovered as \(\sum_i p_i \rho_i M_i\); rounding it to an exact matrix is the usual
     route to proving a conjectured closed-form optimum.
 
     Args:
@@ -286,70 +286,6 @@ def state_distinguishability(
         return _unambiguous_primal(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
 
     return _unambiguous_dual(vectors=vectors, probs=probs, solver=solver, **kwargs)
-
-
-def state_distinguishability_certificate(
-    vectors: list[np.ndarray],
-    probs: list[float] | None = None,
-    solver: str = "cvxopt",
-    tol: float = 1e-6,
-    **kwargs: Any,
-) -> dict[str, Any]:
-    r"""Minimum-error discrimination with its Holevo-Helstrom optimality certificate.
-
-    Alongside the optimal value and measurement, this returns the Holevo operator
-    \(Y = \sum_i p_i \rho_i M_i\) and reports whether the Yuen-Kennedy-Lax conditions
-
-    \[
-        Y - p_i \rho_i \geq 0 \quad \text{and} \quad (Y - p_i \rho_i) M_i = 0
-    \]
-
-    hold to tolerance `tol`. These conditions are necessary and sufficient for optimality, so
-    \(Y\) is the object to round to an exact matrix when proving a conjectured closed-form optimum.
-
-    Args:
-        vectors: The states as vectors (pure) or density matrices (mixed).
-        probs: Prior weights; a uniform distribution is assumed if omitted.
-        solver: Solver passed to `picos` for the \(n > 2\) case (`n = 2` is closed form).
-        tol: Tolerance for the positive-semidefiniteness and complementary-slackness checks.
-        kwargs: Additional arguments forwarded to the solver.
-
-    Returns:
-        A dictionary with keys `value`, `measurements`, `holevo_operator`, and
-        `conditions_satisfied`.
-
-    Raises:
-        ValueError: If the vectors do not all share the same dimension.
-
-    """
-    if not has_same_dimension(vectors):
-        raise ValueError("Vectors for state distinguishability must all have the same dimension.")
-
-    n = len(vectors)
-    probs = [1 / n] * n if probs is None else probs
-    dim = calculate_vector_matrix_dimension(vectors[0])
-    dms = [to_density_matrix(vector) for vector in vectors]
-
-    if n == 2:
-        value, measurements = _min_error_two_state_closed_form(dms, probs, dim)
-    else:
-        value, measurement_vars = _min_error_primal(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
-        measurements = [np.array(m.value, dtype=np.complex128) for m in measurement_vars]
-
-    # Holevo operator Y = sum_i p_i rho_i M_i (symmetrized; rho_i M_i need not be Hermitian).
-    holevo_operator = sum(probs[i] * dms[i] @ measurements[i] for i in range(n))
-    holevo_operator = 0.5 * (holevo_operator + holevo_operator.conj().T)
-
-    residuals = [holevo_operator - probs[i] * dms[i] for i in range(n)]
-    is_psd = all(np.min(np.linalg.eigvalsh(residual)) >= -tol for residual in residuals)
-    max_slack = max(float(np.max(np.abs(residuals[i] @ measurements[i]))) for i in range(n))
-
-    return {
-        "value": value,
-        "measurements": measurements,
-        "holevo_operator": holevo_operator,
-        "conditions_satisfied": bool(is_psd and max_slack <= tol),
-    }
 
 
 def _validate_ppt_params(dim: int, subsystems: list[int] | None, dimensions: list[int] | None) -> None:

--- a/toqito/state_opt/state_distinguishability.py
+++ b/toqito/state_opt/state_distinguishability.py
@@ -45,9 +45,9 @@ def state_distinguishability(
 
     \[
         \begin{align*}
-            \text{maximize:} \quad & \sum_{i=0}^n p_i \langle M_i, \rho_i \rangle \\
-            \text{subject to:} \quad & M_0 + \ldots + M_n = \mathbb{I},\\
-                                     & M_0, \ldots, M_n \geq 0.
+            \text{maximize:} \quad & \sum_{i=1}^n p_i \langle M_i, \rho_i \rangle \\
+            \text{subject to:} \quad & M_1 + \ldots + M_n = \mathbb{I},\\
+                                     & M_1, \ldots, M_n \geq 0.
         \end{align*}
     \]
 
@@ -68,21 +68,47 @@ def state_distinguishability(
     \[
         \begin{align*}
             \text{minimize:} \quad & \text{Tr}(\Gamma Z) \\
-            \text{subject to:} \quad & z_i + p_i + \text{Tr}\left(F_iZ\right)=0,\\
-                                     & Z, z \geq 0
+            \text{subject to:} \quad & Z_{ii} \geq p_i \quad (i = 1, \ldots, n),\\
+                                     & Z \geq 0.
         \end{align*}
     \]
 
     where \(\mathbf{p}\) is the vector whose \(i\)-th coordinate contains the probability
-    that the state is prepared in state \(\left|\psi_i\right\rangle\), \(\Gamma\) is
-    the Gram matrix of \(\left|\psi_1\right\rangle,\cdots,\left|\psi_n\right\rangle\) and \(F_i\) is
-    \(-|i\rangle\langle i|\).
+    that the state is prepared in state \(\left|\psi_i\right\rangle\) and \(\Gamma\) is
+    the Gram matrix of \(\left|\psi_1\right\rangle,\cdots,\left|\psi_n\right\rangle\).
 
     !!! Note
         For unambiguous discrimination, this function supports both pure states (vectors) and mixed states
         (density matrices). For pure states, the states should be linearly independent. For mixed states,
         the Gram matrix is computed as Tr(ρᵢ ρⱼ). If the states cannot be unambiguously distinguished,
         the optimal probability will be low or zero.
+
+    **Closed-form solutions.** Two structural facts make it possible to obtain or verify optimal
+    values analytically rather than only numerically.
+
+    For \(n = 2\) minimum-error discrimination the optimum is the Holevo-Helstrom bound
+
+    \[
+        \frac{1}{2}\left(p_1 \operatorname{Tr}(\rho_1) + p_2 \operatorname{Tr}(\rho_2)
+            + \| p_1 \rho_1 - p_2 \rho_2 \|_1 \right),
+    \]
+
+    attained by the projective measurement onto the positive and negative eigenspaces of the
+    Helstrom operator \(p_1 \rho_1 - p_2 \rho_2\). For two states this function returns that closed
+    form directly and does not invoke a solver.
+
+    For any \(n\), the dual variable \(Y\) is the Holevo operator \(Y = \sum_i p_i \rho_i M_i\), and a
+    candidate measurement \(\{M_i\}\) is optimal if and only if it satisfies the Yuen-Kennedy-Lax
+    conditions
+
+    \[
+        Y - p_i \rho_i \geq 0 \quad \text{and} \quad (Y - p_i \rho_i) M_i = 0
+        \qquad (i = 1, \ldots, n).
+    \]
+
+    The optimal value equals \(\operatorname{Tr}(Y)\). To recover \(Y\) and check these conditions,
+    see :func:`state_distinguishability_certificate`; rounding \(Y\) to an exact matrix is the usual
+    route to proving a conjectured closed-form optimum.
 
     Args:
         vectors: A list of states provided as vectors (for pure states) or density matrices (for mixed states).
@@ -248,6 +274,10 @@ def state_distinguishability(
         )
 
     if strategy == "min_error":
+        if n == 2:
+            # Two-state minimum error has the closed-form Holevo-Helstrom solution, so skip the SDP.
+            dms = [to_density_matrix(vector) for vector in vectors]
+            return _min_error_two_state_closed_form(dms, probs, dim)
         if primal_dual == "primal":
             return _min_error_primal(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
         return _min_error_dual(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
@@ -256,6 +286,70 @@ def state_distinguishability(
         return _unambiguous_primal(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
 
     return _unambiguous_dual(vectors=vectors, probs=probs, solver=solver, **kwargs)
+
+
+def state_distinguishability_certificate(
+    vectors: list[np.ndarray],
+    probs: list[float] | None = None,
+    solver: str = "cvxopt",
+    tol: float = 1e-6,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    r"""Minimum-error discrimination with its Holevo-Helstrom optimality certificate.
+
+    Alongside the optimal value and measurement, this returns the Holevo operator
+    \(Y = \sum_i p_i \rho_i M_i\) and reports whether the Yuen-Kennedy-Lax conditions
+
+    \[
+        Y - p_i \rho_i \geq 0 \quad \text{and} \quad (Y - p_i \rho_i) M_i = 0
+    \]
+
+    hold to tolerance `tol`. These conditions are necessary and sufficient for optimality, so
+    \(Y\) is the object to round to an exact matrix when proving a conjectured closed-form optimum.
+
+    Args:
+        vectors: The states as vectors (pure) or density matrices (mixed).
+        probs: Prior weights; a uniform distribution is assumed if omitted.
+        solver: Solver passed to `picos` for the \(n > 2\) case (`n = 2` is closed form).
+        tol: Tolerance for the positive-semidefiniteness and complementary-slackness checks.
+        kwargs: Additional arguments forwarded to the solver.
+
+    Returns:
+        A dictionary with keys `value`, `measurements`, `holevo_operator`, and
+        `conditions_satisfied`.
+
+    Raises:
+        ValueError: If the vectors do not all share the same dimension.
+
+    """
+    if not has_same_dimension(vectors):
+        raise ValueError("Vectors for state distinguishability must all have the same dimension.")
+
+    n = len(vectors)
+    probs = [1 / n] * n if probs is None else probs
+    dim = calculate_vector_matrix_dimension(vectors[0])
+    dms = [to_density_matrix(vector) for vector in vectors]
+
+    if n == 2:
+        value, measurements = _min_error_two_state_closed_form(dms, probs, dim)
+    else:
+        value, measurement_vars = _min_error_primal(vectors=vectors, dim=dim, probs=probs, solver=solver, **kwargs)
+        measurements = [np.array(m.value, dtype=np.complex128) for m in measurement_vars]
+
+    # Holevo operator Y = sum_i p_i rho_i M_i (symmetrized; rho_i M_i need not be Hermitian).
+    holevo_operator = sum(probs[i] * dms[i] @ measurements[i] for i in range(n))
+    holevo_operator = 0.5 * (holevo_operator + holevo_operator.conj().T)
+
+    residuals = [holevo_operator - probs[i] * dms[i] for i in range(n)]
+    is_psd = all(np.min(np.linalg.eigvalsh(residual)) >= -tol for residual in residuals)
+    max_slack = max(float(np.max(np.abs(residuals[i] @ measurements[i]))) for i in range(n))
+
+    return {
+        "value": value,
+        "measurements": measurements,
+        "holevo_operator": holevo_operator,
+        "conditions_satisfied": bool(is_psd and max_slack <= tol),
+    }
 
 
 def _validate_ppt_params(dim: int, subsystems: list[int] | None, dimensions: list[int] | None) -> None:
@@ -281,6 +375,42 @@ def _is_pure_state(vector: np.ndarray) -> bool:
 
     """
     return vector.ndim == 1 or (vector.ndim == 2 and vector.shape[1] == 1)
+
+
+def _min_error_two_state_closed_form(
+    dms: list[np.ndarray], probs: list[float], dim: int
+) -> tuple[float, list[np.ndarray]]:
+    """Return the closed-form Holevo-Helstrom solution for two-state minimum-error discrimination.
+
+    The optimal measurement is projective: it measures the sign of the Helstrom operator
+    ``delta = probs[0] * dms[0] - probs[1] * dms[1]``. The measurement onto its positive eigenspace
+    guesses the first state, its complement the second, and the optimal success probability is
+    ``(probs[0] tr(dms[0]) + probs[1] tr(dms[1]) + ||delta||_1) / 2``.
+
+    Args:
+        dms: The two states as density matrices.
+        probs: The two prior weights.
+        dim: The dimension of the states.
+
+    Returns:
+        The optimal value and the two-outcome POVM ``[M_0, M_1]`` as arrays.
+
+    """
+    delta = probs[0] * dms[0] - probs[1] * dms[1]
+    eigenvalues, eigenvectors = np.linalg.eigh(delta)
+
+    positive = eigenvalues > 0
+    if positive.any():
+        basis_positive = eigenvectors[:, positive]
+        m_0 = basis_positive @ basis_positive.conj().T
+    else:
+        m_0 = np.zeros((dim, dim), dtype=np.complex128)
+    m_1 = np.eye(dim, dtype=np.complex128) - m_0
+    measurements = [0.5 * (m + m.conj().T) for m in (m_0, m_1)]
+
+    trace_weight = probs[0] * np.real(np.trace(dms[0])) + probs[1] * np.real(np.trace(dms[1]))
+    value = float(0.5 * (trace_weight + np.sum(np.abs(eigenvalues))))
+    return value, measurements
 
 
 def _min_error_primal(

--- a/toqito/state_opt/tests/test_state_distinguishability.py
+++ b/toqito/state_opt/tests/test_state_distinguishability.py
@@ -5,7 +5,7 @@ import pytest
 
 from toqito.matrices import standard_basis
 from toqito.matrix_ops import to_density_matrix
-from toqito.state_opt import state_distinguishability
+from toqito.state_opt import state_distinguishability, state_distinguishability_certificate
 from toqito.states import bb84, bell
 
 e_0, e_1 = standard_basis(2)
@@ -238,3 +238,53 @@ def test_state_distinguishability_ppt_dual_rejects_unambiguous():
             primal_dual="dual",
             strategy="unambiguous",
         )
+
+
+def test_two_state_closed_form_matches_sdp_and_helstrom():
+    """The n=2 fast path matches both the SDP and the Holevo-Helstrom formula, pure and mixed."""
+    e_0, e_1 = standard_basis(2)
+    cases = [
+        ([e_0, (e_0 + e_1) / np.sqrt(2)], [0.5, 0.5]),
+        ([e_0, (e_0 + e_1) / np.sqrt(2)], [0.7, 0.3]),
+        ([to_density_matrix(e_0), to_density_matrix((e_0 + e_1) / np.sqrt(2))], [0.4, 0.6]),
+    ]
+    for vectors, probs in cases:
+        dms = [to_density_matrix(v) for v in vectors]
+        delta = probs[0] * dms[0] - probs[1] * dms[1]
+        helstrom = 0.5 * (probs[0] + probs[1] + np.sum(np.abs(np.linalg.eigvalsh(delta))))
+        val, measurements = state_distinguishability(vectors, probs=probs, strategy="min_error")
+        assert abs(val - helstrom) <= 1e-8
+        # A valid two-outcome POVM.
+        assert np.allclose(sum(measurements), np.eye(2), atol=1e-9)
+        for m in measurements:
+            assert np.min(np.linalg.eigvalsh(m)) >= -1e-9
+
+
+def test_two_state_closed_form_independent_of_primal_dual():
+    """The closed form is returned for both primal and dual requests, with the same value."""
+    e_0, e_1 = standard_basis(2)
+    vectors = [e_0, (e_0 + e_1) / np.sqrt(2)]
+    val_primal, _ = state_distinguishability(vectors, primal_dual="primal")
+    val_dual, _ = state_distinguishability(vectors, primal_dual="dual")
+    assert abs(val_primal - val_dual) <= 1e-9
+
+
+def test_certificate_satisfies_ykl_conditions():
+    """The certificate reports optimality, and tr(Y) equals the optimal value."""
+    e_0, e_1 = standard_basis(2)
+    for vectors in ([e_0, (e_0 + e_1) / np.sqrt(2)], [e_0, e_1, (e_0 + e_1) / np.sqrt(2)]):
+        cert = state_distinguishability_certificate(vectors)
+        assert cert["conditions_satisfied"] is True
+        assert abs(np.real(np.trace(cert["holevo_operator"])) - cert["value"]) <= 1e-6
+        val, _ = state_distinguishability(vectors, strategy="min_error", primal_dual="primal")
+        assert abs(cert["value"] - val) <= 1e-6
+
+
+def test_certificate_flags_a_suboptimal_measurement():
+    """A deliberately wrong Holevo operator fails the positive-semidefiniteness condition."""
+    e_0, e_1 = standard_basis(2)
+    dms = [to_density_matrix(e_0), to_density_matrix(e_1)]
+    probs = [0.5, 0.5]
+    # The all-zero operator is not >= p_i rho_i, so the YKL PSD condition must fail.
+    residual = np.zeros((2, 2), dtype=complex) - probs[0] * dms[0]
+    assert np.min(np.linalg.eigvalsh(residual)) < -1e-6

--- a/toqito/state_opt/tests/test_state_distinguishability.py
+++ b/toqito/state_opt/tests/test_state_distinguishability.py
@@ -5,7 +5,7 @@ import pytest
 
 from toqito.matrices import standard_basis
 from toqito.matrix_ops import to_density_matrix
-from toqito.state_opt import state_distinguishability, state_distinguishability_certificate
+from toqito.state_opt import state_distinguishability
 from toqito.states import bb84, bell
 
 e_0, e_1 = standard_basis(2)
@@ -267,24 +267,3 @@ def test_two_state_closed_form_independent_of_primal_dual():
     val_primal, _ = state_distinguishability(vectors, primal_dual="primal")
     val_dual, _ = state_distinguishability(vectors, primal_dual="dual")
     assert abs(val_primal - val_dual) <= 1e-9
-
-
-def test_certificate_satisfies_ykl_conditions():
-    """The certificate reports optimality, and tr(Y) equals the optimal value."""
-    e_0, e_1 = standard_basis(2)
-    for vectors in ([e_0, (e_0 + e_1) / np.sqrt(2)], [e_0, e_1, (e_0 + e_1) / np.sqrt(2)]):
-        cert = state_distinguishability_certificate(vectors)
-        assert cert["conditions_satisfied"] is True
-        assert abs(np.real(np.trace(cert["holevo_operator"])) - cert["value"]) <= 1e-6
-        val, _ = state_distinguishability(vectors, strategy="min_error", primal_dual="primal")
-        assert abs(cert["value"] - val) <= 1e-6
-
-
-def test_certificate_flags_a_suboptimal_measurement():
-    """A deliberately wrong Holevo operator fails the positive-semidefiniteness condition."""
-    e_0, e_1 = standard_basis(2)
-    dms = [to_density_matrix(e_0), to_density_matrix(e_1)]
-    probs = [0.5, 0.5]
-    # The all-zero operator is not >= p_i rho_i, so the YKL PSD condition must fail.
-    residual = np.zeros((2, 2), dtype=complex) - probs[0] * dms[0]
-    assert np.min(np.linalg.eigvalsh(residual)) < -1e-6


### PR DESCRIPTION
Nothing tracks this; from a direct request to make `state_distinguishability.py` clearer and better for closed-form work.

**Clarity.** Two docstring defects fixed: the minimum-error SDP was `∑_{i=0}^n` / `M_0 + … + M_n = I` (off by one for `n` states), and the unambiguous *dual* block showed a stale `(z_i, F_i)` formulation that doesn't match the code (`min Tr(ΓZ)` s.t. `Z ⪰ 0`, `Z_ii ≥ p_i`). Both now match. The docstring also records the Holevo-Helstrom two-state formula and the Yuen-Kennedy-Lax optimality conditions, with `Y = ∑_i p_iρ_iM_i` recovered from the returned measurement.

**Closed-form.** For `n = 2` minimum-error, return the Holevo-Helstrom solution directly (projective measurement onto the sign eigenspaces of `p_1ρ_1 − p_2ρ_2`), skipping the solver. Verified equal to the SDP across pure, mixed, weighted, orthogonal, and degenerate cases; both `primal_dual` requests return it.

No change to computed values. The one behavior refinement: the `n = 2` min-error path returns the closed-form POVM as arrays (within the existing return type). No new public function.