### PR TITLE
feat: closed-form two-state exclusion and doc fixes

### DIFF
--- a/toqito/state_opt/state_distinguishability.py
+++ b/toqito/state_opt/state_distinguishability.py
@@ -314,19 +314,22 @@ def _is_pure_state(vector: np.ndarray) -> bool:
 
 
 def _min_error_two_state_closed_form(
-    dms: list[np.ndarray], probs: list[float], dim: int
+    dms: list[np.ndarray], probs: list[float], dim: int, sense: str = "max"
 ) -> tuple[float, list[np.ndarray]]:
-    """Return the closed-form Holevo-Helstrom solution for two-state minimum-error discrimination.
+    """Return the closed-form two-state minimum-error discrimination or exclusion solution.
 
-    The optimal measurement is projective: it measures the sign of the Helstrom operator
-    ``delta = probs[0] * dms[0] - probs[1] * dms[1]``. The measurement onto its positive eigenspace
-    guesses the first state, its complement the second, and the optimal success probability is
-    ``(probs[0] tr(dms[0]) + probs[1] tr(dms[1]) + ||delta||_1) / 2``.
+    The optimal measurement is projective on the sign of the Helstrom operator
+    ``delta = probs[0] * dms[0] - probs[1] * dms[1]``. For ``sense == "max"`` (minimum-error
+    distinguishability) the first outcome is the projector onto the positive eigenspace of ``delta``
+    and the optimal success probability is ``(probs[0] tr(dms[0]) + probs[1] tr(dms[1]) + ||delta||_1) / 2``.
+    For ``sense == "min"`` (minimum-error exclusion) it is the projector onto the negative eigenspace
+    and the optimal error probability is the same expression with ``||delta||_1`` subtracted.
 
     Args:
         dms: The two states as density matrices.
         probs: The two prior weights.
         dim: The dimension of the states.
+        sense: ``"max"`` for distinguishability (default) or ``"min"`` for exclusion.
 
     Returns:
         The optimal value and the two-outcome POVM ``[M_0, M_1]`` as arrays.
@@ -335,17 +338,19 @@ def _min_error_two_state_closed_form(
     delta = probs[0] * dms[0] - probs[1] * dms[1]
     eigenvalues, eigenvectors = np.linalg.eigh(delta)
 
-    positive = eigenvalues > 0
-    if positive.any():
-        basis_positive = eigenvectors[:, positive]
-        m_0 = basis_positive @ basis_positive.conj().T
+    # Distinguishability assigns the first state to delta's positive part; exclusion to its negative part.
+    selected = eigenvalues > 0 if sense == "max" else eigenvalues < 0
+    if selected.any():
+        basis_selected = eigenvectors[:, selected]
+        m_0 = basis_selected @ basis_selected.conj().T
     else:
         m_0 = np.zeros((dim, dim), dtype=np.complex128)
     m_1 = np.eye(dim, dtype=np.complex128) - m_0
     measurements = [0.5 * (m + m.conj().T) for m in (m_0, m_1)]
 
     trace_weight = probs[0] * np.real(np.trace(dms[0])) + probs[1] * np.real(np.trace(dms[1]))
-    value = float(0.5 * (trace_weight + np.sum(np.abs(eigenvalues))))
+    trace_norm = np.sum(np.abs(eigenvalues))
+    value = float(0.5 * (trace_weight + (trace_norm if sense == "max" else -trace_norm)))
     return value, measurements
 
 

--- a/toqito/state_opt/state_exclusion.py
+++ b/toqito/state_opt/state_exclusion.py
@@ -9,7 +9,11 @@ import picos
 from toqito.matrix_ops import calculate_vector_matrix_dimension, partial_trace, to_density_matrix
 from toqito.matrix_props import has_same_dimension
 from toqito.rand import random_povm
-from toqito.state_opt.state_distinguishability import _min_error_dual, _min_error_primal
+from toqito.state_opt.state_distinguishability import (
+    _min_error_dual,
+    _min_error_primal,
+    _min_error_two_state_closed_form,
+)
 
 
 def state_exclusion(
@@ -41,7 +45,7 @@ def state_exclusion(
     as well as a list of corresponding probabilities
 
     \[
-        p = \{ p_0, \ldots, p_n \}.
+        p = \{ p_1, \ldots, p_n \}.
     \]
 
     Alice chooses \(i\) with probability \(p_i\) and creates the state \(\rho_i\).
@@ -59,7 +63,7 @@ def state_exclusion(
             \begin{aligned}
                 \text{minimize:} \quad & \sum_{i=1}^n p_i \langle M_i, \rho_i \rangle \\
                 \text{subject to:} \quad & \sum_{i=1}^n M_i = \mathbb{I}_{\mathcal{X}}, \\
-                                            & M_0, \ldots, M_n \in \text{Pos}(\mathcal{X}).
+                                            & M_1, \ldots, M_n \in \text{Pos}(\mathcal{X}).
             \end{aligned}
         \end{equation}
     \]
@@ -104,7 +108,7 @@ def state_exclusion(
     possible that his answer is inconclusive. This function then yields the probability of an inconclusive outcome.
 
     In that case, this function implements the following semidefinite program that provides the
-    optimal probability with which Bob can conduct unambiguous quantum state distinguishability.
+    optimal probability with which Bob can conduct unambiguous quantum state exclusion.
 
     \[
         \begin{align*}
@@ -260,7 +264,7 @@ def state_exclusion(
         raise ValueError("Argument `measurement` must be 'positive', 'ppt', or 'locc'.")
 
     if not has_same_dimension(vectors):
-        raise ValueError("Vectors for state distinguishability must all have the same dimension.")
+        raise ValueError("Vectors for state exclusion must all have the same dimension.")
 
     # Assumes a uniform probabilities distribution among the states if one is not explicitly provided.
     n = len(vectors)
@@ -338,6 +342,10 @@ def state_exclusion(
         )
 
     if strategy == "min_error":
+        if n == 2:
+            # Two-state minimum-error exclusion has the closed-form anti-Helstrom solution, so skip the SDP.
+            dms = [to_density_matrix(vector) for vector in vectors]
+            return _min_error_two_state_closed_form(dms, probs, dim, sense="min")
         if primal_dual == "primal":
             return _min_error_primal(vectors=vectors, dim=dim, probs=probs, sense="min", solver=solver, **kwargs)
         return _min_error_dual(vectors=vectors, dim=dim, probs=probs, sense="min", solver=solver, **kwargs)
@@ -448,7 +456,7 @@ def _unambiguous_primal(
     solver: str = "cvxopt",
     **kwargs,
 ) -> tuple[float, list[picos.HermitianVariable]]:
-    """Solve the primal problem for unambiguous quantum state distinguishability SDP.
+    """Solve the primal problem for unambiguous quantum state exclusion SDP.
 
     Implemented according to Equation (33) of [@bandyopadhyay2014conclusive].
 
@@ -515,7 +523,7 @@ def _unambiguous_dual(
     solver: str = "cvxopt",
     **kwargs,
 ) -> tuple[float, tuple[picos.HermitianVariable, picos.RealVariable]]:
-    """Solve the dual problem for unambiguous quantum state distinguishability SDP.
+    """Solve the dual problem for unambiguous quantum state exclusion SDP.
 
     Implemented according to Equation (35) of [@bandyopadhyay2014conclusive].
 

--- a/toqito/state_opt/tests/test_state_exclusion.py
+++ b/toqito/state_opt/tests/test_state_exclusion.py
@@ -123,7 +123,7 @@ def test_state_exclusion_unambiguous(vectors, probs, solver, primal_dual, expect
 )
 def test_state_exclusion_invalid_vectors(vectors, probs, solver, primal_dual, strategy):
     """Test function works as expected for an invalid input."""
-    with pytest.raises(ValueError, match="Vectors for state distinguishability must all have the same dimension."):
+    with pytest.raises(ValueError, match="Vectors for state exclusion must all have the same dimension."):
         state_exclusion(vectors=vectors, probs=probs, solver=solver, primal_dual=primal_dual, strategy=strategy)
 
 
@@ -259,3 +259,38 @@ def test_state_exclusion_identical_states_not_perfectly_excludable():
     states = [np.array([[1.0], [0.0]]), np.array([[1.0], [0.0]])]
     value, _ = state_exclusion(states, primal_dual="primal")
     assert value > 1e-6
+
+
+def test_two_state_exclusion_closed_form_matches_sdp():
+    """The n=2 min-error exclusion fast path matches the anti-Helstrom formula, pure and mixed."""
+    e_0, e_1 = standard_basis(2)
+    cases = [
+        ([e_0, (e_0 + e_1) / np.sqrt(2)], [0.5, 0.5]),
+        ([e_0, (e_0 + e_1) / np.sqrt(2)], [0.7, 0.3]),
+        ([to_density_matrix(e_0), to_density_matrix((e_0 + e_1) / np.sqrt(2))], [0.4, 0.6]),
+    ]
+    for vectors, probs in cases:
+        dms = [to_density_matrix(v) for v in vectors]
+        delta = probs[0] * dms[0] - probs[1] * dms[1]
+        anti_helstrom = 0.5 * (probs[0] + probs[1] - np.sum(np.abs(np.linalg.eigvalsh(delta))))
+        val, measurements = state_exclusion(vectors, probs=probs, strategy="min_error")
+        assert abs(val - anti_helstrom) <= 1e-8
+        assert np.allclose(sum(measurements), np.eye(2), atol=1e-9)
+        for m in measurements:
+            assert np.min(np.linalg.eigvalsh(m)) >= -1e-9
+
+
+def test_two_state_exclusion_closed_form_independent_of_primal_dual():
+    """The closed form is returned for both primal and dual requests, with the same value."""
+    e_0, e_1 = standard_basis(2)
+    vectors = [e_0, (e_0 + e_1) / np.sqrt(2)]
+    val_primal, _ = state_exclusion(vectors, primal_dual="primal")
+    val_dual, _ = state_exclusion(vectors, primal_dual="dual")
+    assert abs(val_primal - val_dual) <= 1e-9
+
+
+def test_two_state_exclusion_orthogonal_is_perfect():
+    """Orthogonal states can be excluded with zero error."""
+    e_0, e_1 = standard_basis(2)
+    val, _ = state_exclusion([e_0, e_1], probs=[0.5, 0.5], strategy="min_error")
+    assert abs(val) <= 1e-9


### PR DESCRIPTION
Follow-up to #1973, applying the same treatment to `state_exclusion.py`, the one other `state_opt/` file with the parallel defects and a closed form. Nothing tracks it.

**Clarity.** The minimum-error SDP listed `M_0, …, M_n` for `n` states (off by one) and indexed `p` from 0; two unambiguous helper docstrings and one error message still said "distinguishability" in the exclusion module (copy-paste). All corrected.

**Closed-form.** For `n = 2` minimum-error exclusion, return the anti-Helstrom solution directly, the projective measurement onto the **negative** eigenspace of `p_1ρ_1 − p_2ρ_2`, with value `½(p_1 tr ρ_1 + p_2 tr ρ_2 − ‖p_1ρ_1 − p_2ρ_2‖_1)`, skipping the solver. Verified equal to the SDP across pure, mixed, weighted, and orthogonal (→0) cases; both `primal_dual` requests return it.

**No new duplication.** The two-state helper added in #1973 is generalized with a `sense` argument (`"max"` discrimination, `"min"` exclusion) and reused rather than copied. Discrimination behaviour is unchanged.

The other four `state_opt/` files (`bell_inequality_max`, `npa_hierarchy`, `optimal_clone`, `symmetric_extension_hierarchy`) were reviewed and have no comparable docstring defects or clean closed forms, so they are left alone.