### PR TITLE
ci: harden CI supply chain and add a security policy

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -126,7 +126,7 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
     - name: Setup toqito environment
       run: |

--- a/.github/workflows/build-test-actions.yml
+++ b/.github/workflows/build-test-actions.yml
@@ -1,7 +1,8 @@
 name: check-build
+# Least privilege at the workflow level; id-token is granted only to the job that
+# needs it for codecov's OIDC upload (see the toqito-pytest job below).
 permissions:
   contents: read
-  id-token: write
 
 on:
   pull_request:
@@ -20,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       # Pin ruff to the version in pyproject so CI formatting matches local/pre-commit.
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
         with:
           version: "0.16.0"
       # Check only (no --fix / no in-place format): style and format violations must fail CI
@@ -28,7 +29,7 @@ jobs:
       - run: ruff check
       - run: ruff format --check
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
       # Run the ty type checker for visibility. Non-blocking for now: there is a large backlog of existing
@@ -38,6 +39,10 @@ jobs:
         run: uv run --group lint ty check toqito
 
   toqito-pytest:
+    # id-token is needed here for codecov's OIDC upload; the code-style job does not get it.
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -68,7 +73,7 @@ jobs:
         run: |
           brew install openblas lapack suite-sparse
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
       - name: Install toqito + dependencies
@@ -82,7 +87,7 @@ jobs:
         run: uv run pytest -v --runslow -n auto --dist worksteal --cov-config=.coveragerc --cov-report=xml --cov-report term-missing:skip-covered --cov=toqito
       - name: Upload coverage information
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           use_oidc: true
           # Coverage upload is informational; a transient codecov CLI/CDN or

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install uv
         if: github.event.action != 'closed'
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies with uv
         if: github.event.action != 'closed'
@@ -55,7 +55,7 @@ jobs:
           uv run mkdocs build --strict
 
       - name: Deploy PR preview
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1
         with:
           source-dir: docs/site/
           preview-branch: gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
           sudo apt-get install -y libblas-dev liblapack-dev gfortran libatlas-base-dev
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies with uv
         run: uv sync --group docs

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Build sdist and wheel
         run: uv build
@@ -59,4 +59,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported versions
+
+`toqito` is a research library released as a rolling latest version on PyPI.
+Security fixes are applied to the current release; there is no long-term support
+for older versions. Please upgrade to the latest release before reporting an
+issue.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately, not through a public issue or
+pull request. Use GitHub's private vulnerability reporting for this repository:
+
+- Go to the **Security** tab and choose **Report a vulnerability**
+  (https://github.com/vprusso/toqito/security/advisories/new).
+
+Include enough detail to reproduce the problem: affected version, a minimal
+example, and the observed versus expected behavior. You can expect an
+acknowledgement within a few days. If a fix is warranted, it will be prepared
+privately and released before the advisory is published.
+
+## Scope
+
+`toqito` is a numerical library. It performs computations on arrays and numbers
+and has no network, authentication, or persistence layer, so the realistic
+surface is limited to:
+
+- correctness defects that a caller could be induced to rely on for a security
+  decision,
+- the supply chain (dependencies and CI), and
+- code executed at documentation-build or test time.
+
+Reports about any of these are welcome. General bug reports that are not security
+sensitive should go to the public issue tracker instead.


### PR DESCRIPTION
Defensive hardening from a security review of the repo. No library code changes.

Context: the core library has no meaningful attack surface (no `eval`/`exec`/`pickle`/`subprocess`, no file or network I/O), and CI is already well-configured (no `pull_request_target`, no secrets in workflows, fork-PR guard on the write-permission preview job, OIDC publishing). These are defense-in-depth items, not fixes for an exploitable vulnerability.

- **SHA-pin third-party actions** across all workflows (`astral-sh/ruff-action`, `astral-sh/setup-uv`, `codecov/codecov-action`, `rossjrw/pr-preview-action`, and `pypa/gh-action-pypi-publish`), each with a version comment. `pypa/gh-action-pypi-publish` was pinned to the mutable `release/v1` **branch** on the publish step, the highest-impact case since that job has release rights. Floating tags/branches can be repointed to malicious commits; SHA pins remove that. GitHub's own `actions/*` are left on major tags.
- **Narrow `id-token: write`** in `check-build` from workflow scope to only the `toqito-pytest` job that uploads coverage via codecov OIDC; the `code-style` job no longer receives it.
- **Add `SECURITY.md`** with a private vulnerability-reporting policy (GitHub private advisories) and the library's scope.

Nothing tracks this. All workflow YAML validated.